### PR TITLE
Fix for issue #743, less stringent exception handling.

### DIFF
--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -75,13 +75,8 @@ def new_js_proc(js_text, force_docker_pull=False):
 
                 required_node_version = check_js_threshold_version(n)
                 break
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             pass
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                pass
-            else:
-                raise
 
     if nodejs is None or nodejs is not None and required_node_version is False:
         try:


### PR DESCRIPTION
There is no need to care what error has idiosyncratically been thrown, the only thing that matters is that the execution does not succeed.

Fixes #743 