### PR TITLE
Replace `cidfile_` with `cidfile_dir`

### DIFF
--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -339,7 +339,7 @@ class DockerCommandLineJob(ContainerCommandLineJob):
 
         # add parameters to docker to write a container ID file
         if runtimeContext.record_container_id:
-            cidfile_dir = runtimeContext.cidfile_
+            cidfile_dir = runtimeContext.cidfile_dir
             if cidfile_dir != "":
                 if not os.path.isdir(cidfile_dir):
                     _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,


### PR DESCRIPTION
This request is for #838.
It just replace `cidfile_` with `cidfile_dir` to fix a typo.
