### PR TITLE
Appveyor py3 fix: Earlier py3 was falling back to py2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,16 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python33_64"
-      PYTHON_VERSION: "3.3"
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34_64"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,6 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "pip install --disable-pip-version-check --user --upgrade pip"
-  - "pip install --upgrade --no-deps --force-reinstall git+git://github.com/kapilkd13/schema_salad@windows#egg=schema_salad-2.4.201706261942"
 
 build_script:
   - "%CMD_IN_ENV% python setup.py install"


### PR DESCRIPTION
Due to some bad configuration, unit testing for python 3 was falling back to python 2. This disclosed few issues we need to resolve before achieving python 3 compatibility on windows. 