### PR TITLE
Tweak to work with Docker OSX Beta

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -105,8 +105,8 @@ class CommandLineJob(object):
                     with open(createtmp, "w") as f:
                         f.write(vol.resolved.encode("utf-8"))
                     runtime.append(u"--volume=%s:%s:ro" % (createtmp, vol.target))
-            runtime.append(u"--volume=%s:%s:rw" % (os.path.abspath(self.outdir), "/var/spool/cwl"))
-            runtime.append(u"--volume=%s:%s:rw" % (os.path.abspath(self.tmpdir), "/tmp"))
+            runtime.append(u"--volume=%s:%s:rw" % (os.path.realpath(self.outdir), "/var/spool/cwl"))
+            runtime.append(u"--volume=%s:%s:rw" % (os.path.realpath(self.tmpdir), "/tmp"))
             runtime.append(u"--workdir=%s" % ("/var/spool/cwl"))
             runtime.append("--read-only=true")
             if (kwargs.get("enable_net", None) is None and


### PR DESCRIPTION
I was trying to run the docker example from here:
http://www.commonwl.org/v1.0/UserGuide.html#Running_tools_inside_Docker
I received an error about `Mounts denied.../var/folders...`:
```
[job d.cwl] /var/folders/fs/vv08ppmd1mj7g35hyq5m_7nr0000gp/T/tmp24cwqi$ docker \
    run \
    -i \
    --volume=/Users/jpb67/Documents/work/cwl/hello.js:/var/lib/cwl/stg1e37b475-6862-491a-9dbf-8bae6f590abe/hello.js:ro \
    --volume=/var/folders/fs/vv08ppmd1mj7g35hyq5m_7nr0000gp/T/tmp24cwqi:/var/spool/cwl:rw \
    --volume=/var/folders/fs/vv08ppmd1mj7g35hyq5m_7nr0000gp/T/tmpLuHuEa:/tmp:rw \
    --workdir=/var/spool/cwl \
    --read-only=true \
    --user=502 \
    --rm \
    --env=TMPDIR=/tmp \
    --env=HOME=/var/spool/cwl \
    node:slim \
    node \
    /var/lib/cwl/stg1e37b475-6862-491a-9dbf-8bae6f590abe/hello.js
docker: Error response from daemon: Mounts denied: s...
.
The paths /var/folders/fs/vv08ppmd1mj7g35hyq5m_7nr0000gp/T/tmp24cwqi and /var/folders/fs/vv08ppmd1mj7g35hyq5m_7nr0000gp/T/tmpLuHuEa
are not shared from OS X and do not belong to the system.
You can configure shared paths from Docker -> Preference.
[job d.cwl] completed permanentFail
Final process status is permanentFail
```
On my machine `/var` is a symbolic link to `/private/var`.
I am using the Docker for Mac -Version 1.12.0-rc4-beta20 (https://docs.docker.com/docker-for-mac/). I tried adding /var to docker as a setup.

I changed the code to use os.path.realpath instead of os.path.abspath.
This converts the path from `/var/folders/...` to `/private/var/folders...`.
Not sure if this change would have any negative impact for other environments, but it works on my laptop now.

As a work around I found that by setting the TMPDIR environment variable it would work correctly.
```
export TMPDIR=/tmp
```