### PR TITLE
Fixes to --pack behavior:

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -790,7 +790,8 @@ def main(argsl=None,  # type: List[str]
                      'enable_ga4gh_tool_registry': False,
                      'ga4gh_tool_registries': [],
                      'find_default_container': None,
-                     'make_template': False
+                                   'make_template': False,
+                                   'overrides': None
         }):
             if not hasattr(args, k):
                 setattr(args, k, v)
@@ -869,10 +870,6 @@ def main(argsl=None,  # type: List[str]
                                     skip_schemas=args.skip_schemas,
                                     overrides=overrides)
 
-            if args.pack:
-                stdout.write(print_pack(document_loader, processobj, uri, metadata))
-                return 0
-
             if args.print_pre:
                 stdout.write(json.dumps(processobj, indent=4))
                 return 0
@@ -901,6 +898,10 @@ def main(argsl=None,  # type: List[str]
                 return 0
 
             if args.validate:
+                return 0
+
+            if args.pack:
+                stdout.write(print_pack(document_loader, processobj, uri, metadata))
                 return 0
 
             if args.print_rdf:

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -101,14 +101,14 @@ def pack(document_loader, processobj, uri, metadata):
     document_loader = SubLoader(document_loader)
     document_loader.idx = {}
     if isinstance(processobj, dict):
-        document_loader.idx[processobj["id"]] = processobj
+        document_loader.idx[processobj["id"]] = CommentedMap(six.iteritems(processobj))
     elif isinstance(processobj, list):
         path, frag = urllib.parse.urldefrag(uri)
         for po in processobj:
             if not frag:
                 if po["id"].endswith("#main"):
                     uri = po["id"]
-            document_loader.idx[po["id"]] = po
+            document_loader.idx[po["id"]] = CommentedMap(six.iteritems(po.iteritems))
 
     def loadref(b, u):
         # type: (Text, Text) -> Union[Dict, List, Text]

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -127,7 +127,7 @@ def pack(document_loader, processobj, uri, metadata):
     mainpath, _ = urllib.parse.urldefrag(uri)
 
     def rewrite_id(r, mainuri):
-        # type: (Text, Text, bool) -> None
+        # type: (Text, Text) -> None
         if r == mainuri:
             rewrite[r] = "#main"
         elif r.startswith(mainuri) and r[len(mainuri)] in ("#", "/"):

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -108,7 +108,7 @@ def pack(document_loader, processobj, uri, metadata):
             if not frag:
                 if po["id"].endswith("#main"):
                     uri = po["id"]
-            document_loader.idx[po["id"]] = CommentedMap(six.iteritems(po.iteritems))
+            document_loader.idx[po["id"]] = CommentedMap(six.iteritems(po))
 
     def loadref(b, u):
         # type: (Text, Text) -> Union[Dict, List, Text]

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -3,7 +3,7 @@ import copy
 import re
 from typing import Any, Callable, Dict, List, Set, Text, Union, cast
 
-from schema_salad.ref_resolver import Loader
+from schema_salad.ref_resolver import Loader, SubLoader
 from six.moves import urllib
 from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
@@ -91,12 +91,16 @@ def import_embed(d, seen):
                     seen.add(this)
                     break
 
-        for v in d.values():
-            import_embed(v, seen)
+        for k in sorted(d.keys()):
+            import_embed(d[k], seen)
 
 
 def pack(document_loader, processobj, uri, metadata):
     # type: (Loader, Union[Dict[Text, Any], List[Dict[Text, Any]]], Text, Dict[Text, Text]) -> Dict[Text, Any]
+
+    document_loader = SubLoader(document_loader)
+    document_loader.idx = {}
+
     def loadref(b, u):
         # type: (Text, Text) -> Union[Dict, List, Text]
         return document_loader.resolve_ref(u, base_url=b)[0]


### PR DESCRIPTION
* Create a subloader with an empty index.  Ensures that all cross
  references (especially $imports) will be discovered and resolved for packing.

* Move pack to happen after tool loading (ensures everything has passed
  validation before packing)