### PR TITLE
Support for v1.1 TimeLimit, WorkReuse and NetworkAccess

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -208,12 +208,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         help="Specify a default docker container that will be used if the workflow fails to specify one.")
     parser.add_argument("--no-match-user", action="store_true",
                         help="Disable passing the current uid to `docker run --user`")
-    parser.add_argument("--disable-net", action="store_true",
-                        help="Use docker's default networking for containers;"
-                             " the default is to enable networking.")
     parser.add_argument("--custom-net", type=Text,
-                        help="Will be passed to `docker run` as the '--net' "
-                             "parameter. Implies '--enable-net'.")
+                        help="Passed to `docker run` as the '--net' "
+                             "parameter when NetworkAccess is true.")
     parser.add_argument("--disable-validate", dest="do_validate",
                         action="store_false", default=True,
                         help=argparse.SUPPRESS)

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -250,8 +250,11 @@ class CommandLineTool(Process):
             ):
         # type: (...) -> Generator[Union[JobBase, CallbackJob], None, None]
 
+        workReuse = self.get_requirement("WorkReuse")[0]
+        enableReuse = workReuse.get("enableReuse", True) if workReuse else True
+
         jobname = uniquename(kwargs.get("name", shortname(self.tool.get("id", "job"))))
-        if kwargs.get("cachedir"):
+        if kwargs.get("cachedir") and enableReuse:
             cacheargs = kwargs.copy()
             cacheargs["outdir"] = "/out"
             cacheargs["tmpdir"] = "/tmp"

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -497,6 +497,8 @@ class CommandLineTool(Process):
                 if not isinstance(j.timelimit, int) or j.timelimit < 0:
                     raise Exception("timelimit must be an integer >= 0, got: %s" % j.timelimit)
 
+        if self.metadata["cwlVersion"] == "v1.0":
+            j.networkaccess = True
         networkaccess = self.get_requirement("NetworkAccess")[0]
         if networkaccess:
             with SourceLine(networkaccess, "networkAccess", validate.ValidationException, debug):

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -487,6 +487,20 @@ class CommandLineTool(Process):
             adjustDirObjs(builder.files, register_reader)
             adjustDirObjs(builder.bindings, register_reader)
 
+        timelimit = self.get_requirement("TimeLimit")[0]
+        if timelimit:
+            with SourceLine(timelimit, "timelimit", validate.ValidationException, debug):
+                j.timelimit = builder.do_eval(timelimit["timelimit"])
+                if not isinstance(j.timelimit, int) or j.timelimit < 0:
+                    raise Exception("timelimit must be an integer >= 0, got: %s" % j.timelimit)
+
+        networkaccess = self.get_requirement("NetworkAccess")[0]
+        if networkaccess:
+            with SourceLine(networkaccess, "networkAccess", validate.ValidationException, debug):
+                j.networkaccess = builder.do_eval(networkaccess["networkAccess"])
+                if not isinstance(j.networkaccess, bool):
+                    raise Exception("networkAccess must be a boolean, got: %s" % j.networkaccess)
+
         j.environment = {}
         evr = self.get_requirement("EnvVarRequirement")[0]
         if evr:

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -250,7 +250,11 @@ class CommandLineTool(Process):
             ):
         # type: (...) -> Generator[Union[JobBase, CallbackJob], None, None]
 
-        workReuse = self.get_requirement("WorkReuse")[0]
+        require_prefix = ""
+        if self.metadata["cwlVersion"] == "v1.0":
+            require_prefix = "http://commonwl.org/cwltool#"
+
+        workReuse = self.get_requirement(require_prefix+"WorkReuse")[0]
         enableReuse = workReuse.get("enableReuse", True) if workReuse else True
 
         jobname = uniquename(kwargs.get("name", shortname(self.tool.get("id", "job"))))
@@ -490,7 +494,7 @@ class CommandLineTool(Process):
             adjustDirObjs(builder.files, register_reader)
             adjustDirObjs(builder.bindings, register_reader)
 
-        timelimit = self.get_requirement("TimeLimit")[0]
+        timelimit = self.get_requirement(require_prefix+"TimeLimit")[0]
         if timelimit:
             with SourceLine(timelimit, "timelimit", validate.ValidationException, debug):
                 j.timelimit = builder.do_eval(timelimit["timelimit"])
@@ -499,7 +503,7 @@ class CommandLineTool(Process):
 
         if self.metadata["cwlVersion"] == "v1.0":
             j.networkaccess = True
-        networkaccess = self.get_requirement("NetworkAccess")[0]
+        networkaccess = self.get_requirement(require_prefix+"NetworkAccess")[0]
         if networkaccess:
             with SourceLine(networkaccess, "networkAccess", validate.ValidationException, debug):
                 j.networkaccess = builder.do_eval(networkaccess["networkAccess"])

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -267,9 +267,10 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             if not kwargs.get("no_read_only"):
                 runtime.append(u"--read-only=true")
 
-            if kwargs.get("custom_net", None) is not None:
-                runtime.append(u"--net={0}".format(kwargs.get("custom_net")))
-            elif kwargs.get("disable_net", None):
+            if self.networkaccess:
+                if kwargs.get("custom_net"):
+                    runtime.append(u"--net={0}".format(kwargs["custom_net"]))
+            else:
                 runtime.append(u"--net=none")
 
             if self.stdout:

--- a/cwltool/extensions.yml
+++ b/cwltool/extensions.yml
@@ -54,3 +54,84 @@ $graph:
       jsonldPredicate:
         "_type": "@id"
         refScope: 0
+
+
+- type: record
+  name: TimeLimit
+  inVocab: false
+  extends: cwl:ProcessRequirement
+  doc: |
+    Set an upper limit on the execution time of a CommandLineTool or
+    ExpressionTool.  A tool execution which exceeds the time limit may
+    be preemptively terminated and considered failed.  May also be
+    used by batch systems to make scheduling decisions.
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'TimeLimit'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: timelimit
+      type: [long, string]
+      doc: |
+        The time limit, in seconds.  A time limit of zero means no
+        time limit.  Negative time limits are an error.
+
+
+- type: record
+  name: WorkReuse
+  inVocab: false
+  extends: cwl:ProcessRequirement
+  doc: |
+    For implementations that support reusing output from past work (on
+    the assumption that same code and same input produce same
+    results), control whether to enable or disable the reuse behavior
+    for a particular tool or step (to accomodate situations where that
+    assumption is incorrect).  A reused step is not executed but
+    instead returns the same output as the original execution.
+
+    If `enableReuse` is not specified, correct tools should assume it
+    is enabled by default.
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'WorkReuse'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: enableReuse
+      type: [boolean, string]
+      #default: true
+
+
+- type: record
+  name: NetworkAccess
+  inVocab: false
+  extends: cwl:ProcessRequirement
+  doc: |
+    Indicate whether a process requires outgoing IPv4/IPv6 network
+    access.  Choice of IPv4 or IPv6 is implementation and site
+    specific, correct tools must support both.
+
+    If `networkAccess` is false or not specified, tools must not
+    assume network access, except for localhost (the loopback device).
+
+    If `networkAccess` is true, the tool must be able to make outgoing
+    connections to network resources.  Resources may be on a private
+    subnet or the public Internet.  However, implementations and sites
+    may apply their own security policies to restrict what is
+    accessible by the tool.
+
+    Enabling network access does not imply a publically routable IP
+    address or the ability to accept inbound connections.
+
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'NetworkAccess'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: networkAccess
+      type: [boolean, string]

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -440,7 +440,7 @@ def _job_popen(
         cwd,                       # type: Text
         job_dir,                   # type: Text
         job_script_contents=None,  # type: Text
-        timeout=None,              # type: int
+        timelimit=None,            # type: int
         name=None                  # type: Text
        ):  # type: (...) -> int
 

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -441,7 +441,7 @@ def _job_popen(
         job_dir,                   # type: Text
         job_script_contents=None,  # type: Text
         timeout=None,              # type: int
-        name=None                  # type: str
+        name=None                  # type: Text
        ):  # type: (...) -> int
 
     if not job_script_contents and not FORCE_SHELLED_POPEN:

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -17,7 +17,7 @@ from schema_salad.ref_resolver import uri_file_path
 from schema_salad.sourceline import SourceLine
 from six.moves import urllib
 
-from .utils import convert_pathsep_to_unix
+from .utils import convert_pathsep_to_unix, visit_class
 
 from .stdfsaccess import StdFsAccess, abspath
 
@@ -38,17 +38,6 @@ def adjustFiles(rec, op):  # type: (Any, Union[Callable[..., Any], partial[Any]]
         for d in rec:
             adjustFiles(d, op)
 
-def visit_class(rec, cls, op):  # type: (Any, Iterable, Union[Callable[..., Any], partial[Any]]) -> None
-    """Apply a function to with "class" in cls."""
-
-    if isinstance(rec, dict):
-        if "class" in rec and rec.get("class") in cls:
-            op(rec)
-        for d in rec:
-            visit_class(rec[d], cls, op)
-    if isinstance(rec, list):
-        for d in rec:
-            visit_class(d, cls, op)
 
 def adjustFileObjs(rec, op):  # type: (Any, Union[Callable[..., Any], partial[Any]]) -> None
     """Apply an update function to each File object in the object `rec`."""

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -71,6 +71,9 @@ supportedProcessRequirements = ["DockerRequirement",
                                 "StepInputExpressionRequirement",
                                 "ResourceRequirement",
                                 "InitialWorkDirRequirement",
+                                "TimeLimit",
+                                "WorkReuse",
+                                "NetworkAccess",
                                 "http://commonwl.org/cwltool#LoadListingRequirement",
                                 "http://commonwl.org/cwltool#InplaceUpdateRequirement"]
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -74,6 +74,9 @@ supportedProcessRequirements = ["DockerRequirement",
                                 "TimeLimit",
                                 "WorkReuse",
                                 "NetworkAccess",
+                                "http://commonwl.org/cwltool#TimeLimit",
+                                "http://commonwl.org/cwltool#WorkReuse",
+                                "http://commonwl.org/cwltool#NetworkAccess",
                                 "http://commonwl.org/cwltool#LoadListingRequirement",
                                 "http://commonwl.org/cwltool#InplaceUpdateRequirement"]
 

--- a/cwltool/schemas/v1.1.0-dev1/CommandLineTool.yml
+++ b/cwltool/schemas/v1.1.0-dev1/CommandLineTool.yml
@@ -990,3 +990,81 @@ $graph:
     - name: outdirMax
       type: ["null", long, string, Expression]
       doc: Maximum reserved filesystem based storage for the designated output directory, in mebibytes (2**20)
+
+
+- type: record
+  name: TimeLimit
+  extends: ProcessRequirement
+  doc: |
+    Set an upper limit on the execution time of a CommandLineTool or
+    ExpressionTool.  A tool execution which exceeds the time limit may
+    be preemptively terminated and considered failed.  May also be
+    used by batch systems to make scheduling decisions.
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'TimeLimit'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: timelimit
+      type: [long, string, Expression]
+      doc: |
+        The time limit, in seconds.  A time limit of zero means no
+        time limit.  Negative time limits are an error.
+
+
+- type: record
+  name: WorkReuse
+  extends: ProcessRequirement
+  doc: |
+    For implementations that support reusing output from past work (on
+    the assumption that same code and same input produce same
+    results), control whether to enable or disable the reuse behavior
+    for a particular tool or step (to accomodate situations where that
+    assumption is incorrect).  A reused step is not executed but
+    instead returns the same output as the original execution.
+
+    If `enableReuse` is not specified, correct tools should assume it
+    is enabled by default.
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'WorkReuse'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: enableReuse
+      type: [boolean, string, Expression]
+      default: true
+
+
+- type: record
+  name: NetworkAccess
+  extends: ProcessRequirement
+  doc: |
+    Indicate whether a process requires outgoing IPv4/IPv6 network
+    access.  Choice of IPv4 or IPv6 is implementation and site
+    specific, correct tools must support both.
+
+    If `networkAccess` is false or not specified, tools must not
+    assume network access, except for localhost (the loopback device).
+
+    If `networkAccess` is true, the tool must be able to make outgoing
+    connections to network resources.  Resources may be on a private
+    subnet or the public Internet.  However, implementations and sites
+    may apply their own security policies to restrict what is
+    accessible by the tool.
+
+    Enabling network access does not imply a publically routable IP
+    address or the ability to accept inbound connections.
+
+  fields:
+    - name: class
+      type: string
+      doc: "Always 'NetworkAccess'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    - name: networkAccess
+      type: [boolean, string, Expression]

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -137,7 +137,7 @@ DEVUPDATES = {
 ALLUPDATES = UPDATES.copy()
 ALLUPDATES.update(DEVUPDATES)
 
-LATEST = "v1.1.0-dev1"
+LATEST = "v1.0"
 
 
 def identity(doc, loader, baseuri):  # pylint: disable=unused-argument

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -13,7 +13,7 @@ import schema_salad.validate
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.ref_resolver import Loader
 
-from .utils import aslist
+from .utils import aslist, visit_class
 
 def findId(doc, frg):  # type: (Any, Any) -> Dict
     if isinstance(doc, dict):
@@ -112,6 +112,16 @@ def v1_0dev4to1_0(doc, loader, baseuri):
 def v1_0to1_1_0dev1(doc, loader, baseuri):
     # type: (Any, Loader, Text) -> Tuple[Any, Text]
     """Public updater for v1.0 to v1.1.0-dev1."""
+
+    def add_networkaccess(t):
+        t.setdefault("requirements", [])
+        t["requirements"].append({
+            "class": "NetworkAccess",
+            "networkAccess": True
+            })
+
+    visit_class(doc, ("CommandLineTool",), add_networkaccess)
+
     return (doc, "v1.1.0-dev1")
 
 
@@ -127,7 +137,7 @@ DEVUPDATES = {
 ALLUPDATES = UPDATES.copy()
 ALLUPDATES.update(DEVUPDATES)
 
-LATEST = "v1.0"
+LATEST = "v1.1.0-dev1"
 
 
 def identity(doc, loader, baseuri):  # pylint: disable=unused-argument

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -190,6 +190,7 @@ def bytes2str_in_dicts(a):
     # simply return elements itself
     return a
 
+
 def add_sizes(obj):  # type: (Dict[Text, Any]) -> None
        if 'location' in obj:
            try:
@@ -201,3 +202,15 @@ def add_sizes(obj):  # type: (Dict[Text, Any]) -> None
        else:
            return  # best effort
 
+
+def visit_class(rec, cls, op):  # type: (Any, Iterable, Union[Callable[..., Any], partial[Any]]) -> None
+    """Apply a function to with "class" in cls."""
+
+    if isinstance(rec, dict):
+        if "class" in rec and rec.get("class") in cls:
+            op(rec)
+        for d in rec:
+            visit_class(rec[d], cls, op)
+    if isinstance(rec, list):
+        for d in rec:
+            visit_class(d, cls, op)

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -6,7 +6,9 @@ import os
 import platform
 import shutil
 import stat
-from typing import Any, Callable, Dict, List, Text, Tuple, Union
+from functools import partial
+
+from typing import Any, Callable, Dict, List, Text, Tuple, Union, Iterable
 if os.name == 'posix':
     import subprocess32 as subprocess  # type: ignore # pylint: disable=import-error,unused-import
 else:

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -11,7 +11,7 @@ import cwltool.process
 import cwltool.workflow
 from cwltool.main import main
 from cwltool.utils import onWindows
-from .util import get_data, needs_docker
+from .util import get_data, needs_docker, windows_needs_docker
 
 
 @needs_docker
@@ -159,6 +159,7 @@ class TestV1_1backports(unittest.TestCase):
         self.assertEquals(main([get_data('tests/wf/workreuse.cwl')]), 1)
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/workreuse-fail.cwl')]), 1)
 
+    @windows_needs_docker
     def test_require_prefix_timelimit(self):
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit.cwl')]), 0)
         self.assertEquals(main([get_data('tests/wf/timelimit.cwl')]), 1)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -145,3 +145,17 @@ class TestInplaceUpdate(unittest.TestCase):
         finally:
             shutil.rmtree(tmp)
             shutil.rmtree(out)
+
+class TestV1_1backports(unittest.TestCase):
+    def test_require_prefix(self):
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/networkaccess.cwl')]), 0)
+        self.assertEquals(main([get_data('tests/wf/networkaccess.cwl')]), 1)
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/networkaccess-fail.cwl')]), 1)
+
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit.cwl')]), 0)
+        self.assertEquals(main([get_data('tests/wf/timelimit.cwl')]), 1)
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit-fail.cwl')]), 1)
+
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/workreuse.cwl')]), 0)
+        self.assertEquals(main([get_data('tests/wf/workreuse.cwl')]), 1)
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/workreuse-fail.cwl')]), 1)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -147,15 +147,19 @@ class TestInplaceUpdate(unittest.TestCase):
             shutil.rmtree(out)
 
 class TestV1_1backports(unittest.TestCase):
-    def test_require_prefix(self):
+    @needs_docker
+    def test_require_prefix_networkaccess(self):
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/networkaccess.cwl')]), 0)
         self.assertEquals(main([get_data('tests/wf/networkaccess.cwl')]), 1)
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/networkaccess-fail.cwl')]), 1)
 
-        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit.cwl')]), 0)
-        self.assertEquals(main([get_data('tests/wf/timelimit.cwl')]), 1)
-        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit-fail.cwl')]), 1)
-
+    @needs_docker
+    def test_require_prefix_workreuse(self):
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/workreuse.cwl')]), 0)
         self.assertEquals(main([get_data('tests/wf/workreuse.cwl')]), 1)
         self.assertEquals(main(["--enable-ext", get_data('tests/wf/workreuse-fail.cwl')]), 1)
+
+    def test_require_prefix_timelimit(self):
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit.cwl')]), 0)
+        self.assertEquals(main([get_data('tests/wf/timelimit.cwl')]), 1)
+        self.assertEquals(main(["--enable-ext", get_data('tests/wf/timelimit-fail.cwl')]), 1)

--- a/tests/wf/networkaccess-fail.cwl
+++ b/tests/wf/networkaccess-fail.cwl
@@ -1,0 +1,15 @@
+class: CommandLineTool
+cwlVersion: v1.0
+requirements:
+  DockerRequirement:
+    dockerPull: python:3
+  NetworkAccess:
+    networkAccess: true
+inputs: []
+outputs: []
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import urllib.request
+      assert(urllib.request.urlopen("http://commonwl.org").code == 200)

--- a/tests/wf/networkaccess.cwl
+++ b/tests/wf/networkaccess.cwl
@@ -1,0 +1,17 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  cwltool: "http://commonwl.org/cwltool#"
+requirements:
+  DockerRequirement:
+    dockerPull: python:3
+  cwltool:NetworkAccess:
+    networkAccess: true
+inputs: []
+outputs: []
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import urllib.request
+      assert(urllib.request.urlopen("http://commonwl.org").code == 200)

--- a/tests/wf/timelimit-fail.cwl
+++ b/tests/wf/timelimit-fail.cwl
@@ -1,0 +1,8 @@
+class: CommandLineTool
+cwlVersion: v1.0
+inputs: []
+outputs: []
+requirements:
+  TimeLimit:
+    timelimit: 15
+baseCommand: [sleep, "3"]

--- a/tests/wf/timelimit.cwl
+++ b/tests/wf/timelimit.cwl
@@ -1,0 +1,10 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  cwltool: "http://commonwl.org/cwltool#"
+inputs: []
+outputs: []
+requirements:
+  cwltool:TimeLimit:
+    timelimit: 15
+baseCommand: [sleep, "3"]

--- a/tests/wf/workreuse-fail.cwl
+++ b/tests/wf/workreuse-fail.cwl
@@ -1,0 +1,17 @@
+class: CommandLineTool
+cwlVersion: v1.0
+requirements:
+  DockerRequirement:
+    dockerPull: python:3
+  WorkReuse:
+    enableReuse: false
+inputs: []
+outputs:
+  page: stdout
+stdout: time.txt
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import time
+      print(time.time())

--- a/tests/wf/workreuse.cwl
+++ b/tests/wf/workreuse.cwl
@@ -1,0 +1,19 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  cwltool: "http://commonwl.org/cwltool#"
+requirements:
+  DockerRequirement:
+    dockerPull: python:3
+  cwltool:WorkReuse:
+    enableReuse: false
+inputs: []
+outputs:
+  page: stdout
+stdout: time.txt
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import time
+      print(time.time())


### PR DESCRIPTION
- [x] explicit tests for usage of new requirements in v1.0 without prefix
- [x] allow the new requirements in v1.0 with `cwltool` prefix; tests for the same