### PR TITLE
Python 3 support on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: .{build}-{branch}
 
 environment:
+  SYSTEMROOT: "C:\\WINDOWS"
 
   matrix:
     - PYTHON: "C:\\Python27"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,16 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python33_64"
-      PYTHON_VERSION: "3.3"
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34_64"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
 build_script:
-  - "%CMD_IN_ENV% python setup.py install"
+  - "%CMD_IN_ENV% pip install ."
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,6 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "pip install --disable-pip-version-check --user --upgrade pip"
-  - "pip install --upgrade --no-deps --force-reinstall git+git://github.com/kapilkd13/schema_salad@windows#egg=schema_salad-2.4.201706261942"
 
 build_script:
   - "%CMD_IN_ENV% python setup.py install"

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -62,8 +62,8 @@ class Builder(object):
         self.job_script_provider = None  # type: Any
 
     def build_job_script(self, commands):
-        # type: (List[bytes]) -> Text
-        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, List[bytes]], Text]
+        # type: (List[str]) -> Text
+        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, List[str]], Text]
         if build_job_script_method:
             return build_job_script_method(self, commands)
         else:

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -62,8 +62,8 @@ class Builder(object):
         self.job_script_provider = None  # type: Any
 
     def build_job_script(self, commands):
-        # type: (Union[List[str],List[unicode]]) -> Text
-        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, Union[List[str],List[unicode]]], Text]
+        # type: (List[Text]) -> Text
+        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, Union[List[str],List[Text]]], Text]
         if build_job_script_method:
             return build_job_script_method(self, commands)
         else:

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -62,8 +62,8 @@ class Builder(object):
         self.job_script_provider = None  # type: Any
 
     def build_job_script(self, commands):
-        # type: (Union[List[str],List[bytes]]) -> Text
-        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, List[str]], Text]
+        # type: (Union[List[str],List[unicode]]) -> Text
+        build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, Union[List[str],List[unicode]]], Text]
         if build_job_script_method:
             return build_job_script_method(self, commands)
         else:

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -62,7 +62,7 @@ class Builder(object):
         self.job_script_provider = None  # type: Any
 
     def build_job_script(self, commands):
-        # type: (List[str]) -> Text
+        # type: (Union[List[str],List[bytes]]) -> Text
         build_job_script_method = getattr(self.job_script_provider, "build_job_script", None)  # type: Callable[[Builder, List[str]], Text]
         if build_job_script_method:
             return build_job_script_method(self, commands)

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -424,7 +424,7 @@ class DockerCommandLineJob(JobBase):
 
 
 def _job_popen(
-        commands,  # type: List[bytes]
+        commands,  # type: List[str]
         stdin_path,  # type: Text
         stdout_path,  # type: Text
         stderr_path,  # type: Text

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -207,7 +207,7 @@ class JobBase(object):
                     os.makedirs(dn)
                 stdout_path = absout
 
-            commands = [Text(x).encode('utf-8') for x in runtime + self.command_line]
+            commands = [Text(x) for x in (runtime + self.command_line)]
             job_script_contents = None  # type: Text
             builder = getattr(self, "builder", None)  # type: Builder
             if builder is not None:

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -297,6 +297,8 @@ class CommandLineJob(JobBase):
         env["TMPDIR"] = str(self.tmpdir) if onWindows() else self.tmpdir
         if "PATH" not in env:
             env["PATH"] = str(os.environ["PATH"]) if onWindows() else os.environ["PATH"]
+        if "SYSTEMROOT" not in env and "SYSTEMROOT" in os.environ:
+            env["SYSTEMROOT"] = str(os.environ["SYSTEMROOT"]) if onWindows() else os.environ["SYSTEMROOT"]
 
         stageFiles(self.pathmapper, ignoreWritable=True, symLink=True)
         if self.generatemapper:

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -424,7 +424,7 @@ class DockerCommandLineJob(JobBase):
 
 
 def _job_popen(
-        commands,  # type: Union[List[str],List[unicode]]
+        commands,  # type: List[Text]
         stdin_path,  # type: Text
         stdout_path,  # type: Text
         stderr_path,  # type: Text

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -424,7 +424,7 @@ class DockerCommandLineJob(JobBase):
 
 
 def _job_popen(
-        commands,  # type: Union[List[str],List[bytes]]
+        commands,  # type: Union[List[str],List[unicode]]
         stdin_path,  # type: Text
         stdout_path,  # type: Text
         stderr_path,  # type: Text

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -424,7 +424,7 @@ class DockerCommandLineJob(JobBase):
 
 
 def _job_popen(
-        commands,  # type: List[str]
+        commands,  # type: Union[List[str],List[bytes]]
         stdin_path,  # type: Text
         stdout_path,  # type: Text
         stderr_path,  # type: Text

--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -57,7 +57,8 @@ def new_js_proc(force_docker_pull=False):
     # type: (bool) -> subprocess.Popen
 
     res = resource_stream(__name__, 'cwlNodeEngine.js')
-    nodecode = res.read()
+    nodecode = res.read().decode('utf-8')
+
     required_node_version, docker = (False,)*2
     nodejs = None
     trynodes = ("nodejs", "node")
@@ -238,7 +239,7 @@ def execjs(js, jslib, timeout=None, force_docker_pull=False, debug=False):  # ty
                         no_more_error.release()
                         output_thread.join()
                         error_thread.join()
-                if stdout_buf.getvalue().endswith("\n"):
+                if stdout_buf.getvalue().endswith("\n".encode()):
                     rselect = []
                     no_more_output.release()
                     no_more_error.release()


### PR DESCRIPTION
Due to byte encoding of commands passed to `subprocess.Popen()`, a `TypeError: 'str' does not support the buffer interface` occured in python 3 on windows.
As per Docs:
>args should be a string, or a sequence of program arguments. The program to execute is normally the first item in the args sequence or the string if a string is given, but can be explicitly set by using the executable argument.
 