### PR TITLE
Better windows support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'pip install .', returnStdout: true)
-          pybat jenkins.bat
+          pybat 'jenkins.bat'
         }
 
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'pip install .', returnStdout: true)
-          pybat(script: jenkins.bat)
+          pybat jenkins.bat
         }
 
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stage('build') {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
-          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml', returnStdout: true)
+          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml', returnStatus: true)
         }
 
         junit 'tests.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,10 @@ pipeline {
     stage('build') {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
-          pybat(script: 'setup.py test', returnStdout: true)
+          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml', returnStdout: true)
         }
 
+        junit 'tests.xml'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,11 +9,15 @@ pipeline {
     stage('build') {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
-          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml', returnStatus: true)
+          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml')
         }
 
-        junit 'tests.xml'
       }
+    }
+  }
+  post {
+    always {
+      junit 'tests.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,11 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat(script: '\'C:\\Program Files\\Python36\\python.exe\' -m virtualenv env', returnStatus: true, returnStdout: true)
+        bat(script: '\'C:\\Program Files\\Python36\\python.exe\' -m virtualenv env', returnStdout: true)
+        withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
+          pybat(script: 'setup.py test', returnStdout: true)
+        }
+
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat(script: 'C:\\Program Files\\Python36\\python.exe -m virtualenv env', returnStatus: true, returnStdout: true)
+        bat(script: '\'C:\\Program Files\\Python36\\python.exe\' -m virtualenv env', returnStatus: true, returnStdout: true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,13 +11,13 @@ pipeline {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'pip install .', returnStdout: true)
           pybat '''
-set BOOT2DOCKER_VM=default
-set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
-docker-machine start %BOOT2DOCKER_VM%
-REM Set the environment variables to use docker-machine and docker commands
-@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
-setup.py test --addopts --junit-xml=tests.xml
-'''
+		set BOOT2DOCKER_VM=default
+		set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
+		docker-machine start %BOOT2DOCKER_VM%
+		REM Set the environment variables to use docker-machine and docker commands
+		@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
+		setup.py test --addopts --junit-xml=tests.xml
+          '''
         }
 
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat(script: '\'C:\\Program Files\\Python36\\python.exe\' -m virtualenv env', returnStdout: true)
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'setup.py test', returnStdout: true)
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat(script: 'python.exe -m virtualenv env', returnStatus: true, returnStdout: true)
+        bat(script: 'C:\\Program Files\\Python36\\python.exe -m virtualenv env', returnStatus: true, returnStdout: true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat(script: 'python -m virtualenv env', returnStatus: true, returnStdout: true)
+        bat(script: 'python.exe -m virtualenv env', returnStatus: true, returnStdout: true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ pipeline {
     stage('build') {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
-          pybat(script: 'setup.py test --addopts --junit-xml=tests.xml')
+          pybat(script: 'pip install .', returnStdout: true)
+          pybat 'setup.py test --addopts --junit-xml=tests.xml'
         }
 
       }
@@ -18,6 +19,8 @@ pipeline {
   post {
     always {
       junit 'tests.xml'
+
     }
+
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        bat 'python setup.py '
+        pybat 'python setup.py test'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        withPythonEnv(pythonInstallation: 'C:\\Program Files\\Python36\\python.exe') {
-          pybat(script: 'python setup.py test', returnStatus: true, returnStdout: true)
-        }
-
+        bat(script: 'python -m virtualenv env', returnStatus: true, returnStdout: true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
           pybat(script: 'pip install .', returnStdout: true)
           pybat '''
 set BOOT2DOCKER_VM=default
-set PATH=%PATH%;"C:\Program Files\Docker Toolbox\"
+set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
 docker-machine start %BOOT2DOCKER_VM%
 REM Set the environment variables to use docker-machine and docker commands
 @FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        withPythonEnv(pythonInstallation: 'python') {
+        withPythonEnv(pythonInstallation: 'C:\\Users\\Dan\\AppData\\Local\\Programs\\Python\\Python36\\python.exe') {
           pybat(script: 'python setup.py test', returnStatus: true, returnStdout: true)
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        pybat 'python setup.py test'
+	withPythonEnv('python') {
+          pybat 'python setup.py test'
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        withPythonEnv(pythonInstallation: 'C:\\Users\\Dan\\AppData\\Local\\Programs\\Python\\Python36\\python.exe') {
+        withPythonEnv(pythonInstallation: 'C:\\Program Files\\Python36\\python.exe') {
           pybat(script: 'python setup.py test', returnStatus: true, returnStdout: true)
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,14 +10,7 @@ pipeline {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'pip install .', returnStdout: true)
-          pybat '''
-		set BOOT2DOCKER_VM=default
-		set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
-		docker-machine start %BOOT2DOCKER_VM%
-		REM Set the environment variables to use docker-machine and docker commands
-		@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
-		setup.py test --addopts --junit-xml=tests.xml
-          '''
+          pybat(script: jenkins.bat)
         }
 
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,10 @@ pipeline {
   stages {
     stage('build') {
       steps {
-	withPythonEnv('python') {
-          pybat 'python setup.py test'
+        withPythonEnv(pythonInstallation: 'python') {
+          pybat(script: 'python setup.py test', returnStatus: true, returnStdout: true)
         }
+
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,14 @@ pipeline {
       steps {
         withPythonEnv(pythonInstallation: 'Windows-CPython-36') {
           pybat(script: 'pip install .', returnStdout: true)
-          pybat 'setup.py test --addopts --junit-xml=tests.xml'
+          pybat '''
+set BOOT2DOCKER_VM=default
+set PATH=%PATH%;"C:\Program Files\Docker Toolbox\"
+docker-machine start %BOOT2DOCKER_VM%
+REM Set the environment variables to use docker-machine and docker commands
+@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
+setup.py test --addopts --junit-xml=tests.xml
+'''
         }
 
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+  agent {
+    node {
+      label 'windows'
+    }
+
+  }
+  stages {
+    stage('build') {
+      steps {
+        bat 'python setup.py '
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ pylint_report.txt: ${PYSOURCES}
 diff_pylint_report: pylint_report.txt
 	diff-quality --violations=pylint pylint_report.txt
 
-.coverage: tests
+.coverage: testcov
 
 coverage: .coverage
 	coverage report
@@ -135,7 +135,11 @@ diff-cover.html: coverage-gcovr.xml coverage.xml
 		--html-report diff-cover.html
 
 ## test        : run the ${MODULE} test suite
-test: $(PYSOURCES)
+test: $(pysources)
+	python setup.py test
+
+## testcov     : run the ${MODULE} test suite and collect coverage
+testcov: $(pysources)
 	python setup.py test --addopts "--cov cwltool"
 
 sloccount.sc: ${PYSOURCES} Makefile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,10 @@ build_script:
 
 
 test_script:
-  - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider"
+  - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider --addopts --junit-xml=tests.xml"
+  - ps: >-
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,11 @@ install:
 build_script:
   - "%PYTHON%\\python.exe -m pip install ."
 
-
 test_script:
   - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider --junit-xml=tests.xml"
-  - ps: >-
+
+after_test:
+  - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($Env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ test_script:
   - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider --junit-xml=tests.xml"
   - ps: >-
       $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($Env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 
 
 test_script:
-  - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider --addopts --junit-xml=tests.xml"
+  - "%PYTHON%\\python.exe -m pytest --verbose -p no:cacheprovider --junit-xml=tests.xml"
   - ps: >-
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))

--- a/cwltool/factory.py
+++ b/cwltool/factory.py
@@ -38,7 +38,8 @@ class Factory(object):
                  makeTool=workflow.defaultMakeTool,  # type: tCallable[[Any], Process]
                  # should be tCallable[[Dict[Text, Any], Any], Process] ?
                  executor=None,  # type: tCallable[...,Tuple[Dict[Text,Any], Text]]
-                 **execkwargs  # type: Any
+                 makekwargs={},  # type: Dict[Any, Any]
+                 **execkwargs    # type: Dict[Any, Any]
                  ):
         # type: (...) -> None
         self.makeTool = makeTool
@@ -46,17 +47,19 @@ class Factory(object):
             executor = SingleJobExecutor()
         self.executor = executor
 
-        kwargs = get_default_args()
-        kwargs.pop("job_order")
-        kwargs.pop("workflow")
-        kwargs.pop("outdir")
-        kwargs.update(execkwargs)
-        self.execkwargs = kwargs
+        newExecKwargs = get_default_args()
+        newExecKwargs.pop("job_order")
+        newExecKwargs.pop("workflow")
+        newExecKwargs.pop("outdir")
+        newExecKwargs.update(execkwargs)
+        self.execkwargs = newExecKwargs
+        self.makekwargs = makekwargs
 
     def make(self, cwl):
         """Instantiate a CWL object from a CWl document."""
         load = load_tool.load_tool(cwl, self.makeTool,
-                                   strict=self.execkwargs.get("strict", True))
+                                   strict=self.execkwargs.get("strict", True),
+                                   kwargs=self.makekwargs)
         if isinstance(load, int):
             raise Exception("Error loading tool")
         return Callable(load, self)

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -1,6 +1,6 @@
 set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
 docker-machine start default
 REM Set the environment variables to use docker-machine and docker commands
-@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd default') DO @%i
+FOR /f "tokens=*" %%i IN ('docker-machine env --shell cmd default') DO %%i
 
 python setup.py test --addopts --junit-xml=tests.xml

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -1,7 +1,6 @@
-set BOOT2DOCKER_VM=default
 set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
-docker-machine start %BOOT2DOCKER_VM%
+docker-machine start default
 REM Set the environment variables to use docker-machine and docker commands
-@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%
+@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd default') DO @%i
 
 python setup.py test --addopts --junit-xml=tests.xml

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -2,6 +2,6 @@ set BOOT2DOCKER_VM=default
 set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
 docker-machine start %BOOT2DOCKER_VM%
 REM Set the environment variables to use docker-machine and docker commands
-@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
+@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%
 
 python setup.py test --addopts --junit-xml=tests.xml

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -1,0 +1,7 @@
+set BOOT2DOCKER_VM=default
+set PATH=%PATH%;"C:\\Program Files\\Docker Toolbox\\"
+docker-machine start %BOOT2DOCKER_VM%
+REM Set the environment variables to use docker-machine and docker commands
+@FOR /f "tokens=*" %i IN ('docker-machine env --shell cmd %BOOT2DOCKER_VM%') DO @%i
+
+python setup.py test --addopts --junit-xml=tests.xml

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -3,4 +3,6 @@ docker-machine start default
 REM Set the environment variables to use docker-machine and docker commands
 FOR /f "tokens=*" %%i IN ('docker-machine env --shell cmd default') DO %%i
 
-python setup.py test --addopts --junit-xml=tests.xml
+python setup.py test --addopts "--junit-xml=tests.xml --cov-report xml --cov cwltool"
+pip install codecov
+codecov

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -147,7 +147,7 @@ class TestFactory(unittest.TestCase):
             #    _find_default_container, windows_default_container_id)}
             opts = {'default_container': windows_default_container_id,
                     'use_container': True}
-         else:
+        else:
             opts = {}
         f = cwltool.factory.Factory(**opts)
         echo = f.make(get_data("tests/echo.cwl"))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import unittest
 import pytest
-import functools
 import subprocess
 from os import path
 import sys

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import unittest
 import pytest
+import functools
 import subprocess
 from os import path
 import sys

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -138,14 +138,13 @@ class TestParamMatching(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
 
-    #def _find_default_container(default_container_id, builder):
-    #    return default_container_id
+    def _find_default_container(default_container_id, builder):
+        return default_container_id
 
     def test_factory(self):
         if onWindows():
-            #opts = {'find_default_container': functools.partial(
-            #    _find_default_container, windows_default_container_id)}
-            opts = {'default_container': windows_default_container_id,
+            opts = {'find_default_container': functools.partial(
+                _find_default_container, windows_default_container_id),
                     'use_container': True}
         else:
             opts = {}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -138,7 +138,11 @@ class TestParamMatching(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
     def test_factory(self):
-        f = cwltool.factory.Factory()
+        if onWindows():
+            opts = {'default_container': windows_default_container_id}
+        else:
+            opts = {}
+        f = cwltool.factory.Factory(**opts)
         echo = f.make(get_data("tests/echo.cwl"))
         self.assertEqual(echo(inp="foo"), {"out": "foo\n"})
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -29,9 +29,9 @@ import cwltool.process
 import cwltool.workflow
 import schema_salad.validate
 from cwltool.main import main
-from cwltool.utils import onWindows, windows_default_container_id
+from cwltool.utils import onWindows
 
-from .util import get_data, needs_docker
+from .util import get_data, needs_docker, get_windows_safe_factory
 
 sys.argv = ['']
 
@@ -136,20 +136,10 @@ class TestParamMatching(unittest.TestCase):
         self.assertEqual(expr.interpolate("$(foo[\"b\\'ar\"].baz) $(foo[\"b\\'ar\"].baz)", inputs), "true true")
         self.assertEqual(expr.interpolate("$(foo['b\\\"ar'].baz) $(foo['b\\\"ar'].baz)", inputs), "null null")
 
-def _find_default_container(default_container_id, builder):
-   return default_container_id
-
-
 class TestFactory(unittest.TestCase):
 
     def test_factory(self):
-        if onWindows():
-            opts = {'find_default_container': functools.partial(
-                _find_default_container, windows_default_container_id),
-                    'use_container': True}
-        else:
-            opts = {}
-        f = cwltool.factory.Factory(**opts)
+        f = get_windows_safe_factory()
         echo = f.make(get_data("tests/echo.cwl"))
         self.assertEqual(echo(inp="foo"), {"out": "foo\n"})
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -137,10 +137,17 @@ class TestParamMatching(unittest.TestCase):
 
 
 class TestFactory(unittest.TestCase):
+
+    #def _find_default_container(default_container_id, builder):
+    #    return default_container_id
+
     def test_factory(self):
         if onWindows():
-            opts = {'default_container': windows_default_container_id}
-        else:
+            #opts = {'find_default_container': functools.partial(
+            #    _find_default_container, windows_default_container_id)}
+            opts = {'default_container': windows_default_container_id,
+                    'use_container': True}
+         else:
             opts = {}
         f = cwltool.factory.Factory(**opts)
         echo = f.make(get_data("tests/echo.cwl"))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,8 @@ import schema_salad.validate
 from cwltool.main import main
 from cwltool.utils import onWindows
 
-from .util import get_data, needs_docker, get_windows_safe_factory
+from .util import (get_data, needs_docker, get_windows_safe_factory,
+        windows_needs_docker)
 
 sys.argv = ['']
 
@@ -137,6 +138,7 @@ class TestParamMatching(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
 
+    @windows_needs_docker
     def test_factory(self):
         f = get_windows_safe_factory()
         echo = f.make(get_data("tests/echo.cwl"))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -136,11 +136,11 @@ class TestParamMatching(unittest.TestCase):
         self.assertEqual(expr.interpolate("$(foo[\"b\\'ar\"].baz) $(foo[\"b\\'ar\"].baz)", inputs), "true true")
         self.assertEqual(expr.interpolate("$(foo['b\\\"ar'].baz) $(foo['b\\\"ar'].baz)", inputs), "null null")
 
+def _find_default_container(default_container_id, builder):
+   return default_container_id
+
 
 class TestFactory(unittest.TestCase):
-
-    def _find_default_container(default_container_id, builder):
-        return default_container_id
 
     def test_factory(self):
         if onWindows():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -28,7 +28,7 @@ import cwltool.process
 import cwltool.workflow
 import schema_salad.validate
 from cwltool.main import main
-from cwltool.utils import onWindows
+from cwltool.utils import onWindows, windows_default_container_id
 
 from .util import get_data, needs_docker
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -12,6 +12,7 @@ from cwltool.load_tool import load_tool
 from cwltool.main import main
 from cwltool.workflow import defaultMakeTool
 from cwltool.resolver import resolve_local
+from cwltool.utils import onWindows
 
 if sys.version_info < (3, 4):
     from pathlib2 import Path
@@ -71,15 +72,25 @@ class ResolverTest(unittest.TestCase):
     def test_resolve_local(self):
         origpath = os.getcwd()
         os.chdir(os.path.join(get_data("")))
+        def norm(uri):
+            if onWindows():
+                return uri.lower()
+            else:
+                return uri
         try:
             root = Path.cwd()
             rooturi = root.as_uri()
-            self.assertEqual(rooturi+"/tests/echo.cwl", resolve_local(None, os.path.join("tests", "echo.cwl")))
-            self.assertEqual(rooturi+"/tests/echo.cwl#main", resolve_local(None, os.path.join("tests", "echo.cwl")+"#main"))
-            self.assertEqual(rooturi+"/tests/echo.cwl", resolve_local(None, str(root / "tests" / "echo.cwl")))
-            # On Windows and Python 2.7, the left side of this test returns
-            # file:///C:/ (uppercase drive letter) and the right side returns
-            # file:///c:/ (lowercase drive letter) so force a lowercase comparison.
-            self.assertEqual((rooturi+"/tests/echo.cwl#main").lower(), resolve_local(None, str(root / "tests" / "echo.cwl")+"#main").lower())
+            self.assertEqual(norm(rooturi+"/tests/echo.cwl"),
+                    norm(resolve_local(None, os.path.join("tests",
+                        "echo.cwl"))))
+            self.assertEqual(norm(rooturi+"/tests/echo.cwl#main"),
+                    norm(resolve_local(None, os.path.join("tests",
+                        "echo.cwl")+"#main")))
+            self.assertEqual(norm(rooturi+"/tests/echo.cwl"),
+                    norm(resolve_local(None, str(root / "tests" /
+                        "echo.cwl"))))
+            self.assertEqual(norm(rooturi+"/tests/echo.cwl#main"),
+                    norm(resolve_local(None, str(root / "tests" /
+                        "echo.cwl")+"#main")))
         finally:
             os.chdir(origpath)

--- a/tests/test_iwdr.py
+++ b/tests/test_iwdr.py
@@ -2,11 +2,12 @@ import unittest
 
 import cwltool
 import cwltool.factory
-from .util import get_data, get_windows_safe_factory
+from .util import get_data, get_windows_safe_factory, windows_needs_docker
 
 
 class TestInitialWorkDir(unittest.TestCase):
 
+    @windows_needs_docker
     def test_newline_in_entry(self):
         """
         test that files in InitialWorkingDirectory are created with a newline character

--- a/tests/test_iwdr.py
+++ b/tests/test_iwdr.py
@@ -2,7 +2,7 @@ import unittest
 
 import cwltool
 import cwltool.factory
-from .util import get_data
+from .util import get_data, get_windows_safe_factory
 
 
 class TestInitialWorkDir(unittest.TestCase):
@@ -11,6 +11,6 @@ class TestInitialWorkDir(unittest.TestCase):
         """
         test that files in InitialWorkingDirectory are created with a newline character
         """
-        f = cwltool.factory.Factory()
+        f = get_windows_safe_factory()
         echo = f.make(get_data("tests/wf/iwdr-entry.cwl"))
         self.assertEqual(echo(message="hello"), {"out": "CONFIGVAR=hello\n"})

--- a/tests/test_js_sandbox.py
+++ b/tests/test_js_sandbox.py
@@ -13,7 +13,7 @@ from cwltool.sandboxjs import (check_js_threshold_version,
                                exec_js_process)
 import cwltool.sandboxjs
 from cwltool.utils import onWindows
-from .util import get_data
+from .util import get_data, get_windows_safe_factory
 import pytest
 
 
@@ -48,7 +48,7 @@ class Javascript_Sanity_Checks(unittest.TestCase):
 class TestValueFrom(unittest.TestCase):
 
     def test_value_from_two_concatenated_expressions(self):
-        f = cwltool.factory.Factory()
+        f = get_windows_safe_factory()
         echo = f.make(get_data("tests/wf/vf-concat.cwl"))
         self.assertEqual(echo(), {u"out": u"a sting\n"})
 

--- a/tests/test_js_sandbox.py
+++ b/tests/test_js_sandbox.py
@@ -13,7 +13,7 @@ from cwltool.sandboxjs import (check_js_threshold_version,
                                exec_js_process)
 import cwltool.sandboxjs
 from cwltool.utils import onWindows
-from .util import get_data, get_windows_safe_factory
+from .util import get_data, get_windows_safe_factory, windows_needs_docker
 import pytest
 
 
@@ -47,6 +47,7 @@ class Javascript_Sanity_Checks(unittest.TestCase):
 
 class TestValueFrom(unittest.TestCase):
 
+    @windows_needs_docker
     def test_value_from_two_concatenated_expressions(self):
         f = get_windows_safe_factory()
         echo = f.make(get_data("tests/wf/vf-concat.cwl"))

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -7,7 +7,7 @@ import cwltool
 import cwltool.factory
 from cwltool.executors import MultithreadedJobExecutor
 from cwltool.utils import onWindows
-from .util import get_data
+from .util import get_data, get_windows_safe_factory
 
 
 class TestParallel(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestParallel(unittest.TestCase):
     def test_scattered_workflow(self):
         test_file = "tests/wf/scatter-wf4.cwl"
         job_file = "tests/wf/scatter-job2.json"
-        f = cwltool.factory.Factory(executor=MultithreadedJobExecutor())
+        f = get_windows_safe_factory(executor=MultithreadedJobExecutor())
         echo = f.make(get_data(test_file))
         with open(get_data(job_file)) as job:
             self.assertEqual(echo(**json.load(job)), {'out': ['foo one three', 'foo two four']})

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -14,7 +14,7 @@ class TestParallel(unittest.TestCase):
     @windows_needs_docker
     def test_sequential_workflow(self):
         test_file = "tests/wf/count-lines1-wf.cwl"
-        f = cwltool.factory.Factory(executor=MultithreadedJobExecutor())
+        f = get_windows_safe_factory(executor=MultithreadedJobExecutor())
         echo = f.make(get_data(test_file))
         self.assertEqual(echo(file1= {
                 "class": "File",

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -7,13 +7,11 @@ import cwltool
 import cwltool.factory
 from cwltool.executors import MultithreadedJobExecutor
 from cwltool.utils import onWindows
-from .util import get_data, get_windows_safe_factory
+from .util import get_data, get_windows_safe_factory, windows_needs_docker
 
 
 class TestParallel(unittest.TestCase):
-    @pytest.mark.skipif(onWindows(),
-                        reason="Unexplainable behavior: cwltool on AppVeyor does not recognize cwlVersion"
-                               "in count-lines1-wf.cwl")
+    @windows_needs_docker
     def test_sequential_workflow(self):
         test_file = "tests/wf/count-lines1-wf.cwl"
         f = cwltool.factory.Factory(executor=MultithreadedJobExecutor())
@@ -24,6 +22,7 @@ class TestParallel(unittest.TestCase):
             }),
             {"count_output": 16})
 
+    @windows_needs_docker
     def test_scattered_workflow(self):
         test_file = "tests/wf/scatter-wf4.cwl"
         job_file = "tests/wf/scatter-job2.json"

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -73,9 +73,6 @@ outputs: []
             f.close()
             self.assertEquals(main(["--debug", f.name, '--input',
                 get_data('tests/echo.cwl')]), 0)
-            self.assertEquals(main(["--debug", f.name, '--input',
-                get_data('tests/echo.cwl')]), 0)
-
 
     @needs_docker
     def test_bool(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 import os
+import functools
 
 from pkg_resources import (Requirement, ResolutionError,  # type: ignore
                            resource_filename)
 import distutils.spawn
 import pytest
 
-from cwltool.utils import onWindows
+from cwltool.utils import onWindows, windows_default_container_id
 from cwltool.factory import Factory
 
 def get_windows_safe_factory(**execkwargs):

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,6 +6,22 @@ from pkg_resources import (Requirement, ResolutionError,  # type: ignore
 import distutils.spawn
 import pytest
 
+from cwltool.utils import onWindows
+from cwltool.factory import Factory
+
+def get_windows_safe_factory(**execkwargs):
+    if onWindows():
+        opts = {'find_default_container': functools.partial(
+            force_default_container, windows_default_container_id),
+                'use_container': True,
+                'default_container': windows_default_container_id}
+    else:
+        opts = {}
+    return Factory(makekwargs=opts, **execkwargs)
+
+def force_default_container(default_container_id, builder):
+   return default_container_id
+
 def get_data(filename):
     filename = os.path.normpath(
         filename)  # normalizing path depending on OS or else it will cause problem when joining path

--- a/tests/util.py
+++ b/tests/util.py
@@ -15,9 +15,9 @@ def get_windows_safe_factory(**execkwargs):
         makekwargs = {'find_default_container': functools.partial(
             force_default_container, windows_default_container_id),
                       'use_container': True}
-        execkwargs['default_container': windows_default_container_id]
+        execkwargs['default_container'] = windows_default_container_id
     else:
-        opts = {}
+        makekwargs = {}
     return Factory(makekwargs=makekwargs, **execkwargs)
 
 def force_default_container(default_container_id, builder):

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,13 +12,13 @@ from cwltool.factory import Factory
 
 def get_windows_safe_factory(**execkwargs):
     if onWindows():
-        opts = {'find_default_container': functools.partial(
+        makekwargs = {'find_default_container': functools.partial(
             force_default_container, windows_default_container_id),
-                'use_container': True,
-                'default_container': windows_default_container_id}
+                      'use_container': True}
+        execkwargs['default_container': windows_default_container_id]
     else:
         opts = {}
-    return Factory(makekwargs=opts, **execkwargs)
+    return Factory(makekwargs=makekwargs, **execkwargs)
 
 def force_default_container(default_container_id, builder):
    return default_container_id

--- a/tests/util.py
+++ b/tests/util.py
@@ -43,3 +43,8 @@ def get_data(filename):
 needs_docker = pytest.mark.skipif(not bool(distutils.spawn.find_executable('docker')),
                                   reason="Requires the docker executable on the "
                                   "system path.")
+
+windows_needs_docker = pytest.mark.skipif(
+        onWindows() and not bool(distutils.spawn.find_executable('docker')),
+        reason="Running this test on MS Windows requires the docker executable "
+        "on the system path.")


### PR DESCRIPTION
- Runs tests on real Windows 7 system with Docker Toolkit (ci03.commonwl.org)
- Better error message if an input file/directory is on a path not mounted into the Docker VM
- Factory gains a parameter to customize the kwargs sent to load_tool/make_tool
- `make test` no longer collects coverage
- Test results are collected on Appveyor; not just overall pass/fail