### PR TITLE
Cache jobs

### DIFF
--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -42,6 +42,9 @@ class PathMapper(object):
     def files(self):  # type: () -> List[str]
         return self._pathmap.keys()
 
+    def items(self):  # type: () -> List[Tuple[str,Tuple[str,str]]]
+        return self._pathmap.items()
+
     def reversemap(self, target):  # type: (str) -> Tuple[str, str]
         for k, v in self._pathmap.items():
             if v[1] == target:

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -31,7 +31,6 @@ from rdflib import Graph
 _logger = logging.getLogger("cwltool")
 
 supportedProcessRequirements = ["DockerRequirement",
-                                "ExpressionEngineRequirement",
                                 "SchemaDefRequirement",
                                 "EnvVarRequirement",
                                 "CreateFileRequirement",
@@ -309,6 +308,32 @@ class Process(object):
                     checkFormat(builder.job[d], builder.do_eval(i["format"]), self.formatgraph)
 
         builder.bindings.extend(builder.bind_input(self.inputs_record_schema, builder.job))
+
+        if self.tool.get("baseCommand"):
+            for n, b in enumerate(aslist(self.tool["baseCommand"])):
+                builder.bindings.append({
+                    "position": [-1000000, n],
+                    "valueFrom": b
+                })
+
+        if self.tool.get("arguments"):
+            for i, a in enumerate(self.tool["arguments"]):
+                if isinstance(a, dict):
+                    a = copy.copy(a)
+                    if a.get("position"):
+                        a["position"] = [a["position"], i]
+                    else:
+                        a["position"] = [0, i]
+                    a["do_eval"] = a["valueFrom"]
+                    a["valueFrom"] = None
+                    builder.bindings.append(a)
+                else:
+                    builder.bindings.append({
+                        "position": [0, i],
+                        "valueFrom": a
+                    })
+
+        builder.bindings.sort(key=lambda a: a["position"])
 
         builder.resources = self.evalResources(builder, kwargs)
 


### PR DESCRIPTION
Adds `--cachedir`

When enabled, each job computes a hash of the work based on the command line, sizes/time stamps of input files and effective requirements.   The output directory of the job is selected based on this hash.  If the output directory already exists in the cache directory, the work is skipped and the existing output is used.