### PR TITLE
Correct usage of tmpdir and tmp_outdir prefixes

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -191,7 +191,7 @@ def single_job_executor(t, job_order_object, **kwargs):
 
     output_dirs = set()
     finaloutdir = kwargs.get("outdir")
-    kwargs["outdir"] = tempfile.mkdtemp()
+    kwargs["outdir"] = tempfile.mkdtemp(prefix=kwargs["tmp_outdir_prefix"])
     output_dirs.add(kwargs["outdir"])
 
     jobReqs = None
@@ -610,7 +610,9 @@ def main(argsl=None,
                     'workflow': None,
                     'job_order': None,
                     'pack': False,
-                    'on_error': 'continue'}.iteritems():
+                    'on_error': 'continue',
+                    'leave_tmpdir': False,
+                    'leave_outputs': False}.iteritems():
             if not hasattr(args, k):
                 setattr(args, k, v)
 
@@ -683,14 +685,14 @@ def main(argsl=None,
             # Use user defined temp directory (if it exists)
             setattr(args, 'tmp_outdir_prefix',
                     os.path.abspath(args.tmp_outdir_prefix))
-            if not os.path.exists(args.tmp_outdir_prefix):
+            if not os.path.exists(os.path.split(args.tmp_outdir_prefix)[0]):
                 _logger.error("Intermediate output directory prefix doesn't exist.")
                 return 1
 
         if args.tmpdir_prefix != 'tmp':
             # Use user defined prefix (if the folder exists)
             setattr(args, 'tmpdir_prefix', os.path.abspath(args.tmpdir_prefix))
-            if not os.path.exists(args.tmpdir_prefix):
+            if not os.path.exists(os.path.split(args.tmpdir_prefix)[0]):
                 _logger.error("Temporary directory prefix doesn't exist.")
                 return 1
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -428,9 +428,15 @@ class Process(object):
             builder.tmpdir = builder.fs_access.realpath(kwargs.get("docker_tmpdir") or "/tmp")
             builder.stagedir = builder.fs_access.realpath(kwargs.get("docker_stagedir") or "/var/lib/cwl")
         else:
-            builder.outdir = builder.fs_access.realpath(kwargs.get("outdir") or tempfile.mkdtemp())
-            builder.tmpdir = builder.fs_access.realpath(kwargs.get("tmpdir") or tempfile.mkdtemp())
-            builder.stagedir = builder.fs_access.realpath(kwargs.get("stagedir") or tempfile.mkdtemp())
+            builder.outdir = kwargs.get("outdir")
+            builder.tmpdir = kwargs.get("tmpdir")
+            if not builder.outdir:
+                builder.outdir = tempfile.mkdtemp(prefix=kwargs.get('tmp_outdir_prefix'))
+
+            if not builder.tmpdir:
+                builder.tmpdir = tempfile.mkdtemp(prefix=kwargs.get('tmpdir_prefix'))
+
+            builder.stagedir = kwargs.get("stagedir") or tempfile.mkdtemp(prefix=kwargs.get('tmpdir_prefix'))
 
         if self.formatgraph:
             for i in self.tool["inputs"]:

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -1,6 +1,8 @@
 import unittest
 from tempfile import NamedTemporaryFile
+from testfixtures import TempDirectory
 from cwltool.main import main
+import os
 
 
 class ToolArgparse(unittest.TestCase):
@@ -59,3 +61,59 @@ stdout: foo
                 self.assertEquals(main([f.name, '--help']), 0)
             except SystemExit as e:
                 self.assertEquals(e.code, 0)
+
+    def test_leave_tmpdir_prefix(self):
+        with TempDirectory() as d:
+            with NamedTemporaryFile() as f:
+                f.write(self.script)
+                f.flush()
+                try:
+                    import random
+                    indicator_str = 'test%.6f' % random.random()
+                    self.assertEquals(main(['--leave-tmpdir', '--tmpdir-prefix', d.path + "/" + indicator_str,
+                                            f.name, '--input', 'README.rst']), 0)
+                    self.assertTrue([d for d in os.listdir(d.path) if d.startswith(indicator_str)])
+                except SystemExit as e:
+                    self.assertEquals(e.code, 0)
+
+    def test_rm_tmpdir_prefix(self):
+        with TempDirectory() as d:
+            with NamedTemporaryFile() as f:
+                f.write(self.script)
+                f.flush()
+                try:
+                    import random
+                    indicator_str = 'test%.6f' % random.random()
+                    self.assertEquals(main(['--tmpdir-prefix', d.path + "/" + indicator_str,
+                                            f.name, '--input', 'README.rst']), 0)
+                    self.assertFalse([d for d in os.listdir(d.path) if d.startswith(indicator_str)])
+                except SystemExit as e:
+                    self.assertEquals(e.code, 0)
+
+    def test_leave_tmp_outdir_prefix(self):
+        with TempDirectory() as d:
+            with NamedTemporaryFile() as f:
+                f.write(self.script)
+                f.flush()
+                try:
+                    import random
+                    indicator_str = 'test%.6f' % random.random()
+                    self.assertEquals(main(['--leave-outputs', '--tmp-outdir-prefix', d.path + "/" + indicator_str,
+                                            f.name, '--input', 'README.rst']), 0)
+                    self.assertTrue([d for d in os.listdir(d.path) if d.startswith(indicator_str)])
+                except SystemExit as e:
+                    self.assertEquals(e.code, 0)
+
+    def test_rm_tmp_outdir_prefix(self):
+        with TempDirectory() as d:
+            with NamedTemporaryFile() as f:
+                f.write(self.script)
+                f.flush()
+                try:
+                    import random
+                    indicator_str = 'test%.6f' % random.random()
+                    self.assertEquals(main(['--tmp-outdir-prefix', d.path + "/" + indicator_str,
+                                            f.name, '--input', 'README.rst']), 0)
+                    self.assertFalse([d for d in os.listdir(d.path) if d.startswith(indicator_str)])
+                except SystemExit as e:
+                    self.assertEquals(e.code, 0)


### PR DESCRIPTION
Currently these arguments only work correctly when using Docker.
This patch avoid execution halt when the arguments are provided
 and the `--no-container` flag is used.
