### PR TITLE
WIP handle state variables in js comments

### DIFF
--- a/cwltool/expression.py
+++ b/cwltool/expression.py
@@ -53,13 +53,27 @@ def scanner(scan):  # type: (Text) -> List[int]
     SINGLE_QUOTE = 4
     DOUBLE_QUOTE = 5
     BACKSLASH = 6
+    COMMENT = 7
 
     i = 0
     stack = [DEFAULT]
     start = 0
+    com_check = ''
     while i < len(scan):
         state = stack[-1]
         c = scan[i]
+
+        if state == COMMENT:
+            if c == '\n':
+                stack.pop()
+                com_check = ''
+            pass
+        com_check += c
+        if com_check == '//':
+            stack.append(COMMENT)
+            pass
+        elif com_check != '/':
+            com_check = ''
 
         if state == DEFAULT:
             if c == '$':


### PR DESCRIPTION
I haven't tested this, but just wanted to gauge interest in support for some of these STATE variables in the expression tools.

I had a situation like this:
```
${
  // this comment's got a quote in it!
  var asdf = ...
...
```
Which caused:
```
Substitution error, unfinished block starting at position 0: ${
```
I believe because of the quote in the comment. Can add a test or refactor if interested