### PR TITLE
implement logging timestamps and record container ID in a file

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -364,7 +364,7 @@ class DockerCommandLineJob(JobBase):
                         docker_windows_path_adjust(vol.target)))
 
     def run(self, pull_image=True, rm_container=True,
-            record_container_id=False, cidfile_dir="/tmp/",
+            record_container_id=False, cidfile_dir="",
             cidfile_prefix="",
             rm_tmpdir=True, move_outputs="move", **kwargs):
         # type: (bool, bool, bool, Text, Text, bool, Text, **Any) -> None
@@ -469,21 +469,22 @@ class DockerCommandLineJob(JobBase):
         
         # add parameters to docker to write a container ID file
         if record_container_id:
-            if cidfile_dir:
+            if cidfile_dir != "":
                 if not os.path.isdir(cidfile_dir):
                     _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,
-                                  cidfile_dir + " is not a directory or directory doesn't exist, please check it first")
-                    exit(-1)
+                                  cidfile_dir + " is not a directory or "
+                                  "directory doesn't exist, please check it first")
+                    exit(2)
                 if not os.path.exists(cidfile_dir):
                     _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,
                                   "directory doesn't exist, please create it first")
-                    exit(-1)
+                    exit(2)
             else:
-                cidfile_dir = "/tmp/"
+                cidfile_dir = os.getcwd()
             cidfile_name = datetime.datetime.now().strftime("%Y%m%d%H%M%S-%f")+".cid"
             if cidfile_prefix != "":
                 cidfile_name = str(cidfile_prefix + "-" + cidfile_name)
-            cidfile_path = cidfile_dir + cidfile_name
+            cidfile_path = os.path.join(cidfile_dir, cidfile_name)
             runtime.append(u"--cidfile=%s" % cidfile_path)
 
         for t, v in self.environment.items():

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -482,7 +482,7 @@ class DockerCommandLineJob(JobBase):
                 cidfile_dir = "/tmp/"
             cidfile_name = datetime.datetime.now().strftime("%Y%m%d%H%M%S-%f")+".cid"
             if cidfile_prefix != "":
-                cidfile_name = cidfile_prefix + "-" + cidfile_name
+                cidfile_name = str(cidfile_prefix + "-" + cidfile_name)
             cidfile_path = cidfile_dir + cidfile_name
             runtime.append(u"--cidfile=%s" % cidfile_path)
 

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -367,7 +367,7 @@ class DockerCommandLineJob(JobBase):
             record_container_id=False, cidfile_dir="/tmp/",
             cidfile_prefix="",
             rm_tmpdir=True, move_outputs="move", **kwargs):
-        # type: (bool, bool, bool, Text, **Any) -> None
+        # type: (bool, bool, bool, Text, Text, bool, Text, **Any) -> None
 
         (docker_req, docker_is_req) = get_feature(self, "DockerRequirement")
 

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -11,6 +11,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import datetime
 from io import open
 from typing import (IO, Any, Callable, Dict, Iterable, List, MutableMapping, Text,
                     Tuple, Union, cast)
@@ -363,6 +364,8 @@ class DockerCommandLineJob(JobBase):
                         docker_windows_path_adjust(vol.target)))
 
     def run(self, pull_image=True, rm_container=True,
+            record_container_id=False, cidfile_dir="/tmp/",
+            cidfile_prefix="",
             rm_tmpdir=True, move_outputs="move", **kwargs):
         # type: (bool, bool, bool, Text, **Any) -> None
 
@@ -463,6 +466,25 @@ class DockerCommandLineJob(JobBase):
         # directory." but spec might change to designated temp directory.
         # runtime.append("--env=HOME=/tmp")
         runtime.append(u"--env=HOME=%s" % self.builder.outdir)
+        
+        # add parameters to docker to write a container ID file
+        if record_container_id:
+            if cidfile_dir:
+                if not os.path.isdir(cidfile_dir):
+                    _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,
+                                  cidfile_dir + " is not a directory or directory doesn't exist, please check it first")
+                    exit(-1)
+                if not os.path.exists(cidfile_dir):
+                    _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,
+                                  "directory doesn't exist, please create it first")
+                    exit(-1)
+            else:
+                cidfile_dir = "/tmp/"
+            cidfile_name = datetime.datetime.now().strftime("%Y%m%d%H%M%S-%f")+".cid"
+            if cidfile_prefix != "":
+                cidfile_name = cidfile_prefix + "-" + cidfile_name
+            cidfile_path = cidfile_dir + cidfile_name
+            runtime.append(u"--cidfile=%s" % cidfile_path)
 
         for t, v in self.environment.items():
             runtime.append(u"--env=%s=%s" % (t, v))

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -84,27 +84,23 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                          default=True, help="Do not delete Docker container used by jobs after they exit",
                          dest="rm_container")
 
-    group = parser.add_argument_group("options for docker container ID file", 
-                                      "These options determine whether docker"
-                                      "write container ID to a file (cidfile) "
-                                      "when a container is created, where it "
-                                      "should be placed and how it should be named.")
-    group.add_argument("--record-container-id", action="store_true",
+    cidgroup = parser.add_argument_group("Options for recording the Docker container identifier into a file")
+    cidgroup.add_argument("--record-container-id", action="store_true",
                        default=False,
-                       help="If enabled, store the container ID file under the "
-                            "directory specified by --cidfile-dir",
+                       help="If enabled, store the container ID file. "
+                       "See --cidfile-dir to specify the directory.",
                        dest="record_container_id")
 
-    group.add_argument("--cidfile-dir", type=Text,
+    cidgroup.add_argument("--cidfile-dir", type=Text,
                         help="Directory for storing the container ID file. "
-                             "Default at current directory",
+                             "The default is current directory",
                         default="",
                         dest="cidfile_dir")
 
-    group.add_argument("--cidfile-prefix", type=Text,
-                        help="Specify a prefix to the container ID file. "
+    cidgroup.add_argument("--cidfile-prefix", type=Text,
+                        help="Specify a prefix to the container ID filename. "
                              "Final file name will be followed by a timestamp. "
-                             "Default \"\"",
+                             "The default is no prefix.",
                         default="",
                         dest="cidfile_prefix")
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -87,13 +87,13 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     cidgroup = parser.add_argument_group("Options for recording the Docker container identifier into a file")
     cidgroup.add_argument("--record-container-id", action="store_true",
                        default=False,
-                       help="If enabled, store the container ID file. "
+                       help="If enabled, store the Docker container ID into a file. "
                        "See --cidfile-dir to specify the directory.",
                        dest="record_container_id")
 
     cidgroup.add_argument("--cidfile-dir", type=Text,
-                        help="Directory for storing the container ID file. "
-                             "The default is current directory",
+                        help="Directory for storing the Docker container ID file. "
+                             "The default is the current directory",
                         default="",
                         dest="cidfile_dir")
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -84,6 +84,20 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                          default=True, help="Do not delete Docker container used by jobs after they exit",
                          dest="rm_container")
 
+    parser.add_argument("--record-container-id", action="store_true", default=False,
+                        help="If enabled, a file with suffix \".cid\" will be created storing the container ID under CIDFILE_DIR",
+                        dest="record_container_id")
+
+    parser.add_argument("--cidfile-dir", type=Text,
+                        help="Directory for storing cidfiles. Default at /tmp/",
+                        default="/tmp/",
+                        dest="cidfile_dir")
+
+    parser.add_argument("--cidfile-prefix", type=Text,
+                        help="Give a prefix to cidfile. Final file name will be followed by a timestamp. Default empty.",
+                        default="",
+                        dest="cidfile_prefix")
+
     parser.add_argument("--tmpdir-prefix", type=Text,
                         help="Path prefix for temporary directories",
                         default="tmp")
@@ -161,6 +175,7 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--verbose", action="store_true", help="Default logging")
     exgroup.add_argument("--quiet", action="store_true", help="Only print warnings and errors.")
     exgroup.add_argument("--debug", action="store_true", help="Print even more logging")
+    parser.add_argument("--logtstp", action="store_true", help="Print timestamps with logging")
 
     parser.add_argument("--js-console", action="store_true", help="Enable javascript console output")
     parser.add_argument("--user-space-docker-cmd",
@@ -774,6 +789,7 @@ def main(argsl=None,  # type: List[str]
                      'cachedir': None,
                      'quiet': False,
                      'debug': False,
+                     'logtstp': False,
                      'js_console': False,
                      'version': False,
                      'enable_dev': False,
@@ -802,6 +818,10 @@ def main(argsl=None,  # type: List[str]
             _logger.setLevel(logging.WARN)
         if args.debug:
             _logger.setLevel(logging.DEBUG)
+        if args.logtstp:
+            formatter = logging.Formatter("[%(asctime)s] %(message)s",
+                                          "%Y-%m-%d %H:%M:%S")
+            stderr_handler.setFormatter(formatter)
 
         if args.version:
             print(versionfunc())

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -84,17 +84,27 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                          default=True, help="Do not delete Docker container used by jobs after they exit",
                          dest="rm_container")
 
-    parser.add_argument("--record-container-id", action="store_true", default=False,
-                        help="If enabled, a file with suffix \".cid\" will be created storing the container ID under CIDFILE_DIR",
-                        dest="record_container_id")
+    group = parser.add_argument_group("options for docker container ID file", 
+                                      "These options determine whether docker"
+                                      "write container ID to a file (cidfile) "
+                                      "when a container is created, where it "
+                                      "should be placed and how it should be named.")
+    group.add_argument("--record-container-id", action="store_true",
+                       default=False,
+                       help="If enabled, store the container ID file under the "
+                            "directory specified by --cidfile-dir",
+                       dest="record_container_id")
 
-    parser.add_argument("--cidfile-dir", type=Text,
-                        help="Directory for storing cidfiles. Default at /tmp/",
-                        default="/tmp/",
+    group.add_argument("--cidfile-dir", type=Text,
+                        help="Directory for storing the container ID file. "
+                             "Default at current directory",
+                        default="",
                         dest="cidfile_dir")
 
-    parser.add_argument("--cidfile-prefix", type=Text,
-                        help="Give a prefix to cidfile. Final file name will be followed by a timestamp. Default empty.",
+    group.add_argument("--cidfile-prefix", type=Text,
+                        help="Specify a prefix to the container ID file. "
+                             "Final file name will be followed by a timestamp. "
+                             "Default \"\"",
                         default="",
                         dest="cidfile_prefix")
 
@@ -175,7 +185,8 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--verbose", action="store_true", help="Default logging")
     exgroup.add_argument("--quiet", action="store_true", help="Only print warnings and errors.")
     exgroup.add_argument("--debug", action="store_true", help="Print even more logging")
-    parser.add_argument("--logtstp", action="store_true", help="Print timestamps with logging")
+    parser.add_argument("--timestamps", action="store_true", 
+                        help="Add timestamps to the errors, warnings, and notifications.")
 
     parser.add_argument("--js-console", action="store_true", help="Enable javascript console output")
     parser.add_argument("--user-space-docker-cmd",
@@ -789,7 +800,7 @@ def main(argsl=None,  # type: List[str]
                      'cachedir': None,
                      'quiet': False,
                      'debug': False,
-                     'logtstp': False,
+                     'timestamps': False,
                      'js_console': False,
                      'version': False,
                      'enable_dev': False,
@@ -818,7 +829,7 @@ def main(argsl=None,  # type: List[str]
             _logger.setLevel(logging.WARN)
         if args.debug:
             _logger.setLevel(logging.DEBUG)
-        if args.logtstp:
+        if args.timestamps:
             formatter = logging.Formatter("[%(asctime)s] %(message)s",
                                           "%Y-%m-%d %H:%M:%S")
             stderr_handler.setFormatter(formatter)


### PR DESCRIPTION
Added options:
```
--record-container-id
                      If enabled, a file with suffix ".cid" will be created
                      storing the container ID under CIDFILE_DIR
--cidfile-dir CIDFILE_DIR
                      Directory for storing cidfiles. Default at /tmp/
--cidfile-prefix CIDFILE_PREFIX
                      Give a prefix to cidfile. Final file name will be
                      followed by a timestamp. Default empty.
--logtstp             Print timestamps with logging
```
