### PR TITLE
Setting job from stdin. Bug fix: dict -> CommentedMap

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -158,7 +158,11 @@ class CommandLineJob(object):
                 if not vol.staged:
                     continue
                 if vol.type in ("File", "Directory"):
-                    runtime.append(u"--volume=%s:%s:ro" % (vol.resolved, vol.target))
+                    if vol.resolved.startswith("_:"):
+                        createtmp_dir = os.path.join(self.stagedir, os.path.basename(vol.target))
+                        runtime.append(u"--volume=%s:%s:rw" % (createtmp_dir, vol.target))
+                    else:
+                        runtime.append(u"--volume=%s:%s:ro" % (vol.resolved, vol.target))
                 if vol.type == "CreateFile":
                     createtmp = os.path.join(self.stagedir, os.path.basename(vol.target))
                     with open(createtmp, "w") as f:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -414,7 +414,7 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
     if len(args.job_order) == 1 and args.job_order[0][0] != "-":
         job_order_file = args.job_order[0]
     elif len(args.job_order) == 1 and args.job_order[0] == "-":
-        job_order_object = yaml.round_trip_load(stdin)
+        job_order_object = yaml.load(stdin, yaml.RoundTripLoader)
         job_order_object, _ = loader.resolve_all(job_order_object, file_uri(os.getcwd()) + "/")
     else:
         job_order_file = None

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -423,7 +423,7 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
     if len(args.job_order) == 1 and args.job_order[0][0] != "-":
         job_order_file = args.job_order[0]
     elif len(args.job_order) == 1 and args.job_order[0] == "-":
-        job_order_object = yaml.load(stdin, yaml.RoundTripLoader)
+        job_order_object = yaml.round_trip_load(stdin) # type: ignore
         job_order_object, _ = loader.resolve_all(job_order_object, file_uri(os.getcwd()) + "/")
     else:
         job_order_file = None

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -414,8 +414,8 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
     if len(args.job_order) == 1 and args.job_order[0][0] != "-":
         job_order_file = args.job_order[0]
     elif len(args.job_order) == 1 and args.job_order[0] == "-":
-        job_order_object = yaml.load(stdin)
-        job_order_object, _ = loader.resolve_all(job_order_object, "")
+        job_order_object = yaml.load(stdin, yaml.RoundTripLoader)
+        job_order_object, _ = loader.resolve_all(job_order_object, 'file://%s' % os.path.abspath('.'))
     else:
         job_order_file = None
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -414,8 +414,8 @@ def load_job_order(args, t, stdin, print_input_deps=False, relative_deps=False,
     if len(args.job_order) == 1 and args.job_order[0][0] != "-":
         job_order_file = args.job_order[0]
     elif len(args.job_order) == 1 and args.job_order[0] == "-":
-        job_order_object = yaml.load(stdin, yaml.RoundTripLoader)
-        job_order_object, _ = loader.resolve_all(job_order_object, 'file://%s' % os.path.abspath('.'))
+        job_order_object = yaml.round_trip_load(stdin)
+        job_order_object, _ = loader.resolve_all(job_order_object, file_uri(os.getcwd()) + "/")
     else:
         job_order_file = None
 


### PR DESCRIPTION
When setting job from stdin `yaml.load` function is supposed to return `CommentedMap`, but returns `dict`. To return `CommentedMap` `RoundTripLoader` should be used.