### PR TITLE
Showing usage message when no arguments are passed 

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -432,6 +432,7 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
         if toolparser:
             if args.tool_help:
                 toolparser.print_help()
+                print("this is print help")
                 return 0
             cmd_line = vars(toolparser.parse_args(args.job_order))
             for record_name in records:
@@ -630,7 +631,8 @@ def main(argsl=None,  # type: List[str]
                 setattr(args, "workflow", "CWLFile")
             else:
                 _logger.error("")
-                _logger.error("CWL document required, try --help for details")
+                _logger.error("CWL document required, No input file was passed\n")
+                arg_parser().print_help()
                 return 1
         if args.relax_path_checks:
             draft2tool.ACCEPTLIST_RE = draft2tool.ACCEPTLIST_EN_RELAXED_RE

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -432,7 +432,7 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
         if toolparser:
             if args.tool_help:
                 toolparser.print_help()
-                print("this is print help")
+                
                 return 0
             cmd_line = vars(toolparser.parse_args(args.job_order))
             for record_name in records:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -432,7 +432,6 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
         if toolparser:
             if args.tool_help:
                 toolparser.print_help()
-                
                 return 0
             cmd_line = vars(toolparser.parse_args(args.job_order))
             for record_name in records:
@@ -631,7 +630,7 @@ def main(argsl=None,  # type: List[str]
                 setattr(args, "workflow", "CWLFile")
             else:
                 _logger.error("")
-                _logger.error("CWL document required, No input file was passed\n")
+                _logger.error("CWL document required, no input file was provided")
                 arg_parser().print_help()
                 return 1
         if args.relax_path_checks:


### PR DESCRIPTION
When we run cwltool without any argument we get a "try -h" message. Instead of that directly show Usage message.