### PR TITLE
Fix implementation of writable flag

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -295,6 +295,7 @@ class CommandLineTool(Process):
                             et["entryname"] = builder.do_eval(t["entryname"])
                         else:
                             et["entryname"] = None
+                        et["writable"] = t.get("writable", False)
                         ls.append(et)
                     else:
                         ls.append(builder.do_eval(t))
@@ -304,12 +305,14 @@ class CommandLineTool(Process):
                         ls[i] = {
                             "class": "File",
                             "basename": t["entryname"],
-                            "contents": t["entry"]
+                            "contents": t["entry"],
+                            "writable": t.get("writable")
                         }
                     else:
                         if t["entryname"]:
                             t = copy.deepcopy(t)
                             t["entry"]["basename"] = t["entryname"]
+                            t["entry"]["writable"] = t.get("writable")
                         ls[i] = t["entry"]
             j.generatefiles[u"listing"] = ls
 

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -58,7 +58,7 @@ class CommandLineJob(object):
         self.outdir = None  # type: str
         self.tmpdir = None  # type: str
         self.environment = None  # type: Dict[str,str]
-        self.generatefiles = None  # type: Dict[unicode, Union[List[Dict[str, str]], Dict[str,str], str]] 
+        self.generatefiles = None  # type: Dict[unicode, Union[List[Dict[str, str]], Dict[str,str], str]]
         self.stagedir = None  # type: unicode
 
     def run(self, dry_run=False, pull_image=True, rm_container=True,
@@ -251,7 +251,7 @@ class CommandLineJob(object):
                     if os.path.exists(tgt) and os.path.islink(tgt):
                         os.remove(tgt)
                         os.symlink(src, tgt)
-                stageFiles(generatemapper, linkoutdir)
+                stageFiles(generatemapper, linkoutdir, ignoreWritable=True)
 
             outputs = self.collect_outputs(self.outdir)
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -169,16 +169,16 @@ def getListing(fs_access, rec):
                 listing.append({"class": "File", "location": ld})
         rec["listing"] = listing
 
-def stageFiles(pm, stageFunc):
+def stageFiles(pm, stageFunc, ignoreWritable=False):
     # type: (PathMapper, Callable[..., Any]) -> None
     for f, p in pm.items():
         if not os.path.exists(os.path.dirname(p.target)):
             os.makedirs(os.path.dirname(p.target), 0755)
         if p.type == "File":
             stageFunc(p.resolved, p.target)
-        elif p.type == "WritableFile":
+        elif p.type == "WritableFile" and not ignoreWritable:
             shutil.copy(p.resolved, p.target)
-        elif p.type == "CreateFile":
+        elif p.type == "CreateFile" and not ignoreWritable:
             with open(p.target, "w") as n:
                 n.write(p.resolved.encode("utf-8"))
 


### PR DESCRIPTION
Was not correctly propagated from 'entry' to path mapper, and job.py was overwriting the modified output file by accident.