### PR TITLE
Print input and output objects for workflow when debugging

### DIFF
--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -253,6 +253,7 @@ class WorkflowJob(object):
                 datetime.datetime.now())
             self.prov_obj.finalize_prov_profile(str(self.name))
         _logger.info(u"[%s] completed %s", self.name, self.processStatus)
+        _logger.debug(u"[%s] %s", self.name, json_dumps(wo, indent=4))
 
         self.did_callback = True
 
@@ -412,6 +413,9 @@ class WorkflowJob(object):
            ):  # type: (...) -> Generator
         self.state = {}
         self.processStatus = "success"
+
+        _logger.debug(u"[%s] %s", self.name, json_dumps(joborder,
+                                                        indent=4))
 
         runtimeContext = runtimeContext.copy()
         runtimeContext.outdir = None


### PR DESCRIPTION
`cwltool` prints input and output object when `--debug` is specified for CommandLineTool.
For example:

```console
$ cwltool --debug echo.cwl
...
[job echo.cwl] initializing from file:///Users/tom-tan/echo.cwl
[job echo.cwl] {
    "input": null
}
...
[job echo.cwl] completed success
[job echo.cwl] {
    "output": {
        "location": "file:///private/tmp/docker_tmpxrsdnrm2/output",
        "basename": "output",
        "nameroot": "output",
        "nameext": "",
        "class": "File",
        "checksum": "sha1$834e8481813a87f4c25882bda3cd43808d6541aa",
        "size": 365,
        "http://commonwl.org/cwltool#generation": 0
    }
}
...
{
    "output": {
        "location": "file:///Users/tom-tan/output",
        "basename": "output",
        "class": "File",
        "checksum": "sha1$834e8481813a87f4c25882bda3cd43808d6541aa",
        "size": 365,
        "path": "/Users/tom-tan/output"
    }
}
Final process status is success
```

However, `cwltool` does not print input and output object for Workflow.

This request fixes this issue.
This change makes the output more consistent with CommandLineTool and Workfow, and it makes us easier to investigate the execution result by using debug output.
