### PR TITLE
Add option to avoid eliminating symbolic links

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -181,7 +181,8 @@ class CommandLineTool(Process):
 
     def makePathMapper(self, reffiles, stagedir, **kwargs):
         # type: (List[Any], Text, **Any) -> PathMapper
-        return PathMapper(reffiles, kwargs["basedir"], stagedir)
+        return PathMapper(reffiles, kwargs["basedir"], stagedir,
+                          eliminate_symlinks=kwargs.get("eliminate_symlinks", True))
 
     def job(self,
             job_order,  # type: Dict[Text, Text]


### PR DESCRIPTION
Currently the code resolves symbolic links back to the original file,
which can cause issues when files get symlinked with different
extensions. This makes it optional so we can avoid symlinking from Toil.

Specifically, I'm trying to fix the issue with CWL Toil where it copies
all files (BD2KGenomics/toil#1627). Switching to symlinks instead of
copying exposes the issue because files with standard extensions
(`should_work.bam`) are symlinked to internal Toil names
(`tmp12345.tmp`). Resolving the symlinks exposes the internal names to
the program, breaking any code that relies on standard file extensions.

I'm not sure about the origin or motivation for dereferencing (and also
not using os.path.realpath, which would have made it easier to find). It
looks like @tetron has been doing work with this for a while:

common-workflow-language@992e3b1#diff-014f1453ccc1711230a19f9e2893cfacR63