### PR TITLE
setup.py: remove condition which blocks python 3 install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,6 @@ from setuptools import setup
 SETUP_DIR = os.path.dirname(__file__)
 README = os.path.join(SETUP_DIR, 'README.rst')
 
-# if python3 runtime and `setup.py install` is called
-if sys.version_info.major == 3 and sys.argv[1] == 'install':
-    print("Aborting installation. CWL Tool doesn't support Python 3 currently.")
-    print("Install using Python 2 pip.")
-    exit(1)
-
 try:
     import gittaggers
 


### PR DESCRIPTION
the installation will not be blocked when running ``python setup.py install`` under Python 3 runtime.