### PR TITLE
extract/execute workflow subgraph

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -167,6 +167,7 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--version", action="store_true", help="Print version and exit")
     exgroup.add_argument("--validate", action="store_true", help="Validate CWL document only.")
     exgroup.add_argument("--print-supported-versions", action="store_true", help="Print supported CWL specs.")
+    exgroup.add_argument("--extract-subgraph", type=str, help="Extract subgraph containing one or more nodes named from comma-separated list.")
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--strict", action="store_true",

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -167,7 +167,10 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument("--version", action="store_true", help="Print version and exit")
     exgroup.add_argument("--validate", action="store_true", help="Validate CWL document only.")
     exgroup.add_argument("--print-supported-versions", action="store_true", help="Print supported CWL specs.")
-    exgroup.add_argument("--extract-subgraph", type=str, help="Extract subgraph containing one or more nodes named from comma-separated list.")
+    exgroup.add_argument("--print-subgraph", action="store_true",
+                         help="Print workflow subgraph that will execute "
+                         "(can combine with --target)")
+    exgroup.add_argument("--print-targets", action="store_true", help="Print targets (output parameters)")
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--strict", action="store_true",
@@ -293,6 +296,10 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
 
     parser.add_argument("--overrides", type=str,
                         default=None, help="Read process requirement overrides from file.")
+
+    parser.add_argument("--target", "-t", action="append",
+                        help="Only execute steps that contribute to "
+                        "listed targets (can provide more than once).")
 
     parser.add_argument("workflow", type=Text, nargs="?", default=None,
             metavar='cwl_document', help="path or URL to a CWL Workflow, "

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -21,7 +21,7 @@ import pkg_resources  # part of setuptools
 from ruamel import yaml
 from schema_salad import validate
 from schema_salad.ref_resolver import Loader, file_uri, uri_file_path
-from schema_salad.sourceline import strip_dup_lineno
+from schema_salad.sourceline import strip_dup_lineno, cmap
 from six import string_types, iteritems, PY3
 from typing_extensions import Text
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
@@ -54,7 +54,7 @@ from .update import ALLUPDATES, UPDATES
 from .utils import (DEFAULT_TMP_PREFIX, json_dumps, onWindows,
                     processes_to_kill, versionstring, visit_class,
                     windows_default_container_id)
-from .subgraph import print_subgraph
+from .subgraph import get_subgraph
 
 def _terminate_processes():
     # type: () -> None
@@ -694,8 +694,20 @@ def main(argsl=None,                   # type: List[str]
                 printdot(tool, document_loader.ctx, stdout)
                 return 0
 
-            if args.extract_subgraph:
-                print_subgraph(args.extract_subgraph, tool, document_loader, stdout)
+            if args.print_targets:
+                stdout.write("Available targets: %s\n" % ", ".join([shortname(t["id"]) for t in tool.tool["inputs"]]))
+                return 0
+
+            if args.target:
+                extracted = get_subgraph([document_loader.fetcher.urljoin(tool.tool["id"], "#"+r)
+                                          for r in args.target],
+                                         tool)
+                del document_loader.idx[extracted["id"]]
+                tool = make_tool(document_loader, avsc_names,
+                                 metadata, cmap(extracted), loadingContext)
+
+            if args.print_subgraph:
+                stdout.write(json_dumps(tool.tool, indent=4))
                 return 0
 
         except (validate.ValidationException) as exc:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -695,7 +695,7 @@ def main(argsl=None,                   # type: List[str]
                 return 0
 
             if args.print_targets:
-                stdout.write("Available targets: %s\n" % ", ".join([shortname(t["id"]) for t in tool.tool["inputs"]]))
+                stdout.write("Available targets: %s\n" % ", ".join([shortname(t["id"]) for t in tool.tool["outputs"]]))
                 return 0
 
             if args.target:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -54,7 +54,7 @@ from .update import ALLUPDATES, UPDATES
 from .utils import (DEFAULT_TMP_PREFIX, json_dumps, onWindows,
                     processes_to_kill, versionstring, visit_class,
                     windows_default_container_id)
-
+from .subgraph import print_subgraph
 
 def _terminate_processes():
     # type: () -> None
@@ -658,6 +658,7 @@ def main(argsl=None,                   # type: List[str]
             if args.pack:
                 stdout.write(print_pack(document_loader, processobj, uri, metadata))
                 return 0
+
             if args.provenance and runtimeContext.research_obj:
                 # Can't really be combined with args.pack at same time
                 runtimeContext.research_obj.packed_workflow(
@@ -691,6 +692,10 @@ def main(argsl=None,                   # type: List[str]
 
             if args.print_dot:
                 printdot(tool, document_loader.ctx, stdout)
+                return 0
+
+            if args.extract_subgraph:
+                print_subgraph(args.extract_subgraph, tool, document_loader, stdout)
                 return 0
 
         except (validate.ValidationException) as exc:

--- a/cwltool/subgraph.py
+++ b/cwltool/subgraph.py
@@ -1,0 +1,77 @@
+import copy
+from .utils import aslist, json_dumps
+from collections import namedtuple
+
+Node = namedtuple('Node', ('up', 'down'))
+UP = "up"
+DOWN = "down"
+
+def subgraph_visit(current, nodes, visited, direction):
+    if current in visited:
+        return
+    visited.add(current)
+    if direction == UP:
+        d = nodes[current].up
+    else:
+        d = nodes[current].down
+    for c in d:
+        subgraph_visit(c, nodes, visited, direction)
+
+def get_subgraph(roots, tool):
+    if tool.tool["class"] != "Workflow":
+        raise Exception("Can only extract subgraph from workflow")
+
+    nodes = {}
+
+    for inp in tool.tool["inputs"]:
+        nodes.setdefault(inp["id"], Node([], []))
+
+    for st in tool.tool["steps"]:
+        step = nodes.setdefault(st["id"], Node([], []))
+        for i in st["in"]:
+            if "source" not in i:
+                continue
+            for src in aslist(i["source"]):
+                # source is upstream from step (dependency)
+                step.up.append(src)
+                # step is downstream from source
+                nodes.setdefault(src, Node([], []))
+                nodes[src].down.append(st["id"])
+        for out in st["out"]:
+            # output is downstream from step
+            step.down.append(out)
+            # step is upstream from output
+            nodes.setdefault(out, Node([], []))
+            nodes[out].up.append(st["id"])
+
+    for out in tool.tool["outputs"]:
+        nodes.setdefault(out["id"], Node([], []))
+        for i in aslist(out.get("outputSource", [])):
+            # source is upstream from output (dependency)
+            nodes[out["id"]].up.append(i)
+            # output is downstream from step
+            nodes.setdefault(i, Node([], []))
+            nodes[i].down.append(out["id"])
+
+    import pprint
+    pprint.pprint(nodes)
+
+    visited = set()
+    for r in roots:
+        if r in visited:
+            visited.remove(r)
+        subgraph_visit(r, nodes, visited, UP)
+        visited.remove(r)
+        subgraph_visit(r, nodes, visited, DOWN)
+
+    extracted = {}
+    for f in tool.tool:
+        if f in ("steps", "inputs", "outputs"):
+            extracted[f] = []
+            for i in tool.tool[f]:
+                if i["id"] in visited:
+                    extracted[f].append(i)
+        else:
+            extracted[f] = tool.tool[f]
+
+    return extracted

--- a/cwltool/subgraph.py
+++ b/cwltool/subgraph.py
@@ -10,12 +10,14 @@ def subgraph_visit(current, nodes, visited, direction):
     if current in visited:
         return
     visited.add(current)
+
+    if direction == DOWN:
+        d = nodes[current].down
     if direction == UP:
         d = nodes[current].up
-    else:
-        d = nodes[current].down
     for c in d:
         subgraph_visit(c, nodes, visited, direction)
+
 
 def get_subgraph(roots, tool):
     if tool.tool["class"] != "Workflow":
@@ -56,13 +58,15 @@ def get_subgraph(roots, tool):
     import pprint
     pprint.pprint(nodes)
 
-    visited = set()
+    # Find all the downstream nodes from the starting points
+    visited_down = set()
     for r in roots:
-        if r in visited:
-            visited.remove(r)
-        subgraph_visit(r, nodes, visited, UP)
-        visited.remove(r)
-        subgraph_visit(r, nodes, visited, DOWN)
+        subgraph_visit(r, nodes, visited_down, DOWN)
+
+    # Now get all the dependencies of the downstream nodes
+    visited = set()
+    for v in visited_down:
+        subgraph_visit(v, nodes, visited, UP)
 
     extracted = {}
     for f in tool.tool:


### PR DESCRIPTION
Adds --target, --print-targets, and --print-subgraph

--target takes the id of a parameter (input or output) or step of the toplevel workflow and trims the workflow to just the dependencies and/or downstream products of the parameter or step.

--print-targets prints the output parameters

--print-subgraph prints the toplevel workflow (can be combined with --target)

The purpose of this feature is to support Workflows that consist of several independent subgraphs, so it is possible to select a particular subgraph to execute, or execute all of them.  The use case is to be able to group and manage a set of related tasks into a single workflow.