### PR TITLE
cwltool/cwlrdf.py: Pass str rather than bytes to write function (Python 3 fix)

### DIFF
--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -22,7 +22,7 @@ def gather(tool, ctx):  # type: (Process, ContextType) -> Graph
 
 def printrdf(wf, ctx, sr, stdout):
     # type: (Process, ContextType, Text, IO[Any]) -> None
-    stdout.write(gather(wf, ctx).serialize(format=sr))
+    stdout.write(gather(wf, ctx).serialize(format=sr).decode('utf-8'))
 
 
 def lastpart(uri):  # type: (Any) -> Text

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -20,9 +20,9 @@ def gather(tool, ctx):  # type: (Process, ContextType) -> Graph
     return g
 
 
-def printrdf(wf, ctx, sr, stdout):
-    # type: (Process, ContextType, Text, IO[Any]) -> None
-    stdout.write(gather(wf, ctx).serialize(format=sr).decode('utf-8'))
+def printrdf(wf, ctx, sr):
+    # type: (Process, ContextType, Text) -> Text
+    return gather(wf, ctx).serialize(format=sr).decode('utf-8')
 
 
 def lastpart(uri):  # type: (Any) -> Text

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -839,7 +839,7 @@ def main(argsl=None,  # type: List[str]
                 return 0
 
             if args.print_rdf:
-                printrdf(tool, document_loader.ctx, args.rdf_serializer, stdout)
+                stdout.write(printrdf(tool, document_loader.ctx, args.rdf_serializer))
                 return 0
 
             if args.print_dot:

--- a/tests/test_rdfprint.py
+++ b/tests/test_rdfprint.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+import unittest
+
+from six import StringIO
+from cwltool.main import main
+
+class RDF_Print(unittest.TestCase):
+
+    def test_rdf_print(self):
+        self.maxDiff = None
+
+        expected_output = """@prefix CommandLineBinding: <https://w3id.org/cwl/cwl#CommandLineBinding/> .
+@prefix CommandLineTool: <https://w3id.org/cwl/cwl#CommandLineTool/> .
+@prefix CommandOutputBinding: <https://w3id.org/cwl/cwl#CommandOutputBinding/> .
+@prefix Dirent: <https://w3id.org/cwl/cwl#Dirent/> .
+@prefix DockerRequirement: <https://w3id.org/cwl/cwl#DockerRequirement/> .
+@prefix EnvVarRequirement: <https://w3id.org/cwl/cwl#EnvVarRequirement/> .
+@prefix EnvironmentDef: <https://w3id.org/cwl/cwl#EnvironmentDef/> .
+@prefix ExpressionTool: <https://w3id.org/cwl/cwl#ExpressionTool/> .
+@prefix File: <https://w3id.org/cwl/cwl#File/> .
+@prefix InlineJavascriptRequirement: <https://w3id.org/cwl/cwl#InlineJavascriptRequirement/> .
+@prefix LinkMergeMethod: <https://w3id.org/cwl/cwl#LinkMergeMethod/> .
+@prefix Parameter: <https://w3id.org/cwl/cwl#Parameter/> .
+@prefix ResourceRequirement: <https://w3id.org/cwl/cwl#ResourceRequirement/> .
+@prefix ScatterMethod: <https://w3id.org/cwl/cwl#ScatterMethod/> .
+@prefix SchemaDefRequirement: <https://w3id.org/cwl/cwl#SchemaDefRequirement/> .
+@prefix SoftwarePackage: <https://w3id.org/cwl/cwl#SoftwarePackage/> .
+@prefix SoftwareRequirement: <https://w3id.org/cwl/cwl#SoftwareRequirement/> .
+@prefix Workflow: <https://w3id.org/cwl/cwl#Workflow/> .
+@prefix cwl: <https://w3id.org/cwl/cwl#> .
+@prefix ns1: <rdfs:> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sld: <https://w3id.org/cwl/salad#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl> a cwl:Workflow ;
+    Workflow:steps <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#step0> ;
+    cwl:cwlVersion cwl:v1.0 ;
+    cwl:outputs <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#response> ;
+    ns1:comment "Outputs a message using echo" ;
+    ns1:label "Hello World" .
+
+<https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#response> cwl:outputSource <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#step0/response> ;
+    sld:type cwl:File .
+"""
+
+        argsl = ['--print-rdf', 'https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl']
+
+        # capture stdout
+        out = StringIO()
+        main(argsl=argsl, stdout=out)
+        # check substring in the actual print-rdf
+        self.assertTrue(expected_output in out.getvalue(), True)

--- a/tests/test_rdfprint.py
+++ b/tests/test_rdfprint.py
@@ -4,52 +4,9 @@ import unittest
 from six import StringIO
 from cwltool.main import main
 
+from .util import get_data
+
 class RDF_Print(unittest.TestCase):
 
     def test_rdf_print(self):
-        self.maxDiff = None
-
-        expected_output = """@prefix CommandLineBinding: <https://w3id.org/cwl/cwl#CommandLineBinding/> .
-@prefix CommandLineTool: <https://w3id.org/cwl/cwl#CommandLineTool/> .
-@prefix CommandOutputBinding: <https://w3id.org/cwl/cwl#CommandOutputBinding/> .
-@prefix Dirent: <https://w3id.org/cwl/cwl#Dirent/> .
-@prefix DockerRequirement: <https://w3id.org/cwl/cwl#DockerRequirement/> .
-@prefix EnvVarRequirement: <https://w3id.org/cwl/cwl#EnvVarRequirement/> .
-@prefix EnvironmentDef: <https://w3id.org/cwl/cwl#EnvironmentDef/> .
-@prefix ExpressionTool: <https://w3id.org/cwl/cwl#ExpressionTool/> .
-@prefix File: <https://w3id.org/cwl/cwl#File/> .
-@prefix InlineJavascriptRequirement: <https://w3id.org/cwl/cwl#InlineJavascriptRequirement/> .
-@prefix LinkMergeMethod: <https://w3id.org/cwl/cwl#LinkMergeMethod/> .
-@prefix Parameter: <https://w3id.org/cwl/cwl#Parameter/> .
-@prefix ResourceRequirement: <https://w3id.org/cwl/cwl#ResourceRequirement/> .
-@prefix ScatterMethod: <https://w3id.org/cwl/cwl#ScatterMethod/> .
-@prefix SchemaDefRequirement: <https://w3id.org/cwl/cwl#SchemaDefRequirement/> .
-@prefix SoftwarePackage: <https://w3id.org/cwl/cwl#SoftwarePackage/> .
-@prefix SoftwareRequirement: <https://w3id.org/cwl/cwl#SoftwareRequirement/> .
-@prefix Workflow: <https://w3id.org/cwl/cwl#Workflow/> .
-@prefix cwl: <https://w3id.org/cwl/cwl#> .
-@prefix ns1: <rdfs:> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sld: <https://w3id.org/cwl/salad#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-<https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl> a cwl:Workflow ;
-    Workflow:steps <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#step0> ;
-    cwl:cwlVersion cwl:v1.0 ;
-    cwl:outputs <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#response> ;
-    ns1:comment "Outputs a message using echo" ;
-    ns1:label "Hello World" .
-
-<https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#response> cwl:outputSource <https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl#step0/response> ;
-    sld:type cwl:File .
-"""
-
-        argsl = ['--print-rdf', 'https://raw.githubusercontent.com/common-workflow-language/workflows/master/workflows/hello/hello.cwl']
-
-        # capture stdout
-        out = StringIO()
-        main(argsl=argsl, stdout=out)
-        # check substring in the actual print-rdf
-        self.assertTrue(expected_output in out.getvalue(), True)
+        self.assertEquals(main(['--print-rdf', get_data('tests/wf/hello_single_tool.cwl')]), 0)


### PR DESCRIPTION
Fixes ``--print-rdf`` flag under ``Python 3``. ``Python 2.7`` behaviour is unchanged


Before the changes, we got the following error: 
``` pytb
/home/manu/github/cwltool/venv3/bin/cwltool 1.0.20170801042110
I'm sorry, I couldn't load this CWL file.  The error was:
Traceback (most recent call last):
  File "/home/manu/github/cwltool/cwltool/main.py", line 840, in main
    printrdf(tool, document_loader.ctx, args.rdf_serializer, stdout)
  File "/home/manu/github/cwltool/cwltool/cwlrdf.py", line 25, in printrdf
    stdout.write(gather(wf, ctx).serialize(format=sr))
TypeError: write() argument must be str, not bytes
```