### PR TITLE
Handle situations where unique part of the url is in the query.

### DIFF
--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -72,8 +72,10 @@ def normalizeFilesDirs(job):
             d["location"] = urllib.parse.urlunparse((parse.scheme, parse.netloc, path, parse.params, parse.query, parse.fragment))
 
         if "basename" not in d:
-            if parse.query:
-                d["basename"] = os.path.basename(urllib.request.url2pathname(path)) + "?" + urllib.parse.quote(parse.query, safe="")
+            if parse.scheme != "file":
+                d["basename"] = urllib.parse.quote(parse.netloc + parse.path, safe="")
+                if parse.query:
+                    d["basename"] += urllib.parse.quote("?"+parse.query, safe="")
             else:
                 d["basename"] = os.path.basename(urllib.request.url2pathname(path))
 

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -72,7 +72,10 @@ def normalizeFilesDirs(job):
             d["location"] = urllib.parse.urlunparse((parse.scheme, parse.netloc, path, parse.params, parse.query, parse.fragment))
 
         if "basename" not in d:
-            d["basename"] = os.path.basename(urllib.request.url2pathname(path))
+            if parse.query:
+                d["basename"] = os.path.basename(urllib.request.url2pathname(path)) + "?" + urllib.parse.quote(parse.query, safe="")
+            else:
+                d["basename"] = os.path.basename(urllib.request.url2pathname(path))
 
         if d["class"] == "File":
             d["nameroot"], d["nameext"] = os.path.splitext(d["basename"])

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -72,7 +72,7 @@ def normalizeFilesDirs(job):
             d["location"] = urllib.parse.urlunparse((parse.scheme, parse.netloc, path, parse.params, parse.query, parse.fragment))
 
         if "basename" not in d:
-            if parse.scheme != "file":
+            if parse.scheme and parse.scheme != "file":
                 d["basename"] = urllib.parse.quote(parse.netloc + parse.path, safe="")
                 if parse.query:
                     d["basename"] += urllib.parse.quote("?"+parse.query, safe="")


### PR DESCRIPTION
If present, include query part to generated basename in
normalizeFilesDirs.