### PR TITLE
Short circuit google storage schemas during validation.

### DIFF
--- a/cwltool/schemas/v1.0/salad/schema_salad/ref_resolver.py
+++ b/cwltool/schemas/v1.0/salad/schema_salad/ref_resolver.py
@@ -155,7 +155,7 @@ class DefaultFetcher(Fetcher):
                 else:
                     raise RuntimeError('Error reading %s: %s' % (url, e))
         else:
-            raise ValueError('Unsupported scheme in url: %s' % url)
+            raise ValueError('Unsupported scheme in url: %s for scheme %s' % (url, scheme))
 
     def check_exists(self, url):  # type: (Text) -> bool
         if url in self.cache:
@@ -173,8 +173,11 @@ class DefaultFetcher(Fetcher):
             return True
         elif scheme == 'file':
             return os.path.exists(urllib.request.url2pathname(str(path)))
+        # Google storage links are protected by user accounts and thus are not subject to external validation
+        elif scheme == 'gs':
+            return True
         else:
-            raise ValueError('Unsupported scheme in url: %s' % url)
+            raise ValueError('Error while checking link exists: Unsupported scheme %s in url: %s' % (scheme, url))
 
     def urljoin(self, base_url, url):  # type: (Text, Text) -> Text
 


### PR DESCRIPTION
We at the Broad Institute are using cwltool's pre-processing capability.

We have noticed that Google storage links cannot pass the `check_exists` function as they are by nature not publicly accessible.

What I've submitted here is a quick workaround to get over this hurdle.  I've tested it locally and it is working as intended.

One may wonder why we aren't using `schema-salad-tool` directly to do the preprocessing.  We've noticed that `cwltool` seems to handle a larger variety of cases that `schema-salad-tool` does not, however I do not have such comparisons in hand.

We're definitely open to more comprehensive discussion on a parameter to disable this sort of validation (perhaps only applicable during `--print-pre` situations?).