### PR TITLE
Single quote instead of backticks in output

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -193,7 +193,7 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     parser.add_argument("--default-container",
                         help="Specify a default docker container that will be used if the workflow fails to specify one.")
     parser.add_argument("--no-match-user", action="store_true",
-                        help="Disable passing the current uid to 'docker run --user`")
+                        help="Disable passing the current uid to `docker run --user`")
     parser.add_argument("--disable-net", action="store_true",
                         help="Use docker's default networking for containers;"
                              " the default is to enable networking.")

--- a/cwltool/draft2tool.py
+++ b/cwltool/draft2tool.py
@@ -151,7 +151,8 @@ def revmap_file(builder, outdir, f):
         return f
 
 
-    raise WorkflowException(u"Output File object is missing both `location` and `path` fields: %s" % f)
+    raise WorkflowException(u"Output File object is missing both 'location' "
+            "and 'path' fields: %s" % f)
 
 
 class CallbackJob(object):

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -401,7 +401,7 @@ def fillInDefaults(inputs, job):
             elif job.get(fieldname) is None and u"null" in aslist(inp[u"type"]):
                 job[fieldname] = None
             else:
-                raise WorkflowException("Missing required input parameter `%s`" % shortname(inp["id"]))
+                raise WorkflowException("Missing required input parameter '%s'" % shortname(inp["id"]))
 
 
 def avroize_type(field_type, name_prefix=""):
@@ -506,7 +506,8 @@ class Process(six.with_metaclass(abc.ABCMeta, object)):
                 del c["id"]
 
                 if "type" not in c:
-                    raise validate.ValidationException(u"Missing `type` in parameter `%s`" % c["name"])
+                    raise validate.ValidationException(u"Missing 'type' in "
+                            "parameter '%s'" % c["name"])
 
                 if "default" in c and "null" not in aslist(c["type"]):
                     c["type"] = ["null"] + aslist(c["type"])
@@ -522,7 +523,8 @@ class Process(six.with_metaclass(abc.ABCMeta, object)):
             self.inputs_record_schema = cast(Dict[six.text_type, Any], schema_salad.schema.make_valid_avro(self.inputs_record_schema, {}, set()))
             AvroSchemaFromJSONData(self.inputs_record_schema, self.names)
         except avro.schema.SchemaParseException as e:
-            raise validate.ValidationException(u"Got error `%s` while processing inputs of %s:\n%s" %
+            raise validate.ValidationException(u"Got error '%s' while "
+                    "processing inputs of %s:\n%s" %
                                                (Text(e), self.tool["id"],
                                                 json.dumps(self.inputs_record_schema, indent=4)))
 
@@ -530,7 +532,8 @@ class Process(six.with_metaclass(abc.ABCMeta, object)):
             self.outputs_record_schema = cast(Dict[six.text_type, Any], schema_salad.schema.make_valid_avro(self.outputs_record_schema, {}, set()))
             AvroSchemaFromJSONData(self.outputs_record_schema, self.names)
         except avro.schema.SchemaParseException as e:
-            raise validate.ValidationException(u"Got error `%s` while processing outputs of %s:\n%s" %
+            raise validate.ValidationException(u"Got error '%s' while "
+                    "processing outputs of %s:\n%s" %
                                                (Text(e), self.tool["id"],
                                                 json.dumps(self.outputs_record_schema, indent=4)))
 

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -30,7 +30,7 @@ def defaultMakeTool(toolpath_object,  # type: Dict[Text, Any]
                    ):
     # type: (...) -> Process
     if not isinstance(toolpath_object, dict):
-        raise WorkflowException(u"Not a dict: `%s`" % toolpath_object)
+        raise WorkflowException(u"Not a dict: '%s'" % toolpath_object)
     if "class" in toolpath_object:
         if toolpath_object["class"] == "CommandLineTool":
             return draft2tool.CommandLineTool(toolpath_object, **kwargs)


### PR DESCRIPTION
While backticks are good for reStructuredText Docstring formatting
(PEP-0287) they aren't appropriate for printing to the user