### PR TITLE
Ensure full mapping of paths to container

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -149,8 +149,16 @@ class CommandLineTool(Process):
         builder.pathmapper = self.makePathMapper(reffiles, input_basedir, **kwargs)
         builder.requirements = j.requirements
 
+        # map files to assigned path inside a container. We need to also explicitly
+        # walk over input as implicit reassignment doesn't reach everything in builder.bindings
         for f in builder.files:
             f["path"] = builder.pathmapper.mapper(f["path"])[1]
+        def _check_adjust(f):
+            try:
+                return builder.pathmapper.mapper(f)[1]
+            except KeyError:
+                return f
+        adjustFiles(builder.bindings, _check_adjust)
 
         _logger.debug("[job %s] command line bindings is %s", j.name, json.dumps(builder.bindings, indent=4))
         _logger.debug("[job %s] path mappings is %s", j.name, json.dumps({p: builder.pathmapper.mapper(p) for p in builder.pathmapper.files()}, indent=4))


### PR DESCRIPTION
The step in `CommandLineTool.job` that implicitly maps files in
builder.bindings to container paths via dictionary assignment
misses some cases in complex inputs. The result is that builder.bindings
will have correct internal Docker paths in `valueFrom` but not in `do_eval`,
leading to command line arguments that still reference the external
path.

To fix, this does an explicit `adjustFiles` remapping over all elements
in builder.bindings, supplementing the work done by the implicit call
and ensuring both `builder.files` and `builder.bindings` are
synchronized.

Thanks to @tetron for discussion and pointers on digging into the code
to fix this.