### PR TITLE
cwltool/stdfsaccess.py: use io.open instead of builtin open

### DIFF
--- a/cwltool/stdfsaccess.py
+++ b/cwltool/stdfsaccess.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import glob
 import os
+from io import open
 from typing import BinaryIO, List, Union, Text, IO, overload
 
 from .utils import onWindows


### PR DESCRIPTION
Minor addition to https://github.com/common-workflow-language/cwltool/pull/464/commits/69d41788b917e8c95d88f1bd562c1443cc9e7eee