### PR TITLE
Fix typo in error message

### DIFF
--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -344,7 +344,7 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             if cidfile_dir != "":
                 if not os.path.isdir(cidfile_dir):
                     _logger.error("--cidfile-dir %s error:\n%s", cidfile_dir,
-                                  cidfile_dir + "%s is not a directory or "
+                                  cidfile_dir + " is not a directory or "
                                   "directory doesn't exist, please check it first")
                     exit(2)
                 if not os.path.exists(cidfile_dir):


### PR DESCRIPTION
This request fixes a typo in an error message in the following case.

### Before merging this request
```console
# It tries to make cidfiles to $PWD/out but no such directory.
$ cwltool --debug --leave-container --timestamps --compute-checksum --record-container-id --cidfile-dir $PWD/out --outdir $PWD/out ~/common-workflow-language/v1.0/v1.0/search.cwl ~/common-workflow-language/v1.0/v1.0/search-job.json
[2018-08-29 14:21:26] /Users/tom-tan/.pyenv/versions/3.6.5/bin/cwltool 1.0.20180820141117
...
[2018-08-29 14:21:28] --cidfile-dir /Users/tom-tan/out error:
/Users/tom-tan/out%s is not a directory or directory doesn't exist, please check it first
```
In the last line, the error message accidentally contains `%s`.

### After merging this request
```console
$ cwltool --debug --leave-container --timestamps --compute-checksum --record-container-id --cidfile-dir $PWD/out --outdir $PWD/out ~/common-workflow-language/v1.0/v1.0/search.cwl ~/common-workflow-language/v1.0/v1.0/search-job.json
[2018-08-29 14:23:47] /Users/tom-tan/.pyenv/versions/3.6.5/bin/cwltool 1.0.20180827165445
...
[2018-08-29 14:23:49] --cidfile-dir /Users/tom-tan/out error:
/Users/tom-tan/out is not a directory or directory doesn't exist, please check it first
```