### PR TITLE
Copy 3 attributes from array to array items

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -96,7 +96,10 @@ class Builder(object):
                     if binding:
                         b2 = copy.deepcopy(binding)
                         b2["valueFrom"] = item
-                    bindings.extend(self.bind_input({"type": schema["items"], "inputBinding": b2},
+                    bindings.extend(self.bind_input({"type": schema["items"], "inputBinding": b2,
+                                                     "secondaryFiles": schema.get("secondaryFiles"),
+                                                     "format": schema.get("format"),
+                                                     "streamable": schema.get("streamable")},
                                                     item, lead_pos=n, tail_pos=tail_pos))
                 binding = None
 


### PR DESCRIPTION
As discussed on Gitter with @tetron, for arrays of File objects, the secondaryFiles, format and streamable attributes need to be copied from the array down to the File items that are contained in the array. This change requires the schema change: https://github.com/common-workflow-language/common-workflow-language/pull/281