### PR TITLE
configuring build push for master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ install:
 script: tox
 notifications:
   email: false
+branches:
+  only:
+    - master


### PR DESCRIPTION
With this we can enable `build push` option and avoid double builds. Travis will build master branch on each merge. I tested this behavior on my local branch and output looks good. here https://travis-ci.org/kapilkd13/cwltool