### PR TITLE
Fix typo in factory usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ The easiest way to use cwltool to run a tool or workflow from Python is to use a
   import cwltool.factory
   fac = cwltool.factory.Factory()
 
-  echo = f.make("echo.cwl")
+  echo = fac.make("echo.cwl")
   result = echo(inp="foo")
 
   # result["out"] == "foo"


### PR DESCRIPTION
## Question

How to force factory `make` method to resolve `File` `path` as it's done in the reference `cwl-runner`?

I'm getting following exception:
```
WorkflowException: Invalid job input record:
Anonymous file object must have 'contents' and 'basename' fields.
```