### PR TITLE
removing python 3 status from windows documentation

### DIFF
--- a/windowsdoc.md
+++ b/windowsdoc.md
@@ -21,7 +21,7 @@ You can install cwltool using pip or directly from source code.
 
 Before installing cwltool, please install:
 
-* [Python 2 or 3](https://www.python.org/downloads/windows/)
+* [Python 2](https://www.python.org/downloads/windows/)
 * [Docker](https://docs.docker.com/docker-for-windows/install/)
 * [Node.js](https://nodejs.org/en/download/) (optional, please install if your
   workflows or tools contain [Javascript Expressions](http://www.commonwl.org/v1.0/CommandLineTool.html#InlineJavascriptRequirement))


### PR DESCRIPTION
references #499 
with python 3 on windows we use `past` module to use python 2 implementation of  `avro`. This module has reference to `/tmp/..` hardcoded in it.  Thus it need `/tmp` folder in the windows current Drive's root. So I think its best to hold python 3 support from windows docs for now. 