### PR TITLE
Fix/test conformance v1.0

### DIFF
--- a/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
+++ b/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
@@ -643,7 +643,9 @@
   output: {
     "foo": {
         "location": "foo",
-        "class": "File"
+        "class": "File",
+        "checksum": "sha1$f1d2d2f924e986ac86fdf7b36c94bcdf32beec15",
+        "size": 4
     }
   }
   tool: v1.0/test-cwl-out.cwl

--- a/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
+++ b/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
@@ -745,11 +745,15 @@
         "listing": [
             {
               "class": "File",
-              "location": "hello.txt"
+              "location": "hello.txt",
+              "checksum": "sha1$47a013e660d408619d894b20806b1d5086aab03b",
+              "size": 13
             },
             {
               "class": "File",
-              "location": "goodbye.txt"
+              "location": "goodbye.txt",
+              "checksum": "sha1$dd0a4c4c49ba43004d6611771972b6cf969c1c01",
+              "size": 24
             }
         ],
     }

--- a/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
+++ b/cwltool/schemas/v1.0/conformance_test_v1.0.yaml
@@ -327,22 +327,32 @@
             {
                 "location": "input.txt.idx1",
                 "class": "File",
+                "checksum": "sha1$553f3a09003a9f69623f03bec13c0b078d706023",
+                "size": 1500
             },
             {
                 "location": "input.idx2",
                 "class": "File",
+                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                "size": 0
             },
             {
                 "location": "input.txt.idx3",
                 "class": "File",
+                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                "size": 0
             },
             {
                 "location": "input.txt.idx4",
                 "class": "File",
+                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                "size": 0
             },
             {
                 "location": "input.txt.idx5",
                 "class": "File",
+                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                "size": 0
             }
         ],
         "size": 1111


### PR DESCRIPTION
Adds checksum and size to output of 3 test of v1.0: search.cwl, dir3.cwl, test-cwl-out.cwl
These tests were not passing for me when using:
   $ /run_test.sh RUNNER=/home/ubuntu/.virtualenvs/cwl/bin/cwltool