### PR TITLE
Normalize symlinks in out and temp directories

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -420,13 +420,13 @@ class Process(object):
             raise WorkflowException("Document has DockerRequirement under 'requirements' but use_container is false.  DockerRequirement must be under 'hints' or use_container must be true.")
 
         if dockerReq and kwargs.get("use_container"):
-            builder.outdir = kwargs.get("docker_outdir") or "/var/spool/cwl"
-            builder.tmpdir = kwargs.get("docker_tmpdir") or "/tmp"
-            builder.stagedir = kwargs.get("docker_stagedir") or "/var/lib/cwl"
+            builder.outdir = os.path.realpath(kwargs.get("docker_outdir") or "/var/spool/cwl")
+            builder.tmpdir = os.path.realpath(kwargs.get("docker_tmpdir") or "/tmp")
+            builder.stagedir = os.path.realpath(kwargs.get("docker_stagedir") or "/var/lib/cwl")
         else:
-            builder.outdir = kwargs.get("outdir") or tempfile.mkdtemp()
-            builder.tmpdir = kwargs.get("tmpdir") or tempfile.mkdtemp()
-            builder.stagedir = kwargs.get("stagedir") or tempfile.mkdtemp()
+            builder.outdir = os.path.realpath(kwargs.get("outdir") or tempfile.mkdtemp())
+            builder.tmpdir = os.path.realpath(kwargs.get("tmpdir") or tempfile.mkdtemp())
+            builder.stagedir = os.path.realpath(kwargs.get("stagedir") or tempfile.mkdtemp())
 
         builder.fs_access = kwargs.get("fs_access") or StdFsAccess(kwargs["basedir"])
 


### PR DESCRIPTION
When running on systems where temporary directories have symlinks like
(/scratch -> /myfilesystem/scratch) outdir will end up as /scratch/tmp12345
while the actual output files are in /myfilesystem/scratch/tmp12345
resulting in failures in draft2tool
(https://github.com/common-workflow-language/cwltool/blob/e23bf6ae7b7838cf599445830ab3a69648ed8833/cwltool/draft2tool.py#L98). This normalizes these so paths match correctly.