### PR TITLE
Specify absolute path of config file for dependency resolver

### DIFF
--- a/cwltool/software_requirements.py
+++ b/cwltool/software_requirements.py
@@ -42,7 +42,7 @@ class DependenciesConfiguration(object):
             if not tool_dependency_dir:
                 tool_dependency_dir = os.path.abspath(os.path.dirname(conf_file))
             self.tool_dependency_dir = tool_dependency_dir
-            self.dependency_resolvers_config_file = conf_file
+            self.dependency_resolvers_config_file = os.path.abspath(conf_file)
         elif conda_dependencies:
             if not tool_dependency_dir:
                 tool_dependency_dir = os.path.abspath("./cwltool_deps")


### PR DESCRIPTION
Hi all,

The dependency resolver is only using the path of the config file specified by the user. If this path is relative and there is any change of working directory (for instance, `cwltoil` is changing its working directory), the dependency resolver will not be able to find the config file.
I propose a little fix to always transmit the absolute path of the config file to prevent this.

Cheers,
Kenzo