### PR TITLE
Allow disabling matching the container user to the running user

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -172,7 +172,9 @@ class CommandLineJob(object):
                 runtime.append("--log-driver=none")
 
             euid = docker_vm_uid() or os.geteuid()
-            runtime.append(u"--user=%s" % (euid))
+
+            if kwargs.get("no_match_user",None) is False:
+                runtime.append(u"--user=%s" % (euid))
 
             if rm_container:
                 runtime.append("--rm")

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -156,6 +156,8 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
 
     parser.add_argument("--default-container",
                         help="Specify a default docker container that will be used if the workflow fails to specify one.")
+    parser.add_argument("--no-match-user", action="store_true",
+                        help="Disable passing the current uid to 'docker run --user`")
     parser.add_argument("--disable-net", action="store_true",
                         help="Use docker's default networking for containers;"
                         " the default is to enable networking.")


### PR DESCRIPTION
We're running into an issue where cwltool sets the uid to match the running user overriding the `USER` command https://docs.docker.com/engine/reference/builder/#/user

This pull request proposes an option to disable this setting.

This is further documented at https://github.com/ga4gh/dockstore/issues/475

