### PR TITLE
add convenient entry point for cwltool

### DIFF
--- a/cwltool.py
+++ b/cwltool.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""Convienance entry point for cwltool."""
+
+import sys
+from cwltool import main
+
+if __name__ == "__main__":
+    sys.exit(main.main(sys.argv[1:]))

--- a/cwltool.py
+++ b/cwltool.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
-"""Convienance entry point for cwltool."""
+"""Convienance entry point for cwltool.
+
+This can be used instead of the recommended method of `./setup.py install`
+or `./setup.py develop` and then using the generated `cwltool` executable.
+"""
 
 import sys
 from cwltool import main


### PR DESCRIPTION
@tetron I would suggest using this (`cwltool.py`) instead of `cwltool/main.py` to solve the issues Curoverse was having since the move to relative imports.

As a reminder, here is the other workaround:  `setup.py install` or `setup.py develop` and use the `cwltool` that gets install to the appropriate `bin/` directory.