### PR TITLE
sandboxjs.py: fix checking condition for node:slim

### DIFF
--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -42,7 +42,7 @@ def check_js_threshold_version(working_alias):
     """
     # parse nodejs version into int Tuple: 'v4.2.6\n' -> [4, 2, 6]
     current_version_str = subprocess.check_output(
-        [working_alias, "-v"]).decode('ascii')
+        [working_alias, "-v"]).decode('utf-8')
 
     current_version = [int(v) for v in current_version_str.strip().strip('v').split('.')]
     minimum_node_version = [int(v) for v in minimum_node_version_str.split('.')]
@@ -64,7 +64,7 @@ def new_js_proc():
     trynodes = ("nodejs", "node")
     for n in trynodes:
         try:
-            if subprocess.check_output([n, "--eval", "process.stdout.write('t')"]) != "t":
+            if subprocess.check_output([n, "--eval", "process.stdout.write('t')"]).decode('utf-8') != "t":
                 continue
             else:
                 nodejs = subprocess.Popen([n, "--eval", nodecode],
@@ -87,9 +87,11 @@ def new_js_proc():
             nodeimg = "node:slim"
             global have_node_slim
             if not have_node_slim:
-                dockerimgs = subprocess.check_output(["docker", "images", nodeimg]).decode('utf-8')
+                dockerimgs = subprocess.check_output(["docker", "images", "-q", nodeimg]).decode('utf-8')
+                # if output is an empty string
                 if len(dockerimgs.split("\n")) <= 1:
-                    nodejsimg = subprocess.check_output(["docker", "pull", nodeimg])
+                    # pull node:slim docker container
+                    nodejsimg = subprocess.check_output(["docker", "pull", nodeimg]).decode('utf-8')
                     _logger.info("Pulled Docker image %s %s", nodeimg, nodejsimg)
                 have_node_slim = True
             nodejs = subprocess.Popen(["docker", "run",
@@ -134,7 +136,8 @@ def execjs(js, jslib, timeout=None, debug=False):  # type: (Union[Mapping, Text]
 
     killed = []
 
-    def term():
+    """ Kill the node process if it exceeds timeout limit"""
+    def terminate():
         try:
             killed.append(True)
             nodejs.kill()
@@ -144,7 +147,7 @@ def execjs(js, jslib, timeout=None, debug=False):  # type: (Union[Mapping, Text]
     if timeout is None:
         timeout = 20
 
-    tm = threading.Timer(timeout, term)
+    tm = threading.Timer(timeout, terminate)
     tm.start()
 
     stdin_buf = BytesIO((json.dumps(fn) + "\n").encode('utf-8'))
@@ -154,7 +157,8 @@ def execjs(js, jslib, timeout=None, debug=False):  # type: (Union[Mapping, Text]
     rselect = [nodejs.stdout, nodejs.stderr]  # type: List[BytesIO]
     wselect = [nodejs.stdin]  # type: List[BytesIO]
 
-    # On windows system standard input/output are not handled properly by select  module(modules like  pywin32, msvcrt, gevent don't work either)
+    # On windows system standard input/output are not handled properly by select module
+    # (modules like  pywin32, msvcrt, gevent don't work either)
     if sys.platform=='win32':
         READ_BYTES_SIZE = 512
 


### PR DESCRIPTION
- decode subprocess.check_output calls to convert bytes to code
- rename term function to terminate for more clarity
- add some doc strings


Closes https://github.com/common-workflow-language/cwltool/issues/378