### PR TITLE
Enable concatenating input paths with suffix strings

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -338,7 +338,9 @@ class CommandLineTool(Process):
                         globpatterns.extend(aslist(gb))
 
                 for gb in globpatterns:
-                    if gb.startswith("/"):
+                    if gb.startswith(outdir):
+                        gb = gb[len(outdir)+1:]
+                    elif gb.startswith("/"):
                         raise WorkflowException("glob patterns must not start with '/'")
                     try:
                         r.extend([{"path": g, "class": "File", "hostfs": True}


### PR DESCRIPTION
This fixes so that one can concatenate input paths in the output spec's glob field, with e.g. suffixes, like so (see the .amb, .ann, .bwt, .pac, .se suffixes added):

```yaml
outputs:
  - id: output
    type: { type: array, items: File }
    outputBinding:
      glob:
          - $(inputs.input.path).amb
          - $(inputs.input.path).ann
          - $(inputs.input.path).bwt
          - $(inputs.input.path).pac
          - $(inputs.input.path).sa
```

Previously you would get an error if trying to use inputs.[somthing].path, since it starts with a `/`, which was not allowed, until this change.

For more background, see [this discussion on gitter](https://gitter.im/common-workflow-language/common-workflow-language?at=573348c27df8adaf347d5589):

> Samuel Lampa @samuell 16:59
> Hi, this is a yaml question maybe, but do you know how to concatenate a `$(input.something...)` part with another extension, in the glob field of an output for example?
>
> Peter Amstutz @tetron 16:59
> @samuell `$(inputs.something).xyz`
> it is string interpolated
>
> Samuel Lampa @samuell 17:00
> @tetron Tried, but got errors ...
> Error while running job: Error collecting output for parameter 'output': Did not find output file with glob pattern: '['{"class": "File", "co│                                                                                                                                              
> ntainerfs": true, "path": "/home/samuel/code/bils/cwl-evaluation/002-resequencing/Homo_sapiens.GRCh37.75.dna.chromosome.17.fa"}.bwt', ...
>
> Peter Amstutz @tetron 17:00
> Should be `$(inputs.something.path)`
> files are objects
> 
> Samuel Lampa @samuell 17:01
> Hmm, aha, right
>
> Samuel Lampa @samuell 17:09
> (@tetron: Then, .path starts with '/', which glob doesn't like  ... I might need to do some expression foo I guess?  )
>
> Peter Amstutz @tetron 17:09
> oh, that's a bug
> somebody should fix that
> @samuell cwltool.draft2tool.py L334
> @samuell actually L341
> @samuell that should be tweaked with an additional conditional like if `gb.startswith(outdir): gb = gb[:len(outdir)]`