### PR TITLE
Kill child processes when cwltool exits

### DIFF
--- a/cwltool.py
+++ b/cwltool.py
@@ -11,4 +11,4 @@ import sys
 from cwltool import main
 
 if __name__ == "__main__":
-    sys.exit(main.main(sys.argv[1:]))
+    main.run(sys.argv[1:])

--- a/cwltool/__main__.py
+++ b/cwltool/__main__.py
@@ -4,4 +4,4 @@ import sys
 
 from . import main
 
-sys.exit(main.main())
+main.run()

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -31,7 +31,7 @@ from .secrets import SecretStore  # pylint: disable=unused-import
 from .utils import bytes2str_in_dicts  # pylint: disable=unused-import
 from .utils import (  # pylint: disable=unused-import
     DEFAULT_TMP_PREFIX, Directory, copytree_with_merge, json_dump, json_dumps,
-    onWindows, subprocess)
+    onWindows, subprocess, processes_to_kill)
 from .context import (RuntimeContext,  # pylint: disable=unused-import
                       getdefault)
 if TYPE_CHECKING:
@@ -521,6 +521,7 @@ def _job_popen(
                                  stderr=stderr,
                                  env=env,
                                  cwd=cwd)
+        processes_to_kill.append(sproc)
 
         if sproc.stdin:
             sproc.stdin.close()
@@ -589,6 +590,7 @@ def _job_popen(
                 stderr=sys.stderr,
                 stdin=subprocess.PIPE,
             )
+            processes_to_kill.append(sproc)
             if sproc.stdin:
                 sproc.stdin.close()
 

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -534,6 +534,7 @@ def _job_popen(
                 except OSError:
                     pass
             tm = Timer(timelimit, terminate)
+            tm.daemon = True
             tm.start()
 
         rcode = sproc.wait()

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -55,6 +55,7 @@ from .builder import HasReqsHints
 
 
 def _terminate_processes():
+    # type: () -> None
     """Kill all spawned processes.
 
     Processes to be killed must be appended to `utils.processes_to_kill`
@@ -72,6 +73,7 @@ def _terminate_processes():
 
 
 def _signal_handler(signum, frame):
+    # type: (int, Any) -> None
     """Kill all spawned processes and exit.
 
     Note that it's possible for another thread to spawn a process after

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -713,6 +713,7 @@ def find_default_container(builder,                  # type: HasReqsHints
 
 
 def run(*args, **kwargs):
+    # type: (...) -> None
     """Run cwltool."""
     signal.signal(signal.SIGTERM, _signal_handler)
     try:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -10,11 +10,12 @@ import functools
 import io
 import logging
 import os
+import signal
 import sys
 
 from typing import (IO, Any, Callable, Dict,  # pylint: disable=unused-import
-                    Iterable, List, Mapping, MutableMapping, Optional, Text,
-                    TextIO, Tuple, Union, cast)
+                    Deque, Iterable, List, Mapping, MutableMapping, Optional,
+                    Text, TextIO, Tuple, Union, cast)
 import pkg_resources  # part of setuptools
 import ruamel.yaml as yaml
 import schema_salad.validate as validate
@@ -47,9 +48,40 @@ from .software_requirements import (DependenciesConfiguration,
 from .stdfsaccess import StdFsAccess
 from .update import ALLUPDATES, UPDATES
 from .utils import (DEFAULT_TMP_PREFIX, add_sizes, json_dumps, onWindows,
-                    versionstring, windows_default_container_id)
+                    versionstring, windows_default_container_id,
+                    processes_to_kill)
 from .context import LoadingContext, RuntimeContext, getdefault
 from .builder import HasReqsHints
+
+
+def _terminate_processes():
+    """Kill all spawned processes.
+
+    Processes to be killed must be appended to `utils.processes_to_kill`
+    as they are spawned.
+
+    An important caveat: since there's no supported way to kill another
+    thread in Python, this function cannot stop other threads from
+    continuing to execute while it kills the processes that they've
+    spawned. This may occasionally lead to unexpected behaviour.
+    """
+    # It's possible that another thread will spawn a new task while
+    # we're executing, so it's not safe to use a for loop here.
+    while processes_to_kill:
+        processes_to_kill.popleft().kill()
+
+
+def _signal_handler(signum, frame):
+    """Kill all spawned processes and exit.
+
+    Note that it's possible for another thread to spawn a process after
+    all processes have been killed, but before Python exits.
+
+    Refer to the docstring for _terminate_processes() for other caveats.
+    """
+    _terminate_processes()
+    sys.exit(signum)
+
 
 def generate_example_input(inptype):
     # type: (Union[Text, Dict[Text, Any]]) -> Any
@@ -680,5 +712,14 @@ def find_default_container(builder,                  # type: HasReqsHints
     return default_container
 
 
+def run(*args, **kwargs):
+    """Run cwltool."""
+    signal.signal(signal.SIGTERM, _signal_handler)
+    try:
+        sys.exit(main(*args, **kwargs))
+    finally:
+        _terminate_processes()
+
+
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    run(sys.argv[1:])

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -14,8 +14,8 @@ import signal
 import sys
 
 from typing import (IO, Any, Callable, Dict,  # pylint: disable=unused-import
-                    Deque, Iterable, List, Mapping, MutableMapping, Optional,
-                    Text, TextIO, Tuple, Union, cast)
+                    Iterable, List, Mapping, MutableMapping, Optional, Text,
+                    TextIO, Tuple, Union, cast)
 import pkg_resources  # part of setuptools
 import ruamel.yaml as yaml
 import schema_salad.validate as validate

--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -181,6 +181,7 @@ def exec_js_process(js_text,                  # type: Text
         timeout = 20
 
     tm = threading.Timer(timeout, terminate)
+    tm.daemon = True
     tm.start()
 
     stdin_text = u""

--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Mapping, Text, Tuple, Union
 import six
 from pkg_resources import resource_stream
 
-from .utils import json_dumps, onWindows, subprocess
+from .utils import json_dumps, onWindows, subprocess, processes_to_kill
 
 try:
     import queue  # type: ignore
@@ -71,7 +71,7 @@ def new_js_proc(js_text, force_docker_pull=False):
                                           stdin=subprocess.PIPE,
                                           stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)
-
+                processes_to_kill.append(nodejs)
                 required_node_version = check_js_threshold_version(n)
                 break
         except (subprocess.CalledProcessError, OSError):
@@ -95,6 +95,7 @@ def new_js_proc(js_text, force_docker_pull=False):
                                        "--sig-proxy=true", "--interactive",
                                        "--rm", nodeimg, "node", "--eval", js_text],
                                       stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            processes_to_kill.append(nodejs)
             docker = True
         except OSError as e:
             if e.errno == errno.ENOENT:

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -10,11 +10,8 @@ import stat
 import pkg_resources
 from functools import partial  # pylint: disable=unused-import
 from typing import (IO, Any, AnyStr, Callable,  # pylint: disable=unused-import
-                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union,
-                    TYPE_CHECKING)
-
-if TYPE_CHECKING:
-    from typing import Deque
+                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union)
+from typing_extensions import Deque
 
 import six
 from six.moves import urllib, zip_longest

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -10,8 +10,7 @@ import stat
 import pkg_resources
 from functools import partial  # pylint: disable=unused-import
 from typing import (IO, Any, AnyStr, Callable,  # pylint: disable=unused-import
-                    Deque, Dict, Iterable, List, Optional, Text, Tuple, TypeVar,
-                    Union)
+                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union)
 
 import six
 from six.moves import urllib, zip_longest
@@ -33,7 +32,7 @@ Directory = TypedDict('Directory',
 
 DEFAULT_TMP_PREFIX = "tmp"
 
-processes_to_kill = collections.deque()  # type: Deque[subprocess.Popen]
+processes_to_kill = collections.deque()  # type: collections.deque[subprocess.Popen]
 
 def versionstring():
     # type: () -> Text

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import collections
 import json
 import os
 import sys
@@ -9,7 +10,7 @@ import stat
 import pkg_resources
 from functools import partial  # pylint: disable=unused-import
 from typing import (IO, Any, AnyStr, Callable,  # pylint: disable=unused-import
-                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar,
+                    Deque, Dict, Iterable, List, Optional, Text, Tuple, TypeVar,
                     Union)
 
 import six
@@ -31,6 +32,8 @@ Directory = TypedDict('Directory',
                        'basename': Text})
 
 DEFAULT_TMP_PREFIX = "tmp"
+
+processes_to_kill = collections.deque()  # type: Deque[subprocess.Popen]
 
 def versionstring():
     # type: () -> Text

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -10,7 +10,11 @@ import stat
 import pkg_resources
 from functools import partial  # pylint: disable=unused-import
 from typing import (IO, Any, AnyStr, Callable,  # pylint: disable=unused-import
-                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union)
+                    Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union,
+                    TYPE_CHECKING)
+
+if TYPE_CHECKING:
+    from typing import Deque
 
 import six
 from six.moves import urllib, zip_longest
@@ -32,7 +36,7 @@ Directory = TypedDict('Directory',
 
 DEFAULT_TMP_PREFIX = "tmp"
 
-processes_to_kill = collections.deque()  # type: collections.deque[subprocess.Popen]
+processes_to_kill = collections.deque()  # type: Deque[subprocess.Popen]
 
 def versionstring():
     # type: () -> Text

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ bagit==1.6.4
 mypy-extensions
 psutil
 subprocess32 >= 3.5.0; os.name=="posix"
+typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(name='cwltool',
       test_suite='tests',
       tests_require=['pytest', 'mock >= 2.0.0', 'arcp >= 0.2.0', 'rdflib-jsonld >= 0.4.0'],
       entry_points={
-          'console_scripts': ["cwltool=cwltool.main:main"]
+          'console_scripts': ["cwltool=cwltool.main:run"]
       },
       zip_safe=True,
       cmdclass={'egg_info': tagger},

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(name='cwltool',
           'psutil',
           'prov == 1.5.1',
           'bagit >= 1.6.4',
+          'typing-extensions',
       ],
       extras_require={
           ':os.name=="posix"': ['subprocess32 >= 3.5.0'],


### PR DESCRIPTION
(This is a bit of an ugly solution, but I can't see a better way to do it.)

As processes are spawned, they are added to a global list of processes (`utils.processes_to_kill`); when the program exits (either due to execution finishing, an exception being raised, or SIGTERM), `_terminate_processes` is called, and kills all the processes in that list. A new entrypoint `run` is added to do the necessary try/finally to make this happen.

Caveats:

- since Python doesn't allow to kill individual threads, those threads can continue to execute while we're pulling the rug from under their feet, potentially leading to unexpected behaviour
- there's always the chance that a thread could spawn a process after we've killed all the processes, but before Python exits (though this should be very rare)

Alternatives:

- we could [use process groups](https://stackoverflow.com/a/322317/5951320), but that doesn't work on Windows, and also means that cwltool has to SIGKILL itself to kill its children
- there's a way to [use prctl](https://stackoverflow.com/a/27295927/5951320) to get the kernel to send a child process an arbitrary signal when its parent dies, but it's Linux-only and doesn't necessarily work as desired with multiple threads (and also requires using `preexec_fn`, which can lead to deadlocks when there are multiple threads around)

Questions:

- Do we need to handle any signals apart from SIGTERM? SIGINT should already be handled by producing a KeyboardInterrupt.
- Should we send SIGTERM to child processes before SIGKILL, or is the extra complexity for that not worth it?

Fixes #832, fixes #833.