### PR TITLE
changing requests min version to 2.12.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=1.0
+requests>=2.12.4
 ruamel.yaml>=0.12.4,<0.15
 rdflib==4.2.2
 rdflib-jsonld==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='cwltool',
       include_package_data=True,
       install_requires=[
           'setuptools',
-          'requests >= 1.0',
+          'requests >= 2.12.4',
           'ruamel.yaml >= 0.12.4, < 0.15',
           'rdflib >= 4.2.2, < 4.3.0',
           'shellescape >= 3.4.1, < 3.5',


### PR DESCRIPTION
As suggested by Peter, we are moving to `2.12.4` as the min version for requests module

Closes: https://github.com/common-workflow-language/cwltool/issues/250
