### PR TITLE
skip null from items when testing same type

### DIFF
--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -94,6 +94,8 @@ def are_same_type(src, sink):  # type: (Any, Any) -> bool
     """
     if isinstance(src, dict) and isinstance(sink, dict):
         if src["type"] == "array" and sink["type"] == "array":
+            if 'null' in sink["items"]:
+                return are_same_type([src["items"]], [it for it in sink["items"] if it != 'null'])
             return are_same_type(src["items"], sink["items"])
         elif src["type"] == sink["type"]:
             return True


### PR DESCRIPTION
This should fix the issue encountered when a step in a workflow feeds optional arguments to a tool. Example:

__Foo tool:__ 
```
#!/usr/bin/env cwl-runner

cwlVersion: 'cwl:draft-3'
class: CommandLineTool

requirements:
  - class: InlineJavascriptRequirement

inputs:
  - id: foo
    type:
      - 'null'
      - File
    description: foo
outputs:
  - id: '#bar'
    type: File
    outputBinding:
      glob: bar_out
stdout: "bar_out"
baseCommand: 
 - echo
```

__Workflow using Foo tool:__
```
#!/usr/bin/env cwl-runner

class: Workflow
requirements:
  - class: ScatterFeatureRequirement
inputs:
  - id: foo_files
    type:
      type: array
      items: File

outputs:
  - id: '#bar'
    source: "#footool.bar"
    type:
      type: array
      items: File
steps:
  - id: "#footool"
    run: {import: "tool-test.cwl" }
    scatter: "#footool.foo"
    inputs:
      - id: "#footool.foo"
        source: "#foo_files"
    outputs:
      - id: "#footool.bar"
```

Currently, an exception is thrown because the items types are not the same (the sink is an array with _null_ and _File_, while the source is just _File_) :
```
WorkflowException: Type mismatch between source 'file:///Users/abarrera/workspace/cwltool/tests/workflow-test.cwl#foo_files' ({'items': 'File', 'type': 'array'}) and sink 'file:///Users/abarrera/workspace/cwltool/tests/workflow-test.cwl#footool.foo' ({'items': ['null', 'File'], 'type': 'array'})
```
