### PR TITLE
Fix tmp prefix usage

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -539,19 +539,8 @@ def main(args=None,
     if type(t) == int:
         return t
 
-    if args.tmp_outdir_prefix != 'tmp':
-        # Use user defined temp directory (if it exists)
-        args.tmp_outdir_prefix = os.path.abspath(args.tmp_outdir_prefix)
-        if not os.path.exists(args.tmp_outdir_prefix):
-            _logger.error("Intermediate output directory prefix doesn't exist, reverting to default")
-            return 1
-
-    if args.tmpdir_prefix != 'tmp':
-        # Use user defined prefix (if the folder exists)
-        args.tmpdir_prefix = os.path.abspath(args.tmpdir_prefix)
-        if not os.path.exists(args.tmpdir_prefix):
-            _logger.error("Temporary directory prefix doesn't exist.")
-            return 1
+    args.tmp_outdir_prefix = os.path.abspath(args.tmp_outdir_prefix)
+    args.tmpdir_prefix = os.path.abspath(args.tmpdir_prefix)
 
     job_order_object = load_job_order(args, t, parser, stdin,
                                       print_input_deps=args.print_input_deps,

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -276,8 +276,14 @@ class Process(object):
             builder.outdir = kwargs.get("docker_outdir") or "/var/spool/cwl"
             builder.tmpdir = kwargs.get("docker_tmpdir") or "/tmp"
         else:
-            builder.outdir = kwargs.get("outdir") or tempfile.mkdtemp()
-            builder.tmpdir = kwargs.get("tmpdir") or tempfile.mkdtemp()
+            if kwargs.get('tmp_outdir_prefix'):
+                builder.outdir = tempfile.mkdtemp(prefix=kwargs.get('tmp_outdir_prefix'))
+            else:
+                builder.outdir = kwargs.get("outdir") or tempfile.mkdtemp()
+            if kwargs.get('tmpdir_prefix'):
+                builder.tmpdir = tempfile.mkdtemp(prefix=kwargs.get('tmpdir_prefix'))
+            else:
+                builder.tmpdir = kwargs.get("tmpdir") or tempfile.mkdtemp()
 
         builder.fs_access = kwargs.get("fs_access") or StdFsAccess(input_basedir)
 


### PR DESCRIPTION
Modifications to actually use --tmpdir-prefix and --tmp-outdir-prefix paths when cwltool is run with the --no-container flag (addressing issue #3 opened by @schultzmattd). Please note that the execution halt has been removed when tmpdir-prefix or tmp-outdir-prefix do not exist, since prefixes are used to create temporary directories instead of as paths to existing directories.
