### PR TITLE
Override setting --user option for docker run

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -69,7 +69,10 @@ class CommandLineJob(object):
             runtime.append("--read-only=true")
             runtime.append("--net=none")
             euid = docker_vm_uid() or os.geteuid()
-            runtime.append("--user=%s" % (euid))
+            if kwargs.get("no_user") is True:
+                runtime.append("--env=HOSTUSER=%s" % (euid))
+            else:
+                runtime.append("--user=%s" % (euid))
 
             if rm_container:
                 runtime.append("--rm")

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -69,9 +69,7 @@ class CommandLineJob(object):
             runtime.append("--read-only=true")
             runtime.append("--net=none")
             euid = docker_vm_uid() or os.geteuid()
-            if kwargs.get("no_user") is True:
-                runtime.append("--env=HOSTUSER=%s" % (euid))
-            else:
+            if kwargs.get("no_user") is not True:
                 runtime.append("--user=%s" % (euid))
 
             if rm_container:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -115,6 +115,7 @@ def arg_parser():
     exgroup.add_argument("--debug", action="store_true", help="Print even more logging")
 
     parser.add_argument("--tool-help", action="store_true", help="Print command line help for tool")
+    parser.add_argument("--no-user", action="store_true", help="Runs container without setting user")
 
     parser.add_argument("workflow", type=str, nargs="?", default=None)
     parser.add_argument("job_order", nargs=argparse.REMAINDER)
@@ -535,6 +536,7 @@ def main(args=None,
                        outdir=args.outdir,
                        tmp_outdir_prefix=args.tmp_outdir_prefix,
                        use_container=args.use_container,
+                       no_user=args.no_user,
                        preserve_environment=args.preserve_environment,
                        pull_image=args.enable_pull,
                        rm_container=args.rm_container,

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -115,7 +115,7 @@ def arg_parser():
     exgroup.add_argument("--debug", action="store_true", help="Print even more logging")
 
     parser.add_argument("--tool-help", action="store_true", help="Print command line help for tool")
-    parser.add_argument("--no-user", action="store_true", help="Runs container without setting user")
+    parser.add_argument("--no-user", action="store_true", help="Runs container without setting user (default will set user)")
 
     parser.add_argument("workflow", type=str, nargs="?", default=None)
     parser.add_argument("job_order", nargs=argparse.REMAINDER)


### PR DESCRIPTION
The flag **--no-user** will stop cwltools from passing **--user euid** to docker run and will instead pass the environment variable **HOSTUSER=euid**.

This is to deal with situations where the EUID of the host does not match the EUID of the user in the container (or the EUID of the host does not exist in the container).  Such a situation could cause unexpected issues with running the container. Instead what creators of the containers can do is chown the output directory to the given HOSTUSER environment variable (if needed).  This deals with the assumption that the container can be run as the user with EUID the same as the host and that the user with the given EUID exists.