### PR TITLE
Add --print-supported-versions option that prints supported CWL versions

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -30,7 +30,7 @@ from .process import (shortname, Process, relocateOutputs, cleanIntermediate,
 from .resolver import tool_resolver, ga4gh_tool_registries
 from .stdfsaccess import StdFsAccess
 from .mutation import MutationManager
-from .update import ALLUPDATES
+from .update import UPDATES, ALLUPDATES
 
 _logger = logging.getLogger("cwltool")
 
@@ -579,9 +579,12 @@ def versionstring():
     else:
         return u"%s %s" % (sys.argv[0], "unknown version")
 
-def supportedCWLversions():
-    # type: () -> List[Text]
-    versions = ALLUPDATES.keys()
+def supportedCWLversions(enable_dev):
+    # type: (bool) -> List[Text]
+    if enable_dev:
+        versions = ALLUPDATES.keys()
+    else:
+        versions = UPDATES.keys()
     versions.sort()
     return versions
 
@@ -660,7 +663,7 @@ def main(argsl=None,  # type: List[str]
             _logger.info(versionfunc())
 
         if args.print_supported_versions:
-            print("\n".join(supportedCWLversions()))
+            print("\n".join(supportedCWLversions(args.enable_dev)))
             return 0
 
         if not args.workflow:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -30,6 +30,7 @@ from .process import (shortname, Process, relocateOutputs, cleanIntermediate,
 from .resolver import tool_resolver, ga4gh_tool_registries
 from .stdfsaccess import StdFsAccess
 from .mutation import MutationManager
+from .update import ALLUPDATES
 
 _logger = logging.getLogger("cwltool")
 
@@ -129,6 +130,7 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--pack", action="store_true", help="Combine components into single document and print.")
     exgroup.add_argument("--version", action="store_true", help="Print version and exit")
     exgroup.add_argument("--validate", action="store_true", help="Validate CWL document only.")
+    exgroup.add_argument("--print-supported-versions", action="store_true", help="Print supported CWL specs.")
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--strict", action="store_true",
@@ -577,6 +579,10 @@ def versionstring():
     else:
         return u"%s %s" % (sys.argv[0], "unknown version")
 
+def supportedCWLversions():
+    versions = ALLUPDATES.keys()
+    versions.sort()
+    return versions
 
 def main(argsl=None,  # type: List[str]
          args=None,  # type: argparse.Namespace
@@ -651,6 +657,10 @@ def main(argsl=None,  # type: List[str]
             return 0
         else:
             _logger.info(versionfunc())
+
+        if args.print_supported_versions:
+            print("\n".join(supportedCWLversions()))
+            return 0
 
         if not args.workflow:
             if os.path.isfile("CWLFile"):

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -580,6 +580,7 @@ def versionstring():
         return u"%s %s" % (sys.argv[0], "unknown version")
 
 def supportedCWLversions():
+    # type: () -> List[Text]
     versions = ALLUPDATES.keys()
     versions.sort()
     return versions


### PR DESCRIPTION
Currently the only way to check whether the certain version of CWL file is supported by `cwltool` is to run `cwltool` with CWL files and to check its output.

This request adds `--print-supported-versions` that prints supported CWL versions.
We can check the CWL versions supported by `cwltool` by using this option.

Here is the output of `--print-supported-versions` option:
```console
$ ./cwltool.py --print-supported-versions
./cwltool.py 1.0.20170516234254
draft-2
draft-3
draft-3.dev1
draft-3.dev2
draft-3.dev3
draft-3.dev4
draft-3.dev5
draft-4.dev1
draft-4.dev2
draft-4.dev3
v1.0
v1.0.dev4
v1.1.0-dev1
```