### PR TITLE
changing default container for windows from ubuntu to alpine-bash

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -699,7 +699,8 @@ def main(argsl=None,  # type: List[str]
 
         # If On windows platform, A default Docker Container is Used if not explicitely provided by user
         if onWindows() and not args.default_container:
-            args.default_container = "ubuntu"
+            # This docker image is a minimal alpine image with bash installed(size 6 mb). source: https://github.com/frol/docker-alpine-bash
+            args.default_container = "frolvlad/alpine-bash"
 
         # If caller provided custom arguments, it may be not every expected
         # option is set, so fill in no-op defaults to avoid crashing when


### PR DESCRIPTION
Changing default Docker container on windows from ubuntu to Alpine-bash. It would reduce size of container.