### PR TITLE
are_same_type return true if intersection of src and sink not empty

### DIFF
--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -16,3 +16,7 @@ def get_feature(self, feature):  # type: (Any, Any) -> Tuple[Any, bool]
         if t["class"] == feature:
             return (t, False)
     return (None, None)
+
+class HashableDict(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -1,6 +1,6 @@
 from . import job
 from . import draft2tool
-from .utils import aslist
+from .utils import aslist, HashableDict
 from .process import Process, get_feature, empty_subtree, shortname, uniquename
 from .errors import WorkflowException
 import copy
@@ -88,6 +88,7 @@ def match_types(sinktype, src, iid, inputobj, linkMerge, valueFrom):
         return True
     return False
 
+
 def are_same_type(src, sink):  # type: (Any, Any) -> bool
     """Check for identical type specifications, ignoring extra keys like inputBinding.
     """
@@ -99,6 +100,8 @@ def are_same_type(src, sink):  # type: (Any, Any) -> bool
                 src_items = [src_items]
             if not isinstance(sink_items, list):
                 sink_items = [sink_items]
+            src_items = [HashableDict(s) if isinstance(s, dict) else s for s in src_items]
+            sink_items = [HashableDict(s) if isinstance(s, dict) else s for s in sink_items]
             return are_same_type(src_items, sink_items)
         else:
             return src["type"] == sink["type"]

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -93,16 +93,20 @@ def are_same_type(src, sink):  # type: (Any, Any) -> bool
     """
     if isinstance(src, dict) and isinstance(sink, dict):
         if src["type"] == "array" and sink["type"] == "array":
-            if 'null' in sink["items"]:
-                return are_same_type([src["items"]], [it for it in sink["items"] if it != 'null'])
-            return are_same_type(src["items"], sink["items"])
-        elif src["type"] == sink["type"]:
-            return True
+            src_items = src["items"]
+            sink_items = sink["items"]
+            if not isinstance(src_items, list):
+                src_items = [src_items]
+            if not isinstance(sink_items, list):
+                sink_items = [sink_items]
+            return are_same_type(src_items, sink_items)
         else:
-            return False
+            return src["type"] == sink["type"]
     else:
-        return src == sink
-
+        try:
+            return src == sink or len(set(src).intersection(set(sink))) > 0
+        except TypeError:
+            return False
 
 def object_from_state(state, parms, frag_only, supportsMultipleInput):
     # type: (Dict[str,WorkflowStateItem], List[Dict[str, Any]], bool, bool) -> Dict[str, str]


### PR DESCRIPTION
In line with what @tetron commented in #74 the `are_same_type` function should return `True` if the intersection of `src` and `sink` is not empty. I found out that the solution in #74 was only partial (fixing the problem when the _input_ param is optional, but not when the _output_ param is). This should cover both cases. 