### PR TITLE
generating nameroot when not provided explicitly from basename Issue#268

### DIFF
--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -75,6 +75,9 @@ def normalizeFilesDirs(job):
             parse = urllib.parse.urlparse(d["location"])
             d["basename"] = os.path.basename(urllib.request.url2pathname(parse.path))
 
+        if "nameroot" not in d:
+            d["nameroot"] = ('.').join(d["basename"].split('.')[:-1])  # for basenames like a.b.xyz
+
     adjustFileObjs(job, addLocation)
     adjustDirObjs(job, addLocation)
 


### PR DESCRIPTION
When a file is provided in input along with its path and nameroot is not provided, cwltool throws exception. In this PR we are generating nameroot if it is not provide explicitly using basename. Issue #268