### PR TITLE
remove dir before copytree, use copy2 to keep metadata

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -279,7 +279,7 @@ def relocateOutputs(outputObj, outdir, output_dirs, action, fs_access):
         if src != dst:
             _logger.debug("Copying %s to %s", src, dst)
             if os.path.isdir(src):
-                if os.path.exists(dst):
+                if os.path.isdir(dst):
                     shutil.rmtree(dst)
                 shutil.copytree(src, dst)
             else:

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -281,6 +281,8 @@ def relocateOutputs(outputObj, outdir, output_dirs, action, fs_access):
             if os.path.isdir(src):
                 if os.path.isdir(dst):
                     shutil.rmtree(dst)
+                elif os.path.isfile(dst):
+                    os.unlink(dst)
                 shutil.copytree(src, dst)
             else:
                 shutil.copy2(src, dst)

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -279,9 +279,11 @@ def relocateOutputs(outputObj, outdir, output_dirs, action, fs_access):
         if src != dst:
             _logger.debug("Copying %s to %s", src, dst)
             if os.path.isdir(src):
+                if os.path.exists(dst):
+                    shutil.rmtree(dst)
                 shutil.copytree(src, dst)
             else:
-                shutil.copy(src, dst)
+                shutil.copy2(src, dst)
 
     outfiles = []  # type: List[Dict[Text, Any]]
     collectFilesAndDirs(outputObj, outfiles)


### PR DESCRIPTION
Relates to https://github.com/common-workflow-language/cwltool/issues/544

This PR adds:
 * remove an existing directory before copying to avoid errors
 * replace copy with copy2 for files when copying in order to preserve metadata. copytree uses copy2. This way all metadata is consistent for files and dirs.