### PR TITLE
Cleanup around testing and packaging lifecycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 os:
   - linux
 install:
-  - pip install tox-travis
+  - pip install -U pip\>=10.0.0 tox-travis
 jobs:
   include:
     - stage: test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ MODULE=cwltool
 # `[[` conditional expressions.
 PYSOURCES=$(wildcard ${MODULE}/**.py tests/*.py) setup.py
 DEVPKGS=pycodestyle diff_cover autopep8 pylint coverage pydocstyle flake8 \
-	pytest pytest-xdist isort
+	pytest-xdist isort
 DEBDEVPKGS=pep8 python-autopep8 pylint python-coverage pydocstyle sloccount \
 	   python-flake8 python-mock shellcheck
 VERSION=1.0.$(shell date +%Y%m%d%H%M%S --utc --date=`git log --first-parent \
@@ -51,7 +51,7 @@ help: Makefile
 
 ## install-dep : install most of the development dependencies via pip
 install-dep:
-	pip install --upgrade $(DEVPKGS) -rtest-requirements.txt
+	pip install --upgrade $(DEVPKGS) .[test,deps]
 
 ## install-deb-dep: install most of the dev dependencies via apt-get
 install-deb-dep:
@@ -69,13 +69,14 @@ dev: install-dep
 ## dist        : create a module package for distribution
 dist: dist/${MODULE}-$(VERSION).tar.gz
 
+## can't use pip for sdist yet: https://github.com/pypa/pip/issues/5401
 dist/${MODULE}-$(VERSION).tar.gz: $(SOURCES)
-	./setup.py sdist bdist_wheel
+	python setup.py sdist bdist_wheel
 
 ## clean       : clean up all temporary / machine-generated files
 clean: FORCE
 	rm -f ${MODILE}/*.pyc tests/*.pyc
-	./setup.py clean --all || true
+	python setup.py clean --all || true
 	rm -Rf .coverage
 	rm -f diff-cover.html
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,6 @@ Remember, if co-installing multiple CWL implementations then you need to
 maintain which implementation ``cwl-runner`` points to via a symbolic file
 system link or `another facility <https://wiki.debian.org/DebianAlternatives>`_.
 
-=====
 Usage
 =====
 
@@ -486,7 +485,6 @@ For this example, grab the test.json (and input file) from https://github.com/Ca
 
 .. _`GA4GH Tool Registry API`: https://github.com/ga4gh/tool-registry-schemas
 
-===========
 Development
 ===========
 
@@ -499,13 +497,17 @@ To run the basis tests after installing `cwltool` execute the following:
 
 .. code:: bash
 
-  pip install -rtest-requirements.txt
-  py.test --ignore cwltool/schemas/ --pyarg cwltool
+  pip install .
+  pytest
 
 To run various tests in all supported Python environments we use `tox <https://github.com/common-workflow-language/cwltool/tree/master/tox.ini>`_. To run the test suite in all supported Python environments
 first downloading the complete code repository (see the ``git clone`` instructions above) and then run
 the following in the terminal:
-``pip install tox; tox``
+
+.. code:: bash
+
+  pip install tox
+  tox
 
 List of all environment can be seen using:
 ``tox --listenvs``

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ intended to be feature complete and provide comprehensive validation of CWL
 files as well as provide other tools related to working with CWL.
 
 This is written and tested for
-`Python <https://www.python.org/>`_ ``2.7 and 3.x {x = 4, 5, 6, 7}``
+`Python <https://www.python.org/>`_ ``2.7 and 3.x {x = 4, 5, 6, 7}`` on Linux and MacOS.
+Python 3.4 is not supported on Windows due to lack of support in some of the libraries used.
 
 The reference implementation consists of two packages.  The ``cwltool`` package
 is the primary Python module containing the reference implementation in the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m pytest -p no:cacheprovider -p no:stepwise --cov --cov-report xml --junit-xml=tests.xml"
+  - "%PYTHON%\\python.exe -m pytest -n auto --dist=loadfile -p no:cacheprovider -p no:stepwise --cov --cov-report xml --junit-xml=tests.xml"
 
 on_finish:
   - "%PYTHON%\\python.exe -m codecov --file coverage.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,13 +31,12 @@ environment:
 install:
   - ps: 'Install-Product node 0.12 x64'
   - "set PATH=%PYTHON%\\Scripts;%PATH%"
-  - "%PYTHON%\\python.exe -m pip install -U pip setuptools^>=20.3 wheel"
-  - "%PYTHON%\\python.exe -m pip install -U codecov pytest-xdist pytest-cov galaxy-lib -rtest-requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install -U pip^>=10.0.0"
+  - "%PYTHON%\\python.exe -m pip install -U codecov pytest-xdist .[test,deps]"
     # Note the use of a `^` to escape the `>`
 
 build_script:
-  - "%PYTHON%\\python.exe -m pip install -rrequirements.txt"
-  - "%PYTHON%\\python.exe -m pip install -e ."
+  - "%PYTHON%\\python.exe -m pip install ."
 
 test_script:
   - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,6 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
@@ -31,22 +27,17 @@ environment:
 install:
   - ps: 'Install-Product node 0.12 x64'
   - "set PATH=%PYTHON%\\Scripts;%PATH%"
-  - "%PYTHON%\\python.exe -m pip install -U pip^>=10.0.0"
-  - "%PYTHON%\\python.exe -m pip install -U codecov pytest-xdist .[test,deps]"
+  - "%PYTHON%\\python.exe -m pip install -U codecov pip^>=10.0.0"
+  - "%PYTHON%\\python.exe -m pip install .[test,deps]"
     # Note the use of a `^` to escape the `>`
 
-build_script:
-  - "%PYTHON%\\python.exe -m pip install ."
+build: off
 
 test_script:
-  - |
-    %PYTHON%\\python.exe -m coverage run --parallel-mode -m pytest --strict -p no:cacheprovider -p no:stepwise --junit-xml=tests.xml
-  - "%PYTHON%\\python.exe -m coverage combine"
-  - "%PYTHON%\\python.exe -m coverage report"
-  - "%PYTHON%\\python.exe -m coverage xml"
-  - "%PYTHON%\\python.exe -m codecov --file coverage.xml"
+  - "%PYTHON%\\python.exe -m pytest -p no:cacheprovider -p no:stepwise --cov --cov-report xml --junit-xml=tests.xml"
 
 on_finish:
+  - "%PYTHON%\\python.exe -m codecov --file coverage.xml"
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($Env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))

--- a/cwltool.Dockerfile
+++ b/cwltool.Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.6-alpine as builder
+FROM python:3.7-alpine as builder
 
 RUN apk add --no-cache git gcc python3-dev libxml2-dev libxslt-dev libc-dev linux-headers
 
 WORKDIR /cwltool
 COPY . .
 
-RUN python setup.py bdist_wheel --dist-dir=/wheels
-RUN pip wheel -r requirements.txt --wheel-dir=/wheels
+RUN pip wheel --wheel-dir=/wheels .
 RUN pip install --no-index --no-warn-script-location --root=/pythonroot/ /wheels/*.whl
 
 FROM python:3.6-alpine as module
@@ -15,7 +14,7 @@ LABEL maintainer peter.amstutz@curoverse.com
 RUN apk add --no-cache docker nodejs graphviz libxml2 libxslt
 COPY --from=builder /pythonroot/ /
 
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 LABEL maintainer peter.amstutz@curoverse.com
 
 RUN apk add --no-cache docker nodejs graphviz libxml2 libxslt

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -30,7 +30,7 @@ do
 	venv cwltool-venv${PYTHON_VERSION}
 	export PIP_DOWNLOAD_CACHE=/var/lib/jenkins/pypi-cache/
 	# use pip2.7 and pip3 in separate loop runs
-	pip${PYTHON_VERSION} install -U setuptools wheel pip
+	pip${PYTHON_VERSION} install -U pip\>=10.0.0
 	pip${PYTHON_VERSION} uninstall -y cwltool
 	pip${PYTHON_VERSION} install -e .
 	pip${PYTHON_VERSION} install "cwltest>=1.0.20180518074130" codecov

--- a/jenkins.bat
+++ b/jenkins.bat
@@ -3,6 +3,7 @@ docker-machine start default
 REM Set the environment variables to use docker-machine and docker commands
 FOR /f "tokens=*" %%i IN ('docker-machine env --shell cmd default') DO %%i
 docker version
+pip install -U pip^>=10.0.0
 python setup.py test --addopts "--junit-xml=tests.xml --cov-report xml --cov cwltool"
 pip install codecov
 codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools >= 40.0.4",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 40.0.4",
+    "setuptools >= 40.6.0",
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'

--- a/release-test.sh
+++ b/release-test.sh
@@ -9,25 +9,14 @@ package=cwltool
 module=cwltool
 slug=${TRAVIS_PULL_REQUEST_SLUG:=common-workflow-language/cwltool}
 repo=https://github.com/${slug}.git
-parallel=""
-if [[ "${OSTYPE}" == linux* ]]
-then
-	parallel=-n$(( $(nproc) / 2 ))
-fi
-if [[ "${OSTYPE}" == darwin* ]]
-then
-	parallel=-n$(( $(sysctl -n hw.physicalcpu) / 2 ))
-fi
-test_prefix=""
-run_tests() {
+run_tests_installed_package() {
 	local mod_loc
 	mod_loc=$(pip show ${package} |
 		grep ^Location | awk '{print $2}')/${module}
-	${test_prefix}bin/py.test "--ignore=${mod_loc}/schemas/" \
-		--pyarg -x ${module} ${parallel} --dist=loadfile
+	pytest "--ignore=${mod_loc}/schemas/" \
+		--pyargs -x ${module} -n auto --dist=loadfile
 }
 pipver=10.0.0 # required to install build deps
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 rm -Rf testenv? || /bin/true
 
@@ -36,64 +25,76 @@ export HEAD=${TRAVIS_PULL_REQUEST_SHA:-$(git rev-parse HEAD)}
 if [ "${RELEASE_SKIP}" != "head" ]
 then
 	virtualenv testenv1
+	virtualenv testenv0
 	# First we test the head
 	# shellcheck source=/dev/null
 	source testenv1/bin/activate
-	rm -Rf testenv1/local
-	rm testenv1/lib/python-wheels/setuptools* \
-		&& pip install --force-reinstall -U pip\>=${pipver}
-	make install-dep
+	rm -Rf testenv1/{local,lib/python-wheels/setuptools*}
+	pip install --force-reinstall -U pip\>=${pipver}
+	pip install .[test,deps]
 	make test
 	pip uninstall -y ${package} || true; pip uninstall -y ${package} || true; make install
 	mkdir testenv1/not-${module}
-	# if there is a subdir named '${module}' py.test will execute tests
-	# there instead of the installed module's tests
+	# Avoid having a subdir named '${module}' pytest may execute tests from that dir
+	# instead of the installed module's tests
 	pushd testenv1/not-${module}
 	# shellcheck disable=SC2086
-	test_prefix=../ run_tests; popd
+	run_tests_installed_package
+	deactivate; popd
 fi
 
 virtualenv testenv2
 virtualenv testenv3
-rm -Rf testenv[23]/local
+virtualenv testenv4
+rm -Rf testenv[234]/local
 
-# Secondly we test via pip
+# Install the package using git, run the tests in-place
+# Create a package to later run tests on those
 
-cd testenv2
 # shellcheck source=/dev/null
-source bin/activate
-rm lib/python-wheels/setuptools* \
-	&& pip install --force-reinstall -U pip\>=${pipver}
-pip install -e "git+${repo}@${HEAD}#egg=${package}"  #[deps]
-cd src/${package}
-make install-dep
-make dist
+source testenv2/bin/activate
+rm -Rf testenv2/{local,src,lib/python-wheels/setuptools*}
+pushd testenv2
+pip install --force-reinstall -U pip\>=${pipver}
+pip install -e "git+${repo}@${HEAD}#egg=${package}[test,deps]"
+pushd src/${package}
 make test
-cp dist/${package}*tar.gz ../../../testenv3/
-pip uninstall -y ${package} || true; pip uninstall -y ${package} || true; make install
-cd ../.. # no subdir named ${proj} here, safe for py.testing the installed module
-# shellcheck disable=SC2086
-run_tests
+make dist
+pushd dist
+package_tar=(${package}*.tar.gz)
+popd
+cp dist/${package_tar} ../../../testenv3/
+deactivate; popd; popd
 
 # Is the distribution in testenv2 complete enough to build another
 # functional distribution?
 
-cd ../testenv3/
 # shellcheck source=/dev/null
-source bin/activate
-rm lib/python-wheels/setuptools* \
-	&& pip install --force-reinstall -U pip\>=${pipver}
-package_tar=${package}*tar.gz
-pip install "${DIR}[test,deps]"
-pip install "${package_tar}"  # [deps]
+source testenv3/bin/activate
+rm -Rf testenv3/{local,lib/python-wheels/setuptools*}
+pushd testenv3/
+pip install --force-reinstall -U pip\>=${pipver}
+pip install "${package_tar}""[test,deps]"
 mkdir out
-tar --extract --directory=out -z -f ${package}*.tar.gz
-cd out/${package}*
+tar --extract --directory=out -z -f "${package_tar}"
+pushd out/${package}*
 make install-dep
-make dist
 make test
-pip uninstall -y ${package} || true; pip uninstall -y ${package} || true; make install
-mkdir ../not-${module}
-pushd ../not-${module}
+# Avoid having a subdir named '${module}' pytest may execute tests from that dir
+# instead of the installed module's tests
+popd; rm -Rf out/
 # shellcheck disable=SC2086
-test_prefix=../../ run_tests; popd
+run_tests_installed_package
+deactivate; popd
+
+# Install the package using git, run the tests from the package
+
+# shellcheck source=/dev/null
+source testenv4/bin/activate
+rm -Rf testenv4/{local,lib/python-wheels/setuptools*}
+pushd testenv4
+pip install "git+${repo}@${HEAD}#egg=${package}""[test,deps]"
+# no subdir named ${proj} here, safe for testing the installed module
+# shellcheck disable=SC2086
+run_tests_installed_package
+deactivate; popd;

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ NEEDS_PYTEST = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 PYTEST_RUNNER = ['pytest-runner', 'pytest-cov'] if NEEDS_PYTEST else []
 
 test_deps = ['pytest', 'mock >= 2.0.0', 'pytest-mock >= 1.10.0',
-             'pytest-cov', 'arcp >= 0.2.0', 'rdflib-jsonld >= 0.4.0']
+             'pytest-cov', 'pytest-xdist', 'arcp >= 0.2.0', 'rdflib-jsonld >= 0.4.0']
 
 setup(name='cwltool',
       version='1.0',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ except ImportError:
 NEEDS_PYTEST = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 PYTEST_RUNNER = ['pytest-runner', 'pytest-cov'] if NEEDS_PYTEST else []
 
+test_deps = ['pytest', 'mock >= 2.0.0', 'pytest-mock >= 1.10.0',
+             'pytest-cov', 'arcp >= 0.2.0', 'rdflib-jsonld >= 0.4.0']
+
 setup(name='cwltool',
       version='1.0',
       description='Common workflow language reference implementation',
@@ -47,7 +50,6 @@ setup(name='cwltool',
           'hello.simg']},
       include_package_data=True,
       install_requires=[
-          'setuptools',
           'requests >= 2.6.1',  # >= 2.6.1 to workaround
           # https://github.com/ionrock/cachecontrol/issues/137
           'ruamel.yaml >= 0.12.4, <= 0.15.77',
@@ -55,7 +57,6 @@ setup(name='cwltool',
           'shellescape >= 3.4.1, < 3.5',
           'schema-salad >= 3.0, < 3.1',
           'mypy-extensions',
-          'six >= 1.9.0',  # >= 1.9.0 required by prov
           'psutil',
           'scandir',
           'prov == 1.5.1',
@@ -66,13 +67,13 @@ setup(name='cwltool',
           ':os.name=="posix" and python_version<"3.5"': ['subprocess32 >= 3.5.0'],
           ':python_version<"3"': ['pathlib2 == 2.3.2'],
           ':python_version<"3.6"': ['typing >= 3.5.3'],
-          'deps': ["galaxy-lib >= 17.09.9"]
+          'deps': ["galaxy-lib >= 17.09.9"],
+          'test': test_deps
       },
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
-      setup_requires=PYTEST_RUNNER,
       test_suite='tests',
-      tests_require=['pytest', 'mock >= 2.0.0', 'pytest-mock >= 1.10.0',
-                     'arcp >= 0.2.0', 'rdflib-jsonld >= 0.4.0'],
+      tests_require=test_deps,
+      setup_requires=PYTEST_RUNNER,
       entry_points={
           'console_scripts': ["cwltool=cwltool.main:run"]
       },

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,0 @@
-pytest
-mock >= 2.0.0
-pytest-mock >= 1.10.0
-pytest-cov
-arcp >= 0.2.0
-rdflib-jsonld >= 0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,9 @@ whitelist_externals =
   py{34,35,36,36,37}-mypy{2,3}: make
 
 [testenv:py27-pipconflictchecker]
-commands = pipconflictchecker
-whitelist_externals = pipconflictchecker
+commands = python -m pip check
 deps =
-  pip-conflict-checker
-  pip==9.0.3
+  pip>=9.0.3
 
 [testenv:py27-lint-readme]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
   py27-lint-readme,
   py27-pydocstyle
 
+isolated_build = True
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ setenv =
   py{27,34,35,36,37}-unit: LC_ALL = C
 
 commands =
-  py{27,34,35,36,37}-unit: pytest --strict --cov --cov-report term --cov-report xml {posargs}
+  py{27,34,35,36,37}-unit: pytest -n auto --dist=loadfile --strict --cov --cov-report term --cov-report xml {posargs}
   py{27,34,35,36,37}-unit: - codecov --file coverage.xml
   py{27,34,35,36,37}-lint: flake8 schema_salad setup.py
   py{34,35,36,36,37}-mypy2: make mypy2

--- a/tox.ini
+++ b/tox.ini
@@ -7,44 +7,25 @@ envlist =
   py27-lint-readme,
   py27-pydocstyle
 
-skipsdist = True
 skip_missing_interpreters = True
 
-[travis]
-python =
-  2.7: py27
-  3.4: py34
-  3.5: py35
-  3.6: py36
-  3.7: py37
-
 [testenv]
-passenv =
-  CI
-  TRAVIS
-  TRAVIS_*
+passenv = CI TRAVIS*
 deps =
-  -rrequirements.txt
   py{27,34,35,36,37}-unit: codecov
-  py{27,34,35,36,37}-unit: pytest-xdist
-  py{27,34,35,36,37}-unit: pytest-cov
-  py{27,34,35,36,37}-unit: -rtest-requirements.txt
-  py{27,34,35,36,37}-unit: galaxy-lib
   py{27,34,35,36,37}-lint: flake8
   py{34,35,36,36,37}-mypy{2,3}: mypy==0.620
+
+extras =
+  py{27,34,35,36,37}-unit: deps
+  py{27,34,35,36,37}-unit: test
 
 setenv =
   py{27,34,35,36,37}-unit: LC_ALL = C
 
 commands =
-  py{27,34,35,36,37}-unit: python -m pip install -U pip setuptools wheel
-  py{27,34,35,36,37}-unit: python -m pip install -e .[deps]
-  py{27,34,35,36,37}-unit: python -m pip install -rtest-requirements.txt
-  py{27,34,35,36,37}-unit: coverage run --parallel-mode -m pytest --strict {posargs}
-  py{27,34,35,36,37}-unit: coverage combine
-  py{27,34,35,36,37}-unit: coverage report
-  py{27,34,35,36,37}-unit: coverage xml
-  py{27,34,35,36,37}-unit: codecov --file coverage.xml
+  py{27,34,35,36,37}-unit: pytest --strict --cov --cov-report term --cov-report xml {posargs}
+  py{27,34,35,36,37}-unit: - codecov --file coverage.xml
   py{27,34,35,36,37}-lint: flake8 schema_salad setup.py
   py{34,35,36,36,37}-mypy2: make mypy2
   py{34,35,36,36,37}-mypy3: make mypy3


### PR DESCRIPTION
I've simplified managing with python packaging, removing test-requirements.txt and removing the direct usage of setup.py for installing the package and dependencies: that can be handled through pip and PEP518.

I also think there is a case to remove requirements.txt as it is, since it does not list all the dependencies needed in the environment, nor they are locked.

Let me know your thoughts, especially about requirements.txt. I haven't deleted the file but there is no other piece of code that actually uses it.