### PR TITLE
Polish help and error messages related to optional dependency on galaxy-lib.

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -33,7 +33,7 @@ from .process import (Process, cleanIntermediate, normalizeFilesDirs,
                       relocateOutputs, scandeps, shortname, use_custom_schema,
                       use_standard_schema)
 from .resolver import ga4gh_tool_registries, tool_resolver
-from .software_requirements import DependenciesConfiguration, get_container_from_software_requirements
+from .software_requirements import DependenciesConfiguration, get_container_from_software_requirements, SOFTWARE_REQUIREMENTS_ENABLED
 from .stdfsaccess import StdFsAccess
 from .update import ALLUPDATES, UPDATES
 
@@ -153,14 +153,21 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--quiet", action="store_true", help="Only print warnings and errors.")
     exgroup.add_argument("--debug", action="store_true", help="Print even more logging")
 
-    # help="Dependency resolver configuration file describing how to adapt 'SoftwareRequirement' packages to current system."
-    parser.add_argument("--beta-dependency-resolvers-configuration", default=None, help=argparse.SUPPRESS)
-    # help="Defaut root directory used by dependency resolvers configuration."
-    parser.add_argument("--beta-dependencies-directory", default=None, help=argparse.SUPPRESS)
-    # help="Use biocontainers for tools without an explicitly annotated Docker container."
-    parser.add_argument("--beta-use-biocontainers", default=None, help=argparse.SUPPRESS, action="store_true")
-    # help="Short cut to use Conda to resolve 'SoftwareRequirement' packages."
-    parser.add_argument("--beta-conda-dependencies", default=None, help=argparse.SUPPRESS, action="store_true")
+    dependency_resolvers_configuration_help = argparse.SUPPRESS
+    dependencies_directory_help = argparse.SUPPRESS
+    use_biocontainers_help = argparse.SUPPRESS
+    conda_dependencies = argparse.SUPPRESS
+
+    if SOFTWARE_REQUIREMENTS_ENABLED:
+        dependency_resolvers_configuration_help = "Dependency resolver configuration file describing how to adapt 'SoftwareRequirement' packages to current system."
+        dependencies_directory_help = "Defaut root directory used by dependency resolvers configuration."
+        use_biocontainers_help = "Use biocontainers for tools without an explicitly annotated Docker container."
+        conda_dependencies = "Short cut to use Conda to resolve 'SoftwareRequirement' packages."
+
+    parser.add_argument("--beta-dependency-resolvers-configuration", default=None, help=dependency_resolvers_configuration_help)
+    parser.add_argument("--beta-dependencies-directory", default=None, help=dependencies_directory_help)
+    parser.add_argument("--beta-use-biocontainers", default=None, help=use_biocontainers_help, action="store_true")
+    parser.add_argument("--beta-conda-dependencies", default=None, help=conda_dependencies, action="store_true")
 
     parser.add_argument("--tool-help", action="store_true", help="Print command line help for tool")
 


### PR DESCRIPTION
Previously the new options would always be suppressed in `cwltool --help`, now they will show up only if galaxy-lib is available.

I've also unified and improved the wording around the exceptions that get raised when these options are used but galaxy-lib is unavailable.

```
cwltool --beta-conda-dependencies tests/seqtk_seq.cwl tests/seqtk_seq_job.json
/Users/john/workspace/cwltool/.venv/bin/cwltool 1.0.20170708080313
Resolved 'tests/seqtk_seq.cwl' to 'file:///Users/john/workspace/cwltool/tests/seqtk_seq.cwl'
[job seqtk_seq.cwl] /private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmpr1IeGr$ seqtk \
    seq \
    -a \
    /private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmp9MWLCz/stg52d703ba-c684-46f0-ade9-2ae574004bea/2.fastq > /private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmpr1IeGr/out
Exception while running job
Traceback (most recent call last):
  File "build/bdist.macosx-10.12-x86_64/egg/cwltool/job.py", line 197, in _execute
    job_script_contents = builder.build_job_script(commands)
  File "build/bdist.macosx-10.12-x86_64/egg/cwltool/builder.py", line 59, in build_job_script
    return build_job_script_method(self, commands)
  File "build/bdist.macosx-10.12-x86_64/egg/cwltool/software_requirements.py", line 64, in build_job_script
    ensure_galaxy_lib_available()
  File "build/bdist.macosx-10.12-x86_64/egg/cwltool/software_requirements.py", line 121, in ensure_galaxy_lib_available
    raise Exception("Optional Python library galaxy-lib not available, it is required for this configuration.")
Exception: Optional Python library galaxy-lib not available, it is required for this configuration.
[job seqtk_seq.cwl] completed permanentFail
{}
Final process status is permanentFail
```