### PR TITLE
Replace cwltool_module with cwltool-module

### DIFF
--- a/build-cwl-docker.sh
+++ b/build-cwl-docker.sh
@@ -6,6 +6,6 @@ docker build --file=cwltool.Dockerfile --tag=commonworkflowlanguage/cwltool .
 version=$(git describe --tags)
 echo $version | grep -vq '\-' >& /dev/null
 if [ $? -eq 0 ];then
-    docker tag commonworkflowlanguage/cwltool_module commonworkflowlanguage/cwltool_module:$version
+    docker tag commonworkflowlanguage/cwltool-module commonworkflowlanguage/cwltool-module:$version
     docker tag commonworkflowlanguage/cwltool commonworkflowlanguage/cwltool:$version
 fi


### PR DESCRIPTION
This request fixes docker image name for cwltool module.

Related:  #403

