### PR TITLE
Fix Python 3 incompatibility in PYTHON_RUN_SCRIPT.

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -69,7 +69,7 @@ with open(sys.argv[1], "r") as f:
     if sp.stdin:
         sp.stdin.close()
     rcode = sp.wait()
-    if isinstance(stdin, file):
+    if stdin is not subprocess.PIPE:
         stdin.close()
     if stdout is not sys.stderr:
         stdout.close()


### PR DESCRIPTION
`file` is no longer a built-in with the new `io` framework. Was causing jobs to fail depending on the python in the conda env.