### PR TITLE
Do not evaluate expressions with `self` if input object is null

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -251,7 +251,8 @@ class Builder(object):
                 return {k: self.do_eval(v, context, pull_image, recursive) for k, v in iteritems(ex)}
             if isinstance(ex, list):
                 return [self.do_eval(v, context, pull_image, recursive) for v in ex]
-
+        if context is None and type(ex) is str and "self" in ex:
+            return None
         return expression.do_eval(ex, self.job, self.requirements,
                                   self.outdir, self.tmpdir,
                                   self.resources,


### PR DESCRIPTION
fixes https://github.com/common-workflow-language/cwltool/issues/621