### PR TITLE
when complete, remove tmp-outdirs while retaining cachedirs

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -202,6 +202,7 @@ class CommandLineTool(Process):
             _logger.debug("[job %s] keydictstr is %s -> %s", jobname, keydictstr, cachekey)
 
             jobcache = os.path.join(kwargs["cachedir"], cachekey)
+            self.cachedirs.add(jobcache)
             jobcachepending = jobcache + ".pending"
 
             if os.path.isdir(jobcache) and not os.path.isfile(jobcachepending):
@@ -235,6 +236,8 @@ class CommandLineTool(Process):
         reffiles = copy.deepcopy(builder.files)
 
         j = self.makeJobRunner()
+        if kwargs.get("cachedir"):
+            j.cachedirs = self.cachedirs
         j.builder = builder
         j.joborder = builder.job
         j.stdin = None

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -207,11 +207,15 @@ def single_job_executor(t, job_order_object, **kwargs):
                     output_callback,
                     **kwargs)
 
+    workflow_cachedirs = set()
     try:
         for r in jobiter:
             if r.outdir:
                 output_dirs.add(r.outdir)
 
+                if type(r).__name__ == 'CommandLineJob' and kwargs["cachedir"] is not '':
+                    for item in r.cachedirs:
+                        workflow_cachedirs.add(item)
             if r:
                 r.run(**kwargs)
             else:
@@ -230,7 +234,7 @@ def single_job_executor(t, job_order_object, **kwargs):
                                           output_dirs, kwargs.get("move_outputs"))
 
     if kwargs.get("rm_tmpdir"):
-        cleanIntermediate(output_dirs)
+        cleanIntermediate(output_dirs, workflow_cachedirs)
 
     return final_output[0]
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -223,9 +223,9 @@ def relocateOutputs(outputObj, outdir, output_dirs, action):
 
     return outputObj
 
-def cleanIntermediate(output_dirs):  # type: (Set[unicode]) -> None
+def cleanIntermediate(output_dirs, workflow_cachedirs):  # type: (Set[unicode]) -> None
     for a in output_dirs:
-        if os.path.exists(a) and empty_subtree(a):
+        if os.path.exists(a) and (a not in workflow_cachedirs):
             _logger.debug(u"Removing intermediate output directory %s", a)
             shutil.rmtree(a, True)
 
@@ -331,6 +331,7 @@ class Process(object):
         else:
             self.names = names
         self.tool = toolpath_object
+        self.cachedirs = set()
         self.requirements = kwargs.get("requirements", []) + self.tool.get("requirements", [])
         self.hints = kwargs.get("hints", []) + self.tool.get("hints", [])
         self.formatgraph = None  # type: Graph


### PR DESCRIPTION
Currently, when a workflow completes, cwltool retains both tmp-outdirs and cachedirs, accumulating storage for each run. This PR creates a set of cachedirs, and passes this set to cleanIntermediate(), so that any tmp-outdir, which is not a cachedir, is removed.