### PR TITLE
Avoid input binding of optional arguments when they are not specified.

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -66,7 +66,7 @@ class Builder(object):
 
             if schema["type"] == "record":
                 for f in schema["fields"]:
-                    if f["name"] in datum:
+                    if f["name"] in datum and datum[f["name"]]:
                         bindings.extend(self.bind_input(f, datum[f["name"]], lead_pos=lead_pos, tail_pos=f["name"]))
                     else:
                         datum[f["name"]] = f.get("default")


### PR DESCRIPTION
It seems to be an oversight. Currently, this is only a problem when valueFrom is specified and a expression uses _self_, which will be null when doing the eval. 
