### PR TITLE
Fix typo in dependency-resolvers-conf.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,7 @@ the correct module environment before executing the above tool would simply be:
 
 .. code:: yaml
 
-  - type: module
+  - type: modules
 
 The outer list indicates that one plugin is being enabled, the plugin parameters are
 defined as a dictionary for this one list item. There is only one required parameter


### PR DESCRIPTION
Hi, I noticed that the example given to use module thanks to the dependency resolver did not work. It was raising a `KeyError: 'module'` so I fixed that in the `dependency-resolvers-conf.yml`. Thanks !