### PR TITLE
[RFC] Tool Dependencies for CWL

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -220,6 +220,7 @@ class CommandLineTool(Process):
         reffiles = copy.deepcopy(builder.files)
 
         j = self.makeJobRunner()
+        j.tool_dependency_manager = self.tool_dependency_manager
         j.builder = builder
         j.joborder = builder.job
         j.stdin = None

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -6,6 +6,7 @@ import glob
 import json
 import logging
 import sys
+import string
 import requests
 from . import docker
 from .process import get_feature, empty_subtree, stageFiles
@@ -23,6 +24,9 @@ import functools
 _logger = logging.getLogger("cwltool")
 
 needs_shell_quoting_re = re.compile(r"""(^$|[\s|&;()<>\'"$@])""")
+
+FORCE_SHELLED_POPEN = os.getenv("CWLTOOL_FORCE_SHELL_POPEN", "1") == "1"
+
 
 def deref_links(outputs):  # type: (Any) -> None
     if isinstance(outputs, dict):
@@ -188,50 +192,36 @@ class CommandLineJob(object):
                 stageFiles(generatemapper, linkoutdir)
 
             if self.stdin:
-                stdin = open(self.pathmapper.reversemap(self.stdin)[1], "rb")
+                stdin_path = self.pathmapper.reversemap(self.stdin)[1]
             else:
-                stdin = subprocess.PIPE
+                stdin_path = None
 
             if self.stderr:
                 abserr = os.path.join(self.outdir, self.stderr)
                 dnerr = os.path.dirname(abserr)
                 if dnerr and not os.path.exists(dnerr):
                     os.makedirs(dnerr)
-                stderr = open(abserr, "wb")
+                stderr_path = abserr
             else:
-                stderr = sys.stderr
+                stderr_path = None
 
             if self.stdout:
                 absout = os.path.join(self.outdir, self.stdout)
                 dn = os.path.dirname(absout)
                 if dn and not os.path.exists(dn):
                     os.makedirs(dn)
-                stdout = open(absout, "wb")
+                stdout_path = absout
             else:
-                stdout = sys.stderr
+                stdout_path = None
 
-            sp = subprocess.Popen([unicode(x).encode('utf-8') for x in runtime + self.command_line],
-                                  shell=False,
-                                  close_fds=True,
-                                  stdin=stdin,
-                                  stderr=stderr,
-                                  stdout=stdout,
-                                  env=env,
-                                  cwd=self.outdir)
-
-            if sp.stdin:
-                sp.stdin.close()
-
-            rcode = sp.wait()
-
-            if isinstance(stdin, file):
-                stdin.close()
-
-            if stderr is not sys.stderr:
-                stderr.close()
-
-            if stdout is not sys.stderr:
-                stdout.close()
+            rcode = shelled_popen(
+                [unicode(x).encode('utf-8') for x in runtime + self.command_line],
+                stdin_path=stdin_path,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                env=env,
+                cwd=self.outdir,
+            )
 
             if self.successCodes and rcode in self.successCodes:
                 processStatus = "success"
@@ -290,3 +280,152 @@ class CommandLineJob(object):
         if move_outputs == "move" and empty_subtree(self.outdir):
             _logger.debug(u"[job %s] Removing empty output directory %s", self.name, self.outdir)
             shutil.rmtree(self.outdir, True)
+
+
+SHELL_COMMAND_TEMPLATE = string.Template("""#!/bin/bash
+$prefix
+python "run_job.py" "job.json"
+""")
+PYTHON_RUN_SCRIPT = """
+import json
+import sys
+import subprocess
+
+with open(sys.argv[1], "r") as f:
+    popen_description = json.load(f)
+    commands = popen_description["commands"]
+    cwd = popen_description["cwd"]
+    env = popen_description["env"]
+    stdin_path = popen_description["stdin_path"]
+    stdout_path = popen_description["stdout_path"]
+    stderr_path = popen_description["stderr_path"]
+
+    if stdin_path is not None:
+        stdin = open(stdin_path, "rd")
+    else:
+        stdin = subprocess.PIPE
+
+    if stdout_path is not None:
+        stdout = open(stdout_path, "wb")
+    else:
+        stdout = sys.stderr
+
+    if stderr_path is not None:
+        stderr = open(stderr_path, "wb)
+    else:
+        stderr = sys.stderr
+
+    sp = subprocess.Popen(commands,
+                          shell=False,
+                          close_fds=True,
+                          stdin=stdin,
+                          stdout=stdout,
+                          env=env,
+                          cwd=cwd)
+
+    if sp.stdin:
+        sp.stdin.close()
+
+    rcode = sp.wait()
+
+    if isinstance(stdin, file):
+        stdin.close()
+
+    if stdout is not sys.stderr:
+        stdout.close()
+
+    if stderr is not sys.stderr:
+        stderr.close()
+
+    sys.exit(rcode)
+"""
+
+
+def shelled_popen(commands,
+                  stdin_path,
+                  stdout_path,
+                  stderr_path,
+                  env,
+                  cwd,
+                  prefix=None):
+    if prefix is None and not FORCE_SHELLED_POPEN:
+        if stdin_path is not None:
+            stdin = open(stdin_path, "rd")
+        else:
+            stdin = subprocess.PIPE
+
+        if stdout_path is not None:
+            stdout = open(stdout_path, "wb")
+        else:
+            stdout = sys.stderr
+
+        if stderr_path is not None:
+            stderr = open(stderr_path, "wb")
+        else:
+            stderr = sys.stderr
+
+        sp = subprocess.Popen(commands,
+                              shell=False,
+                              close_fds=True,
+                              stdin=stdin,
+                              stdout=stdout,
+                              stderr=stderr,
+                              env=env,
+                              cwd=cwd)
+
+        if sp.stdin:
+            sp.stdin.close()
+
+        rcode = sp.wait()
+
+        if isinstance(stdin, file):
+            stdin.close()
+
+        if stdout is not sys.stderr:
+            stdout.close()
+
+        if stderr is not sys.stderr:
+            stderr.close()
+
+        return rcode
+    else:
+        template_kwds = dict(
+            prefix=prefix or '',
+        )
+        job_script_contents = SHELL_COMMAND_TEMPLATE.substitute(
+            **template_kwds
+        )
+        job_dir = tempfile.mkdtemp(prefix="cwltooljob")
+        job_description = dict(
+            commands=commands,
+            cwd=cwd,
+            env=env,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            stdin_path=stdin_path,
+        )
+        with open(os.path.join(job_dir, "job.json"), "w") as f:
+            json.dump(job_description, f)
+        try:
+            job_script = os.path.join(job_dir, "run_job.bash")
+            with open(job_script, "w") as f:
+                f.write(job_script_contents)
+            job_run = os.path.join(job_dir, "run_job.py")
+            with open(job_run, "w") as f:
+                f.write(PYTHON_RUN_SCRIPT)
+            sp = subprocess.Popen(
+                ["bash", job_script],
+                shell=False,
+                cwd=job_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
+            if sp.stdin:
+                sp.stdin.close()
+
+            rcode = sp.wait()
+
+            return rcode
+        finally:
+            shutil.rmtree(job_dir)

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -389,7 +389,7 @@ class Process(object):
             avro.schema.make_avsc_object(self.outputs_record_schema, self.names)
         except avro.schema.SchemaParseException as e:
             raise validate.ValidationException(u"Got error `%s` while prcoessing outputs of %s:\n%s" % (str(e), self.tool["id"], json.dumps(self.outputs_record_schema, indent=4)))
-
+        self.tool_dependency_manager = kwargs.get("tool_dependency_manager", None)
 
     def _init_job(self, joborder, **kwargs):
         # type: (Dict[unicode, unicode], **Any) -> Builder


### PR DESCRIPTION
## Overview

This initial prototype describes a new abstract Hint type (``Dependency``) for CWL tools to annotate and act on software packages depended on by a tool definition. This is backed by a pluggable framework for "resolving" these dependencies across a wide variety of platforms. These resolution strategies include custom shell scripts for a local infrastructure, environment modules (http://modules.sourceforge.net/), Homebrew (http://brew.sh/), and conda (https://conda.anaconda.org/). While certainly PRs to adapt this to other package managers, such as Debian, would be welcome - these existing ones have the distinct advantage of allowing multiple versions of a package to exist on the same machine and work in a cross platform fashion.

While I believe that the work on custom packages and environment modules are important steps to allow consumers of CWL to leverage it on HPC resources - the conda resolver (and to a lesser extent the Homebrew resolver) is more exciting and more powerful because it allows for automatic installation as well mere resolution. The Mulled project for instance (https://github.com/mulled/mulled) (ping @bgruening) is work to automatically build Docker images from Homebrew and Conda dependency lists as described by this work. CWL tools that describe dependencies should therefore "get Docker for free" while also being readily usable on HPC and other non-Docker platforms using the same stack of dependencies. In addition to this increased reproducibility, Mulled Docker containers are arguably a little more structured and provide greater transparency than arbitrary Dockerfile-based containers - due to the declarative, structured nature of their construction.

This work is backed by the [galaxy-lib](https://github.com/galaxyproject/galaxy-lib) project that makes various Galaxy functionality available as a Python library - in particular this work reuses the ``galaxy.tools.deps`` package within cwltool. The implementation could use **a lot of work** for sure - but I want to get a sense for what the path forward is for this.

 - No thanks - if you want to submit patches that make forking cwltool a little easier feel free...
 - Cool, this belongs in the reference implementation and here is a long list of things you can do to clean up the implementation...
 - Cool, lets get it in the reference implementation and the hint definition should probably be described in the specification in some way, here is an outline of how to add to a future draft...

## How To Use (Conda Example)

Add dependencies as ``hints``:

```
hints
 - type: Dependency
   name: bwa
   version: 0.7.13
```

or just for a unversioned dependency:

```
hints
 - type: Dependency
   name: bwa
```

Create a dependency resolvers configuration file - sets call it ``/path/tool/deps/conda_resolvers_conf.yml`` - for example the following one will work for conda and enable advanced features such as automatic installation of conda, automatic installation of tools, and inexact version resolution if the exact version cannot be found. This file can be XML or JSON as well... but who cares...

```
- type: conda
  auto_init: True
  auto_install: True
- type: conda
  versionless: True
  auto_init: True
  auto_install: True
```

Install ``galaxy-lib`` in cwltool's environment - e.g. ``pip install cwltool``. The only new dependency this should introduce besides ``galaxy-lib`` is ``six`` I think.

Call cwltool with a ``--dependency-resolvers-configuration`` argument.

```
cwltool --dependency-resolvers-configuration /path/tool/deps/conda_resolvers_conf.yml [tool] [job]
```

Execution of this tool should now install conda, install bwa from bioconda, and setup a conda environment just or that job with that precise version of bwa (or combination of dependencies if multiple ones are supplied), and then run the tool with that environment sourced.

## Implementation

In addition to the routine plumbing of adding a command-line argument and passing the Galaxy object around - this reworked job.py to optionally run shell commands to setup an environment before actually calling Popen in another process. This is probably incorrect in some ways - I'll keep working on testing and such if there is interest in this.

Galaxy code is imported conditionally so galaxy-lib remains an optional dependency.
