### PR TITLE
Stop looking for nodejs when found

### DIFF
--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -16,6 +16,7 @@ def execjs(js, jslib):
     for n in trynodes:
         try:
             nodejs = subprocess.Popen(n, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            break
         except OSError as e:
             if e.errno == errno.ENOENT:
                 pass


### PR DESCRIPTION
A small fix for 6ce637045 to stop searching for nodejs
implementations when the first is found. This prevents an error
when you have a local nodejs but not the node:slim docker image.
(ref #45 and #39).