### PR TITLE
Enable src/sink comparisons for records

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -168,6 +168,12 @@ class TestTypeCompare(unittest.TestCase):
             {'items': ['string'], 'type': 'array'},
             {'items': ['int'], 'type': 'array'}))
 
+    def test_recordcompare(self):
+        src = {'fields': [{'type': {'items': 'string', 'type': 'array'}, 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/wf-variantcall.cwl#vc_rec/vc_rec/description'}, {'type': {'items': 'File', 'type': 'array'}, 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/wf-variantcall.cwl#vc_rec/vc_rec/vrn_file'}], 'type': 'record', 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/wf-variantcall.cwl#vc_rec/vc_rec'}
+        sink = {'fields': [{'type': {'items': 'string', 'type': 'array'}, 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/steps/vc_output_record.cwl#vc_rec/vc_rec/description'}, {'type': {'items': 'File', 'type': 'array'}, 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/steps/vc_output_record.cwl#vc_rec/vc_rec/vrn_file'}], 'type': 'record', 'name': u'file:///home/chapmanb/drive/work/cwl/test_bcbio_cwl/run_info-cwl-workflow/steps/vc_output_record.cwl#vc_rec/vc_rec'}
+        self.assertTrue(cwltool.workflow.can_assign_src_to_sink(src, sink))
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The logic for comparing records from two different sections of the
workflow previous failed due to falling back to a `==` comparison that
would not pass due to differences in fully qualified record names.

This fix adds an explicit record comparison function that normalizes
field names by the record namespace and then ensures that all of the
types of each field are identical from both records.

Also adds a test to demonstrate the behavior.