### PR TITLE
Delete intermediate outputs even when they exist

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -97,8 +97,9 @@ class JobExecutor(six.with_metaclass(ABCMeta, object)):
                 path_mapper=runtime_context.path_mapper)
 
         if runtime_context.rm_tmpdir:
-            if runtime_context.cachedir is not None:
-                cleanIntermediate(filter(lambda x: not x.startswith(runtime_context.cachedir), self.output_dirs))
+          cachedir = runtime_context.cachedir
+            if cachedir is not None:
+                cleanIntermediate(filter(lambda x: not x.startswith(cachedir), self.output_dirs))
             else:
                 cleanIntermediate(self.output_dirs)
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -97,7 +97,7 @@ class JobExecutor(six.with_metaclass(ABCMeta, object)):
                 path_mapper=runtime_context.path_mapper)
 
         if runtime_context.rm_tmpdir:
-            cleanIntermediate(filter(lambda x: x != runtime_context.cachedir, self.output_dirs))
+            cleanIntermediate(filter(lambda x: not x.startswith(runtime_context.cachedir), self.output_dirs))
 
         if self.final_output and self.final_status:
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -5,7 +5,7 @@ import tempfile
 import threading
 from abc import ABCMeta, abstractmethod
 import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 from typing_extensions import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
@@ -97,11 +97,11 @@ class JobExecutor(six.with_metaclass(ABCMeta, object)):
                 path_mapper=runtime_context.path_mapper)
 
         if runtime_context.rm_tmpdir:
-          cachedir = runtime_context.cachedir
-            if cachedir is not None:
-                cleanIntermediate(filter(lambda x: not x.startswith(cachedir), self.output_dirs))
+            if runtime_context.cachedir is None:
+                output_dirs = self.output_dirs # type: Iterable[Any]
             else:
-                cleanIntermediate(self.output_dirs)
+                output_dirs = filter(lambda x: not x.startswith(runtime_context.cachedir), self.output_dirs)
+            cleanIntermediate(output_dirs)
 
         if self.final_output and self.final_status:
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -97,7 +97,7 @@ class JobExecutor(six.with_metaclass(ABCMeta, object)):
                 path_mapper=runtime_context.path_mapper)
 
         if runtime_context.rm_tmpdir:
-            cleanIntermediate(self.output_dirs)
+            cleanIntermediate(filter(lambda x: x != runtime_context.cachedir, self.output_dirs))
 
         if self.final_output and self.final_status:
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -97,7 +97,10 @@ class JobExecutor(six.with_metaclass(ABCMeta, object)):
                 path_mapper=runtime_context.path_mapper)
 
         if runtime_context.rm_tmpdir:
-            cleanIntermediate(filter(lambda x: not x.startswith(runtime_context.cachedir), self.output_dirs))
+            if runtime_context.cachedir is not None:
+                cleanIntermediate(filter(lambda x: not x.startswith(runtime_context.cachedir), self.output_dirs))
+            else:
+                cleanIntermediate(self.output_dirs)
 
         if self.final_output and self.final_status:
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -375,7 +375,7 @@ def relocateOutputs(outputObj,             # type: Union[Dict[Text, Any],List[Di
     return outputObj
 
 
-def cleanIntermediate(output_dirs):  # type: (Set[Text]) -> None
+def cleanIntermediate(output_dirs):  # type: (Iterable[Text]) -> None
     for a in output_dirs:
         if os.path.exists(a):
             _logger.debug(u"Removing intermediate output directory %s", a)

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -377,7 +377,7 @@ def relocateOutputs(outputObj,             # type: Union[Dict[Text, Any],List[Di
 
 def cleanIntermediate(output_dirs):  # type: (Set[Text]) -> None
     for a in output_dirs:
-        if os.path.exists(a) and empty_subtree(a):
+        if os.path.exists(a):
             _logger.debug(u"Removing intermediate output directory %s", a)
             shutil.rmtree(a, True)
 


### PR DESCRIPTION
Fixes #892.

The current behaviour goes back to at least cwltool version
1.0.20170723124118.