### PR TITLE
Avoid keyword type argument when adding boolean inputs

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -285,8 +285,10 @@ def generate_parser(toolparser, tool, namemap):
             _logger.debug(u"Can't make command line argument from %s", inptype)
             return None
 
-        toolparser.add_argument(flag + name, required=required,
-                help=ahelp, action=action, type=atype, default=default)
+        argument_kwargs = {'required': required, 'help': ahelp, 'action': action, 'default': default}
+        if inptype != "boolean":
+            argument_kwargs['type'] = atype
+        toolparser.add_argument(flag + name, **argument_kwargs)
 
     return toolparser
 


### PR DESCRIPTION
Currently, boolean types do not translate well into argparse arguments. This is very general, but here is an example to test:

```
#!/usr/bin/env cwl-runner
cwlVersion: 'cwl:draft-3'
class: CommandLineTool
inputs:
  - id: bdg
    type: "boolean"
outputs:
  - id: output
    type: File
    outputBinding:
      glob: foo
baseCommand:
  - echo
  - "ff"
stdout: foo
```

 