### PR TITLE
Fix exec_js_process process caching

### DIFF
--- a/tests/test_js_sandbox.py
+++ b/tests/test_js_sandbox.py
@@ -2,20 +2,25 @@ from __future__ import absolute_import
 
 import unittest
 
-from mock import Mock
+from mock import Mock, patch
+from mock import MagicMock
 
 import cwltool
 import cwltool.factory
 # we should modify the subprocess imported from cwltool.sandboxjs
 from cwltool.sandboxjs import (check_js_threshold_version,
-                               subprocess)
+                               subprocess,
+                               exec_js_process)
+import cwltool.sandboxjs
+from cwltool.utils import onWindows
 from .util import get_data
+import pytest
 
 
 class Javascript_Sanity_Checks(unittest.TestCase):
 
     def setUp(self):
-        self.check_output = subprocess.check_output 
+        self.check_output = subprocess.check_output
 
     def tearDown(self):
         subprocess.check_output = self.check_output
@@ -37,7 +42,7 @@ class Javascript_Sanity_Checks(unittest.TestCase):
         self.assertEquals(check_js_threshold_version('node'), True)
 
     def test_is_javascript_installed(self):
-            pass
+        pass
 
 
 class TestValueFrom(unittest.TestCase):
@@ -46,3 +51,13 @@ class TestValueFrom(unittest.TestCase):
         f = cwltool.factory.Factory()
         echo = f.make(get_data("tests/wf/vf-concat.cwl"))
         self.assertEqual(echo(), {u"out": u"a sting\n"})
+
+
+class ExecJsProcessTest(unittest.TestCase):
+
+    def test_caches_js_processes(self):
+        exec_js_process("7", context="{}")
+
+        with patch("cwltool.sandboxjs.new_js_proc", new=Mock(wraps=cwltool.sandboxjs.new_js_proc)) as mock:
+            exec_js_process("7", context="{}")
+            mock.assert_not_called()


### PR DESCRIPTION
The existing logic doesn't properly cache processes, leading to a new process being created for every invocation of `exec_js_process` (eventually leading to an error due to too many processes with many calls to execjs). This PR fixes this logic and adds tests for this.