### PR TITLE
fix tests when python3 is installed as default

### DIFF
--- a/tests/wf/echo.cwl
+++ b/tests/wf/echo.cwl
@@ -5,8 +5,9 @@ inputs:
   script:
     type: string
     default: |
+      from __future__ import print_function
       import sys
-      print sys.argv[1]
+      print(sys.argv[1])
       if sys.argv[1] == "2":
         exit(1)
       else:


### PR DESCRIPTION
When the system has installed the python 3 as the default interpreter some tests fail because of the workflow https://raw.githubusercontent.com/common-workflow-language/cwltool/1bdb36dbfce5f90dfd40878b00bb1a64261e15d7/tests/wf/echo.cwl assumes python 2 is used by default.

This happens when running `tox`, or when running `python setup.py install` under a python 2.7 virtual environment.

The test are very easy to fix: use python2 as the command, or making the code compatible with python 2 and 3. On the other hand changing the behaviour to open new processes under the same virtual environment might not.

For the time being I've fixed the tests under python 3.6 by adding a `__future__` import