### PR TITLE
Fix --tmp-outdir-prefix for CommandLineTools.  

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -206,7 +206,7 @@ def single_job_executor(t, job_order_object, **kwargs):
 
     output_dirs = set()
     finaloutdir = kwargs.get("outdir")
-    kwargs["outdir"] = tempfile.mkdtemp(prefix=kwargs.get("tmp_outdir_prefix"))
+    kwargs["outdir"] = tempfile.mkdtemp(prefix=kwargs["tmp_outdir_prefix"]) if kwargs.get("tmp_outdir_prefix") else tempfile.mkdtemp()
     output_dirs.add(kwargs["outdir"])
 
     jobReqs = None

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -693,7 +693,7 @@ def main(argsl=None,  # type: List[str]
         if args.cachedir:
             if args.move_outputs == "move":
                 setattr(args, 'move_outputs', "copy")
-            args.tmp_outdir_prefix = args.cachedir
+            setattr(args, "tmp_outdir_prefix", args.cachedir)
 
         if job_order_object is None:
             job_order_object = load_job_order(args, tool, stdin,


### PR DESCRIPTION
Clean up initialization of args.tmp_outdir_prefix, args.tmpdir_prefix, and args.cachedir.