### PR TITLE
Include subprocess32 when building for Mac OS X.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ shellescape>=3.4.1,<3.5
 schema-salad>=2.6.20170927145003,<3
 typing>=3.5.3
 pathlib2==2.3.2; python_version<"3"
-subprocess32 >= 3.5.0; platform_system=="Linux"
+subprocess32 >= 3.5.0; os.name=="posix"
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name='cwltool',
           'six >= 1.8.0',
       ],
       extras_require={
-          ':platform_system=="Linux"': ['subprocess32 >= 3.5.0'],
+          ':os.name=="posix"': ['subprocess32 >= 3.5.0'],
           ':python_version<"3"': ['pathlib2 == 2.3.2'],
           'deps': ["galaxy-lib >= 17.09.3"]
       },


### PR DESCRIPTION
The code gates imports on os.name == "posix", so the dependency gates should match right? I'm guessing pip installing subprocess32 locally fixing problems means this was likely an issue - but let me know if this doesn't make sense.