### PR TITLE
Avoid parse already parsed Workflows in update.py

### DIFF
--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -349,6 +349,10 @@ def _draft3toDraft4dev1(doc, loader, baseuri):
     # type: (Any, Loader, Text) -> Any
     if isinstance(doc, dict):
         if "class" in doc and doc["class"] == "Workflow":
+            if 'parsed' in doc:
+                del doc['parsed']
+                return doc
+
             def fixup(f):  # type: (Text) -> Text
                 doc, frg = urllib.parse.urldefrag(f)
                 frg = '/'.join(frg.rsplit('.', 1))
@@ -370,6 +374,7 @@ def _draft3toDraft4dev1(doc, loader, baseuri):
                     step["scatter"] = [fixup(s) for s in aslist(step["scatter"])]
             for out in doc["outputs"]:
                 out["source"] = fixup(out["source"])
+            doc['parsed']=True
         for key, value in doc.items():
             doc[key] = _draft3toDraft4dev1(value, loader, baseuri)
     elif isinstance(doc, list):
@@ -389,11 +394,15 @@ def _draft4Dev1toDev2(doc, loader, baseuri):
     # type: (Any, Loader, Text) -> Any
     if isinstance(doc, dict):
         if "class" in doc and doc["class"] == "Workflow":
+            if 'parsed' in doc:
+                del doc['parsed']
+                return doc
             for out in doc["outputs"]:
                 out["outputSource"] = out["source"]
                 del out["source"]
         for key, value in doc.items():
             doc[key] = _draft4Dev1toDev2(value, loader, baseuri)
+        doc['parsed']=True
     elif isinstance(doc, list):
         for i, a in enumerate(doc):
             doc[i] = _draft4Dev1toDev2(a, loader, baseuri)

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -5,6 +5,7 @@ import re
 import traceback
 from typing import (Any, Callable, Dict, Text,  # pylint: disable=unused-import
                     Tuple, Union)
+from copy import deepcopy
 
 import six
 from six.moves import urllib
@@ -349,9 +350,6 @@ def _draft3toDraft4dev1(doc, loader, baseuri):
     # type: (Any, Loader, Text) -> Any
     if isinstance(doc, dict):
         if "class" in doc and doc["class"] == "Workflow":
-            if 'parsed' in doc:
-                del doc['parsed']
-                return doc
 
             def fixup(f):  # type: (Text) -> Text
                 doc, frg = urllib.parse.urldefrag(f)
@@ -374,8 +372,9 @@ def _draft3toDraft4dev1(doc, loader, baseuri):
                     step["scatter"] = [fixup(s) for s in aslist(step["scatter"])]
             for out in doc["outputs"]:
                 out["source"] = fixup(out["source"])
-            doc['parsed']=True
         for key, value in doc.items():
+            if key == 'run':
+                value = deepcopy(value)
             doc[key] = _draft3toDraft4dev1(value, loader, baseuri)
     elif isinstance(doc, list):
         for i, a in enumerate(doc):
@@ -394,15 +393,13 @@ def _draft4Dev1toDev2(doc, loader, baseuri):
     # type: (Any, Loader, Text) -> Any
     if isinstance(doc, dict):
         if "class" in doc and doc["class"] == "Workflow":
-            if 'parsed' in doc:
-                del doc['parsed']
-                return doc
             for out in doc["outputs"]:
                 out["outputSource"] = out["source"]
                 del out["source"]
         for key, value in doc.items():
+            if key == 'run':
+                value = deepcopy(value)
             doc[key] = _draft4Dev1toDev2(value, loader, baseuri)
-        doc['parsed']=True
     elif isinstance(doc, list):
         for i, a in enumerate(doc):
             doc[i] = _draft4Dev1toDev2(a, loader, baseuri)


### PR DESCRIPTION
When cwltool tries to update a workflow that includes more than once the
same subworkflow an exception is raised. This is a product of the updating
procedure where workflows are passed by reference in the document. Once
a workflow has been updated, it should not be processed again -otherwise
expected keys will be missed.

This is a _hacky_ fix that **I do not expect to be merged** because it does not cover all use cases of the `update.py` script, but I thought it would be a good way to draft a possible solution. To test the problem, try running cwltool/cwl-runner with any DukeGCB top level pipelines with-control like [this one](https://github.com/Duke-GCB/GGR-cwl/blob/master/ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl). 

Try:

```
cwl-runner --debug https://raw.githubusercontent.com/Duke-GCB/GGR-cwl/master/ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
```

Which produces the following error:

```
/Users/abarrera/miniconda2/envs/cwl10/bin/cwltool 1.0.20160726135535
I'm sorry, I couldn't load this CWL file.  The error was:
Traceback (most recent call last):
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/main.py", line 638, in main
    preprocess_only=args.print_pre or args.pack)
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/load_tool.py", line 130, in validate_document
    processobj, document_loader, fileuri, enable_dev, metadata)
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 503, in update
    (cdoc, version) = nextupdate(cdoc, loader, baseuri)
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 358, in draft3toDraft4dev1
    return (_draft3toDraft4dev1(doc, loader, baseuri), "draft-4.dev1")
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 349, in _draft3toDraft4dev1
    doc[key] = _draft3toDraft4dev1(value, loader, baseuri)
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 351, in _draft3toDraft4dev1
    doc = [_draft3toDraft4dev1(item, loader, baseuri) for item in doc]
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 349, in _draft3toDraft4dev1
    doc[key] = _draft3toDraft4dev1(value, loader, baseuri)
  File "/Users/abarrera/miniconda2/envs/cwl10/lib/python2.7/site-packages/cwltool/update.py", line 333, in _draft3toDraft4dev1
    step["in"] = step["inputs"]
KeyError: 'inputs'
```
