### PR TITLE
glob tweak

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -655,8 +655,6 @@ class CommandLineTool(Process):
                     for gb in globpatterns:
                         if gb.startswith(outdir):
                             gb = gb[len(outdir) + 1:]
-                        elif gb == ".":
-                            gb = outdir
                         elif gb.startswith("/"):
                             raise WorkflowException(
                                 "glob patterns must not start with '/'")


### PR DESCRIPTION
Otherwise fs_access.join has to implement some extra weird behavior:

https://docs.python.org/2/library/os.path.html#os.path.join
> If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.