### PR TITLE
Allow the disabling of the network inside a docker container, and add the ability to provide a default docker container if one is not specified

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -87,6 +87,9 @@ class CommandLineJob(object):
         if docker_req and kwargs.get("use_container") is not False:
             env = os.environ
             img_id = docker.get_from_requirements(docker_req, docker_is_req, pull_image)
+        elif kwargs.get("default_container", None) is not None:
+            env = os.environ
+            img_id = kwargs.get("default_container")
 
         if docker_is_req and img_id is None:
             raise WorkflowException("Docker is required for running this tool.")
@@ -109,7 +112,7 @@ class CommandLineJob(object):
             
             if kwargs.get("custom_net", None) is not None:
                 runtime.append("--net={0}".format(kwargs.get("custom_net")))
-            elif not kwargs.get("enable_net", None):
+            elif kwargs.get("disable_net", None):
                 runtime.append("--net=none")
 
             if self.stdout:

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -109,7 +109,7 @@ class CommandLineJob(object):
             runtime.append(u"--volume=%s:%s:rw" % (os.path.realpath(self.tmpdir), "/tmp"))
             runtime.append(u"--workdir=%s" % ("/var/spool/cwl"))
             runtime.append("--read-only=true")
-            
+
             if kwargs.get("custom_net", None) is not None:
                 runtime.append("--net={0}".format(kwargs.get("custom_net")))
             elif kwargs.get("disable_net", None):

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -106,11 +106,11 @@ class CommandLineJob(object):
             runtime.append(u"--volume=%s:%s:rw" % (os.path.realpath(self.tmpdir), "/tmp"))
             runtime.append(u"--workdir=%s" % ("/var/spool/cwl"))
             runtime.append("--read-only=true")
-            if (kwargs.get("enable_net", None) is None and
-                    kwargs.get("custom_net", None) is not None):
-                runtime.append("--net=none")
-            elif kwargs.get("custom_net", None) is not None:
+            
+            if kwargs.get("custom_net", None) is not None:
                 runtime.append("--net={0}".format(kwargs.get("custom_net")))
+            elif not kwargs.get("enable_net", None):
+                runtime.append("--net=none")
 
             if self.stdout:
                 runtime.append("--log-driver=none")

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -154,9 +154,11 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         help="Allow loading and running development versions "
                         "of CWL spec.", default=False)
 
-    parser.add_argument("--enable-net", action="store_true",
+    parser.add_argument("--default-container",
+                        help="Specify a default docker container that will be used if the workflow fails to specify one.")
+    parser.add_argument("--disable-net", action="store_true",
                         help="Use docker's default networking for containers;"
-                        " the default is to disable networking.")
+                        " the default is to enable networking.")
     parser.add_argument("--custom-net", type=Text,
                         help="Will be passed to `docker run` as the '--net' "
                         "parameter. Implies '--enable-net'.")


### PR DESCRIPTION
This pull request addresses two security issues we have faced when using CWL.

The first is that the `--enable-net` flag never actually worked, in that the network in a docker container was always enabled, even if this flag was not present. It claimed the default behavior was to disable the network, but this was not the case.

In order to not surprise everyone who expects the network to be enabled without passing in a flag, this was changed to `--disable-net`, which disables the network inside a docker container if present.

The other issue was that we want to enforce the use of a docker container (in order to prevent network calls) even if the tool itself doesn't specify one. For this a `--default-container` flag was added that, if present, sets the docker container to run the command in if a docker container is not specified.

Let me know any questions, thanks!