### PR TITLE
Tweak SoftwareRequirement handling for reuse in Toil.

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -42,7 +42,6 @@ class Builder(object):
         self.pathmapper = None  # type: PathMapper
         self.stagedir = None  # type: Text
         self.make_fs_access = None  # type: Type[StdFsAccess]
-        self.build_job_script = None  # type: Callable[[List[str]], Text]
         self.debug = False  # type: bool
         self.mutation_manager = None  # type: MutationManager
 
@@ -51,6 +50,15 @@ class Builder(object):
         self.loadListing = "deep_listing"  # type: Union[None, str]
 
         self.find_default_container = None  # type: Callable[[], Text]
+        self.job_script_provider = None  # type: Any
+
+    def build_job_script(self, commands):
+        # type: (List[str]) -> Text
+        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, List[str]], Text]
+        if build_job_script_method:
+            return build_job_script_method(self, commands)
+        else:
+            return None
 
     def bind_input(self, schema, datum, lead_pos=None, tail_pos=None):
         # type: (Dict[Text, Any], Any, Union[int, List[int]], List[int]) -> List[Dict[Text, Any]]

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -255,6 +255,9 @@ def single_job_executor(t,  # type: Process
     try:
         for r in jobiter:
             if r:
+                builder = kwargs.get("builder", None)  # type: Builder
+                if builder is not None:
+                    r.builder = builder
                 if r.outdir:
                     output_dirs.add(r.outdir)
                 r.run(**kwargs)

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -728,10 +728,10 @@ def main(argsl=None,  # type: List[str]
 
             make_tool_kwds = vars(args)
 
-            build_job_script = None  # type: Callable[[Any, List[str]], Text]
+            job_script_provider = None  # type: Callable[[Any, List[str]], Text]
             if conf_file or use_conda_dependencies:
                 dependencies_configuration = DependenciesConfiguration(args)  # type: DependenciesConfiguration
-                make_tool_kwds["build_job_script"] = dependencies_configuration.build_job_script
+                make_tool_kwds["job_script_provider"] = dependencies_configuration
 
             make_tool_kwds["find_default_container"] = functools.partial(find_default_container, args)
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -21,6 +21,7 @@ from schema_salad.ref_resolver import Fetcher, Loader, file_uri, uri_file_path
 from schema_salad.sourceline import strip_dup_lineno
 
 from . import draft2tool, workflow
+from .builder import Builder
 from .cwlrdf import printdot, printrdf
 from .errors import UnsupportedRequirement, WorkflowException
 from .load_tool import fetch_document, make_tool, validate_document, jobloaderctx

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -598,12 +598,7 @@ class Process(object):
 
         builder.resources = self.evalResources(builder, kwargs)
 
-        build_job_script = kwargs.get("build_job_script", None)  # type: Callable[[Builder, List[str]], Text]
-        curried_build_job_script = None  # type: Callable[[List[str]], Text]
-        if build_job_script:
-            curried_build_job_script = lambda commands: build_job_script(builder, commands)
-        builder.build_job_script = curried_build_job_script
-
+        builder.job_script_provider = kwargs.get("job_script_provider", None)
         return builder
 
     def evalResources(self, builder, kwargs):

--- a/tests/test_deps_env/random-lines/1.0/env.sh
+++ b/tests/test_deps_env/random-lines/1.0/env.sh
@@ -4,5 +4,5 @@
 # This shouldn't need to use bash-isms - but we don't know the full path to this file,
 # so for testing it is setup this way. For actual deployments just using full paths
 # directly would be preferable.
-PACKAGE_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/tests/test_deps_env/random-lines/1.0/"
+PACKAGE_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/"
 export PATH=$PATH:$PACKAGE_DIRECTORY/scripts


### PR DESCRIPTION
With these changes I can get the requirement handling from #214 to work properly in simple toil tests (after a couple tweaks to toil itself). ~~I'll mark this as WIP until #214 is merged - though comments on the last few commits are more than welcome.~~

There are three commits here:
 - aa1b7c996040026101e095526a06b088f88c0c36 - the main refactor which seems uniformly positive.
 - 5069580853d6f2287a590a4d9b87d8793ebb0470 - which fixes a bug introduced at the last second in #214.
 - 33d1e96b90054c94ba2d3f93fda9a6f6e4d2190a - contains a small tweak which might not be so great. It restores the ``builder`` parameter in ``single_job_executor`` on jobs before executing if it is supplied to the method. I'm guessing I'm somehow depending on ``builder`` later in the job lifecycle than the previous code paths did and I'm not sure if this is a bad thing?
