### PR TITLE
Removing unnecessary warning due to generation field

### DIFF
--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -537,8 +537,6 @@ class CommandLineTool(Process):
                 visit_class(ret, ("File", "Directory"), cast(Callable[[Any], Any], revmap))
                 visit_class(ret, ("File", "Directory"), remove_path)
                 normalizeFilesDirs(ret)
-                if builder.mutation_manager:
-                    adjustFileObjs(ret, builder.mutation_manager.set_generation)
                 visit_class(ret, ("File", "Directory"), partial(check_valid_locations, fs_access))
 
                 if compute_checksum:
@@ -546,6 +544,8 @@ class CommandLineTool(Process):
 
             validate.validate_ex(self.names.get_name("outputs_record_schema", ""), ret,
                                  strict=False, logger=_logger_validation_warnings)
+            if ret is not None and builder.mutation_manager is not None:
+                adjustFileObjs(ret, builder.mutation_manager.set_generation)
             return ret if ret is not None else {}
         except validate.ValidationException as e:
             raise WorkflowException("Error validating output record. " + Text(e) + "\n in " + json.dumps(ret, indent=4))

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -915,6 +915,9 @@ def main(argsl=None,  # type: List[str]
 
                 visit_class(out, ("File", "Directory"), locToPath)
 
+                # Unsetting the Generation fron final output object
+                visit_class(out,("File",), MutationManager().unset_generation)
+
                 if isinstance(out, six.string_types):
                     stdout.write(out)
                 else:

--- a/cwltool/mutation.py
+++ b/cwltool/mutation.py
@@ -67,3 +67,7 @@ class MutationManager(object):
         loc = obj["location"]
         current = self.generations.get(loc, MutationState(0,[], ""))
         obj[_generation] = current.generation
+
+    def unset_generation(self, obj):
+        # type: (Dict) -> None
+        obj.pop(_generation, None)


### PR DESCRIPTION
setting generation field after schema validation and removing this generation field from the final output.

closes #382 