### PR TITLE
Add Appveyor and codecov badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,21 @@
 Common Workflow Language tool description reference implementation
 ==================================================================
 
-CWL conformance tests: |Build Status| Travis CI: |Unix Build Status|
+CWL conformance tests: |Conformance Status| |Linux Status| |Windows Status| |Coverage Status|
 
-.. |Unix Build Status| image:: https://img.shields.io/travis/common-workflow-language/cwltool/master.svg?label=unix%20build
+
+.. |Conformance Status| image:: https://ci.commonwl.org/buildStatus/icon?job=cwltool-conformance
+   :target: https://ci.commonwl.org/job/cwltool-conformance/
+   
+.. |Linux Status| image:: https://img.shields.io/travis/common-workflow-language/cwltool/master.svg?label=Linux%20builds
    :target: https://travis-ci.org/common-workflow-language/cwltool
+   
+.. |Windows Status| image:: https://img.shields.io/appveyor/ci/mr-c/cwltool/master.svg?label=Windows%20builds
+   :target: https://ci.appveyor.com/project/mr-c/cwltool
 
+.. |Coverage Status| image:: https://img.shields.io/codecov/c/github/common-workflow-language/cwltool.svg
+  :target: https://codecov.io/gh/common-workflow-language/cwltool
+   
 This is the reference implementation of the Common Workflow Language.  It is
 intended to feature complete and provide comprehensive validation of CWL
 files as well as provide other tools related to working with CWL.
@@ -109,9 +119,6 @@ To run CWL successfully with boot2docker you need to set the ``--tmpdir-prefix``
 and ``--tmp-outdir-prefix`` to somewhere under ``/Users``::
 
     $ cwl-runner --tmp-outdir-prefix=/Users/username/project --tmpdir-prefix=/Users/username/project wc-tool.cwl wc-job.json
-
-.. |Build Status| image:: https://ci.commonwl.org/buildStatus/icon?job=cwltool-conformance
-   :target: https://ci.commonwl.org/job/cwltool-conformance/
 
 Using user-space replacements for Docker
 ----------------------------------------


### PR DESCRIPTION
This change adds 2 badges to the top of the readme, the appveyor one with status of windows builds, and the codecov with coverage info.
It also adds relevant text to the badges and removes the text that was next to them.

I would have changed the CWL conformance one to include the text inside the [badge](https://img.shields.io/jenkins/s/https/ci.commonwl.org/job/cwltool-conformance.svg?label=CWL%20conformance).
Unfortunately shields.io doesn't retrieve the info from Jenkins even though the [API endpoint](https://ci.commonwl.org/job/cwltool-conformance/api/json?tree=color) that should be queried works.