### PR TITLE
Hashes in filenames

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -25,7 +25,7 @@ from .stdfsaccess import StdFsAccess
 from .utils import aslist
 
 ACCEPTLIST_EN_STRICT_RE = re.compile(r"^[a-zA-Z0-9._+-]+$")
-ACCEPTLIST_EN_RELAXED_RE = re.compile(r"^[ a-zA-Z0-9._+-]+$")  # with spaces
+ACCEPTLIST_EN_RELAXED_RE = re.compile(r"^[ #a-zA-Z0-9._+-]+$")  # with spaces and hashes
 ACCEPTLIST_RE = ACCEPTLIST_EN_STRICT_RE
 
 from .flatten import flatten

--- a/cwltool/resolver.py
+++ b/cwltool/resolver.py
@@ -29,4 +29,4 @@ def tool_resolver(document_loader, uri):
         ret = r(document_loader, uri)
         if ret is not None:
             return ret
-    return file_uri(os.path.abspath(uri))
+    return file_uri(os.path.abspath(uri), split_frag=True)

--- a/cwltool/stdfsaccess.py
+++ b/cwltool/stdfsaccess.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import urllib
 
 from schema_salad.ref_resolver import file_uri
 from typing import BinaryIO, Text
@@ -30,7 +31,7 @@ class StdFsAccess(object):
         return os.path.isdir(self._abs(fn))
 
     def listdir(self, fn):  # type: (Text) -> List[Text]
-        return [abspath(l, fn) for l in os.listdir(self._abs(fn))]
+        return [abspath(urllib.quote(l), fn) for l in os.listdir(self._abs(fn))]
 
     def join(self, path, *paths):  # type: (Text, *Text) -> Text
         return os.path.join(path, *paths)

--- a/cwltool/stdfsaccess.py
+++ b/cwltool/stdfsaccess.py
@@ -31,7 +31,7 @@ class StdFsAccess(object):
         return os.path.isdir(self._abs(fn))
 
     def listdir(self, fn):  # type: (Text) -> List[Text]
-        return [abspath(urllib.quote(l), fn) for l in os.listdir(self._abs(fn))]
+        return [abspath(urllib.quote(str(l)), fn) for l in os.listdir(self._abs(fn))]
 
     def join(self, path, *paths):  # type: (Text, *Text) -> Text
         return os.path.join(path, *paths)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='cwltool',
           'ruamel.yaml >= 0.12.4',
           'rdflib >= 4.2.2, < 4.3.0',
           'shellescape >= 3.4.1, < 3.5',
-          'schema-salad >= 2.2.20170216125639, < 3',
+          'schema-salad >= 2.2.20170222151604, < 3',
           'typing >= 3.5.2, < 3.6'
       ],
       setup_requires=[] + pytest_runner,


### PR DESCRIPTION
Quote hashes in filenames except in special cases, in order to distinguish between hash used as fragment identifier and as part of filename.
