### PR TITLE
Add nothing to command line if prefix is absent for boolean

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -230,7 +230,7 @@ class Builder(object):
             return [prefix] if prefix else []
         elif value is True and prefix:
             return [prefix]
-        elif value is False or value is None:
+        elif value is False or value is None or (value is True and not prefix):
             return []
         else:
             l = [value]


### PR DESCRIPTION
Fix https://github.com/common-workflow-language/cwltool/issues/618
Conformance test: https://github.com/common-workflow-language/common-workflow-language/pull/610