### PR TITLE
Improve Research Object manifest

### DIFF
--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -1020,8 +1020,10 @@ class ResearchObject():
         })
 
         # How was it run?
+        # FIXME: Only primary*
         prov_files = [posixpath.relpath(p, METADATA) for p in self.tagfiles
-                      if p.startswith(_posix_path(PROVENANCE))]
+                      if p.startswith(_posix_path(PROVENANCE))
+                         and "/primary." in p]
         annotations.append({
             "uri": uuid.uuid4().urn,
             "about": self.workflow_run_uri,

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -187,8 +187,6 @@ class WritableBagFile(io.FileIO):
         # FIXME: Convert below block to a ResearchObject method?
         if self.rel_path.startswith("data/"):
             self.research_object.bagged_size[self.rel_path] = self.tell()
-        elif self.rel_path.startswith("metadata/"):
-            pass
         else:
             self.research_object.tagfiles.add(self.rel_path)
 
@@ -1080,7 +1078,6 @@ class ResearchObject():
         manifest["manifest"] = filename
         manifest.update(self._self_made())
         manifest.update(self._authored_by())
-
         manifest["aggregates"] = self._ro_aggregates()
         manifest["annotations"] = self._ro_annotations()
 

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -943,7 +943,7 @@ class ResearchObject():
                     and extension in prov_conforms_to):
                 if ".cwlprov" in rel_path:
                     # Our own!
-                    local_aggregate["conformsTo"] = [prov_conforms_to[extension], __citation__]
+                    local_aggregate["conformsTo"] = [prov_conforms_to[extension], CWLPROV_VERSION]
                 else:
                     # Some other PROV
                     # TODO: Recognize ProvOne etc.

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -1035,15 +1035,15 @@ class ResearchObject():
         # Where is the main workflow?
         annotations.append({
             "uri": uuid.uuid4().urn,
-            "about": posixpath.join(WORKFLOW, "packed.cwl"),
+            "about": posixpath.join("..", WORKFLOW, "packed.cwl"),
             "oa:motivatedBy": {"@id": "oa:highlighting"}
         })
 
         annotations.append({
             "uri": uuid.uuid4().urn,
             "about": self.workflow_run_uri,
-            "content": [posixpath.join(WORKFLOW, "packed.cwl"),
-                        posixpath.join(WORKFLOW, "primary-job.json")],
+            "content": [posixpath.join("..", WORKFLOW, "packed.cwl"),
+                        posixpath.join("..", WORKFLOW, "primary-job.json")],
             "oa:motivatedBy": {"@id": "oa:linking"}
         })
 


### PR DESCRIPTION
This PR ensure that `metadata/` **is** included in the RO `metadata/manifest.json`, including then `metadata/provenance/primary.cwlprov.provn` and friends.  Note that  `metadata/manifest.json` itself is **not** included in its own aggregation, but should be (and is) included in the `tagmanifest*` files.

As well this PR fixes some relative paths in the generated manifest, they need `../` to access `workflow/` etc as the manifest file resides inside `metadata/`.

The `conformsTo` for cwlprov files is also set to CWLPROV_VERSION (aka https://w3id.org/cwl/prov/0.3.0) rather than the `__citation__` DOI.  

This may however add confusion as to if this profile specifies the RO structure or the structure of the PROV files, but the PROV files also say they conformTo their corresponding PROV spec, e.g. (shortened):

```json
        {
            "uri": "provenance/primary.cwlprov.nt",
            "mediatype": "application/n-triples",
            "conformsTo": [
                "http://www.w3.org/TR/2013/REC-prov-o-20130430/",
                "https://w3id.org/cwl/prov/0.3.0"
            ]
        },
```