### PR TITLE
Add check that workflow step 'out' parameter

### DIFF
--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -352,7 +352,7 @@ class WorkflowJob(object):
             made_progress = False
 
             for step in self.steps:
-                if kwargs["on_error"] == "stop" and self.processStatus != "success":
+                if kwargs.get("on_error", "stop") == "stop" and self.processStatus != "success":
                     break
 
                 if not step.submitted:
@@ -360,7 +360,7 @@ class WorkflowJob(object):
 
                 if step.iterable:
                     for newjob in step.iterable:
-                        if kwargs["on_error"] == "stop" and self.processStatus != "success":
+                        if kwargs.get("on_error", "stop") == "stop" and self.processStatus != "success":
                             break
                         if newjob:
                             made_progress = True
@@ -455,7 +455,11 @@ class WorkflowStep(Process):
                         found = True
                         break
                 if not found:
-                    param["type"] = "Any"
+                    if stepfield == "in":
+                        param["type"] = "Any"
+                    else:
+                        raise WorkflowException("[%s] Workflow step output '%s' not found in the outputs of the tool (expected one of '%s')" % (
+                            self.id, shortname(step_entry), "', '".join([shortname(tool_entry["id"]) for tool_entry in self.embedded_tool.tool[toolfield]])))
                 param["id"] = inputid
                 toolpath_object[toolfield].append(param)
 

--- a/tests/test_bad_outputs_wf.cwl
+++ b/tests/test_bad_outputs_wf.cwl
@@ -1,0 +1,31 @@
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs:
+  b:
+    type: string
+    outputSource: step2/c
+steps:
+  step1:
+    in: []
+    out: [c]
+    run:
+      class: CommandLineTool
+      inputs: []
+      outputs:
+        b:
+          type: string
+          outputBinding:
+            outputEval: "qq"
+      baseCommand: echo
+  step2:
+    in:
+      a: step1/c
+    out: [c]
+    run:
+      class: CommandLineTool
+      inputs:
+        a: string
+      outputs:
+        b: string
+      baseCommand: echo

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -196,5 +196,14 @@ class TestTypeCompare(unittest.TestCase):
         self.assertTrue(cwltool.workflow.can_assign_src_to_sink(src, sink))
 
 
+    def test_lifting(self):
+        # check that lifting the types of the process outputs to the workflow step
+        # fails if the step 'out' doesn't match.
+        with self.assertRaises(cwltool.workflow.WorkflowException):
+            f = cwltool.factory.Factory()
+            echo = f.make("tests/test_bad_outputs_wf.cwl")
+            self.assertEqual(echo(inp="foo"), {"out": "foo\n"})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Must match one of the outputs of the underlying process.