### PR TITLE
enabling a test that was ignored due to similar name

### DIFF
--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -124,7 +124,7 @@ class TestInplaceUpdate(unittest.TestCase):
             shutil.rmtree(tmp)
             shutil.rmtree(out)
 
-    def test_updateval_inplace(self):
+    def test_updatedir_inplace(self):
         try:
             tmp = tempfile.mkdtemp()
             with open(os.path.join(tmp, "value"), "w") as f:


### PR DESCRIPTION
In tes_ext file two different tests had same names therefore one was getting ignored. Renamed the second one. see line 60 and line 127 here https://github.com/common-workflow-language/cwltool/blob/master/tests/test_ext.py