### PR TITLE
Add poll interval

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -25,6 +25,10 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         help="[experimental] Run jobs in parallel. "
                              "Does not currently keep track of ResourceRequirements like the number of cores"
                              "or memory and can overload this system")
+
+    parser.add_argument("--poll-interval", type=float, default=0,
+                        help="Delay polling of nodes to avoid hammering CPU in parallel workflows")
+
     envgroup = parser.add_mutually_exclusive_group()
     envgroup.add_argument("--preserve-environment", type=Text, action="append",
                         help="Preserve specific environment variable when "

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -70,6 +70,8 @@ class RuntimeContext(ContextBase):
         self.use_container = True       # type: bool
         self.force_docker_pull = False  # type: bool
 
+        self.poll_interval = 0          # type: float
+
         self.tmp_outdir_prefix = DEFAULT_TMP_PREFIX  # type: Text
         self.tmpdir_prefix = DEFAULT_TMP_PREFIX  # type: Text
         self.tmpdir = ""                # type: Text

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import tempfile
 import threading
 from abc import ABCMeta, abstractmethod
@@ -182,6 +183,9 @@ class MultithreadedJobExecutor(JobExecutor):
                 else:
                     logger.error("Workflow cannot make any more progress.")
                     break
+
+                time.sleep(runtimeContext.poll_interval)
+                # Don't let CWLtool hammer the CPU
 
         while self.threads:
             self.wait_for_next_completion()

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -5,7 +5,6 @@ import functools
 import logging
 import random
 import tempfile
-import time
 from collections import namedtuple
 from typing import (Any, Callable, Dict,  # pylint: disable=unused-import
                     Generator, Iterable, List, Optional,
@@ -444,9 +443,6 @@ class WorkflowJob(object):
                     break
                 else:
                     yield None
-
-            time.sleep(runtimeContext.poll_interval)
-            # Don't let CWLtool hammer the CPU
 
         if not self.did_callback:
             self.do_output_callback(output_callback)

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import random
 import tempfile
+import time
 from collections import namedtuple
 from typing import (Any, Callable, Dict,  # pylint: disable=unused-import
                     Generator, Iterable, List, Optional,
@@ -443,6 +444,9 @@ class WorkflowJob(object):
                     break
                 else:
                     yield None
+
+            time.sleep(runtimeContext.poll_interval)
+            # Don't let CWLtool hammer the CPU
 
         if not self.did_callback:
             self.do_output_callback(output_callback)


### PR DESCRIPTION
This saves CWLtool from hammering the CPU when running
a workflow with parallel components