### PR TITLE
Fix #740 (cachedir not working in certain situations)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: false
+sudo: true
+services:
+  - docker
 language: python
 cache: pip
 python:

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -296,7 +296,7 @@ class CommandLineTool(Process):
                            "EnvVarRequirement",
                            "CreateFileRequirement",
                            "ShellCommandRequirement"}
-            for rh in (self.requirements, self.hints):
+            for rh in (self.original_requirements, self.original_hints):
                 for r in reversed(rh):
                     if r["class"] in interesting and r["class"] not in keydict:
                         keydict[r["class"]] = r

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -17,6 +17,7 @@ from io import open
 from functools import cmp_to_key
 from typing import (Any, Callable, Dict, Generator, List, Set, Text,
                     Tuple, Union, cast, Optional)
+import copy
 
 import schema_salad.schema as schema
 import schema_salad.validate as validate
@@ -453,6 +454,9 @@ class Process(six.with_metaclass(abc.ABCMeta, object)):
                              self.tool.get("requirements", []) +
                              get_overrides(kwargs.get("overrides", []), self.tool["id"]).get("requirements", []))
         self.hints = kwargs.get("hints", []) + self.tool.get("hints", [])
+        # Versions of requirements and hints which aren't mutated.
+        self.original_requirements = copy.deepcopy(self.requirements)
+        self.original_hints = copy.deepcopy(self.hints)
         self.formatgraph = None  # type: Graph
         if "loader" in kwargs:
             self.formatgraph = kwargs["loader"].graph

--- a/tests/wf/cache_test_workflow.cwl
+++ b/tests/wf/cache_test_workflow.cwl
@@ -1,0 +1,21 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs: []
+outputs: []
+
+steps:
+  task1:
+    run: touch_tool.cwl
+    in:
+      message:
+         default: one
+    out: []
+  task2:
+    run: touch_tool.cwl
+    in:
+      message:
+         default: two
+    out: []

--- a/tests/wf/touch_tool.cwl
+++ b/tests/wf/touch_tool.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: touch
+requirements:
+  DockerRequirement:
+    dockerPull: alpine
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs:
+  - id: out
+    type: File
+    outputBinding:
+      glob: "*"


### PR DESCRIPTION
This fixes the problem illustrated in #740. This also adds tests for this and changes `TestCache` to use a temporary directory instead of the folder `cache`.