### PR TITLE
Allow to force glob: ${ return [];} for output type: ["null", File] t…

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -210,6 +210,8 @@ class CommandLineTool(Process):
                     try:
                         gb = builder.do_eval(gb)
                         globpatterns.append(gb)
+                        if not gb or len(gb) < 1:
+                            continue
                         r.extend([{"path": g, "class": "File"} for g in builder.fs_access.glob(os.path.join(outdir, gb))])
                     except (OSError, IOError) as e:
                         _logger.warn(str(e))


### PR DESCRIPTION
This patch allows to return [] in glob section:

```yaml
outputs:
  - id: "#indices"
    type: ["null",File]
    outputBinding:
      glob: |
          ${
            if (inputs.runMode == "genomeGenerate")
              return inputs.genomeDir+"/Genome";
            return [];
          }

```
actual output when [] is returned will be:
```json
[job 4399300496] Removing temporary directory /var/folders/hx/3qsmpl9s50zdmn49jb03l_tw0000gn/T/tmpxPlAIt
{
    "indices": null
}
```