### PR TITLE
feat(docker-net-option): Allows user to define the docker network

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -67,8 +67,10 @@ class CommandLineJob(object):
             runtime.append("--volume=%s:%s:rw" % (os.path.abspath(self.tmpdir), "/tmp"))
             runtime.append("--workdir=%s" % ("/var/spool/cwl"))
             runtime.append("--read-only=true")
-            if kwargs.get("enable_net") is not True:
+            if kwargs.get("enable_net", None) is None: 
                 runtime.append("--net=none")
+            else:
+                runtime.append("--net={0}".format(kwargs.get("enable_net")))
 
             if self.stdout:
                 runtime.append("--log-driver=none")

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -67,10 +67,11 @@ class CommandLineJob(object):
             runtime.append("--volume=%s:%s:rw" % (os.path.abspath(self.tmpdir), "/tmp"))
             runtime.append("--workdir=%s" % ("/var/spool/cwl"))
             runtime.append("--read-only=true")
-            if kwargs.get("enable_net", None) is None: 
+            if (kwargs.get("enable_net", None) is None and
+                    kwargs.get("custom_net", None) is not None):
                 runtime.append("--net=none")
-            else:
-                runtime.append("--net={0}".format(kwargs.get("enable_net")))
+            elif kwargs.get("custom_net", None) is not None:
+                runtime.append("--net={0}".format(kwargs.get("custom_net")))
 
             if self.stdout:
                 runtime.append("--log-driver=none")

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -125,8 +125,12 @@ def arg_parser():
     parser.add_argument("--relative-deps", choices=['primary', 'cwd'], default="primary",
                          help="When using --print-deps, print paths relative to primary file or current working directory.")
 
-    parser.add_argument("--enable-net", help="Use the provided docker's network for container, default to disable network")
-
+    parser.add_argument("--enable-net", action="store_true",
+            help="Use docker's default networking for containers; the default is "
+            "to disable networking.")
+    parser.add_argument("--custom-net", type=str,
+            help="Will be passed to `docker run` as the '--net' parameter. "
+            "Implies '--enable-net'.")
     parser.add_argument("workflow", type=str, nargs="?", default=None)
     parser.add_argument("job_order", nargs=argparse.REMAINDER)
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -125,7 +125,7 @@ def arg_parser():
     parser.add_argument("--relative-deps", choices=['primary', 'cwd'], default="primary",
                          help="When using --print-deps, print paths relative to primary file or current working directory.")
 
-    parser.add_argument("--enable-net", action="store_true", help="Use docker's default network for container, default to disable network")
+    parser.add_argument("--enable-net", help="Use the provided docker's network for container, default to disable network")
 
     parser.add_argument("workflow", type=str, nargs="?", default=None)
     parser.add_argument("job_order", nargs=argparse.REMAINDER)


### PR DESCRIPTION
Instead of `--enable_net` being a boolean, I added the ability to explicitly define the docker network id. If I wanted to use, say, the `host` docker network:

```
cwltool.py --enable-net host ...
```

If you don't use the option is acts just as before.