### PR TITLE
better feedback on empty outputs section

### DIFF
--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -123,24 +123,30 @@ def _convert_stdstreams_to_files(workflowobj):
 
     if isinstance(workflowobj, dict):
         if workflowobj.get('class') == 'CommandLineTool':
-            for out in workflowobj.get('outputs', []):
-                if type(out) is not CommentedMap:
-                    with SourceLine(workflowobj, "outputs", ValidationException, _logger.isEnabledFor(logging.DEBUG)):
-                        raise ValidationException("Output '%s' is not a valid OutputParameter." % out)
-                for streamtype in ['stdout', 'stderr']:
-                    if out.get('type') == streamtype:
-                        if 'outputBinding' in out:
-                            raise ValidationException(
-                                "Not allowed to specify outputBinding when"
-                                " using %s shortcut." % streamtype)
-                        if streamtype in workflowobj:
-                            filename = workflowobj[streamtype]
-                        else:
-                            filename = Text(hashlib.sha1(json.dumps(workflowobj,
-                                        sort_keys=True).encode('utf-8')).hexdigest())
-                            workflowobj[streamtype] = filename
-                        out['type'] = 'File'
-                        out['outputBinding'] = cmap({'glob': filename})
+            with SourceLine(workflowobj, "outputs", ValidationException,
+                            _logger.isEnabledFor(logging.DEBUG)):
+                outputs = workflowobj.get('outputs', [])
+                if not isinstance(outputs, CommentedSeq):
+                    raise ValidationException('"outputs" section is not '
+                            'valid.')
+                for out in workflowobj.get('outputs', []):
+                    if type(out) is not CommentedMap:
+                        raise ValidationException("Output '{}' is not a "
+                                    "valid OutputParameter.".format(out))
+                    for streamtype in ['stdout', 'stderr']:
+                        if out.get('type') == streamtype:
+                            if 'outputBinding' in out:
+                                raise ValidationException(
+                                    "Not allowed to specify outputBinding when"
+                                    " using %s shortcut." % streamtype)
+                            if streamtype in workflowobj:
+                                filename = workflowobj[streamtype]
+                            else:
+                                filename = Text(hashlib.sha1(json.dumps(workflowobj,
+                                            sort_keys=True).encode('utf-8')).hexdigest())
+                                workflowobj[streamtype] = filename
+                            out['type'] = 'File'
+                            out['outputBinding'] = cmap({'glob': filename})
             for inp in workflowobj.get('inputs', []):
                 if inp.get('type') == 'stdin':
                     if 'inputBinding' in inp:
@@ -219,9 +225,11 @@ def validate_document(document_loader,  # type: Loader
             workflowobj['cwlVersion'] = metadata['cwlVersion']
         else:
             raise ValidationException(
-                  "No cwlVersion found. "
-                  "Use the following syntax in your CWL document to declare the version: cwlVersion: <version>.\n"
-                  "Note: if this is a CWL draft-2 (pre v1.0) document then it will need to be upgraded first.")
+                "No cwlVersion found. "
+                "Use the following syntax in your CWL document to declare "
+                "the version: cwlVersion: <version>.\n"
+                "Note: if this is a CWL draft-2 (pre v1.0) document then it "
+                "will need to be upgraded first.")
 
     if not isinstance(workflowobj["cwlVersion"], (str, Text)):
         raise Exception("'cwlVersion' must be a string, got %s" % type(workflowobj["cwlVersion"]))

--- a/tests/echo_broken_outputs.cwl
+++ b/tests/echo_broken_outputs.cwl
@@ -1,0 +1,10 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+inputs:
+  - id: inp
+    type: string
+    inputBinding: {}
+baseCommand: echo
+stdout: out.txt
+outputs:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -138,6 +138,11 @@ class TestFactory(unittest.TestCase):
         echo = f.make(get_data("tests/echo.cwl"))
         self.assertEqual(echo(inp="foo"), {"out": "foo\n"})
 
+    def test_factory_bad_outputs(self):
+        f = cwltool.factory.Factory()
+        with self.assertRaises(schema_salad.validate.ValidationException):
+            echo = f.make(get_data("tests/echo_broken_outputs.cwl"))
+
     def test_default_args(self):
         f = cwltool.factory.Factory()
         assert f.execkwargs["use_container"] is True


### PR DESCRIPTION
Fixes #709

```
$ cwltool https://raw.githubusercontent.com/ska-sa/den/1c9e1f28bd06c07e808a82fd86f0cc25d08be251/main.cwl
/home/michael/cwltool/env3/bin/cwltool 1.0.20180403124038
Tool definition failed initialization:
Tool definition https://raw.githubusercontent.com/ska-sa/den/1c9e1f28bd06c07e808a82fd86f0cc25d08be251/steps/casa_applycal.cwl failed validation:
https://raw.githubusercontent.com/ska-sa/den/1c9e1f28bd06c07e808a82fd86f0cc25d08be251/steps/casa_applycal.cwl:158:1:   "outputs" section is not valid.
```