### PR TITLE
Do not capture errors in the context

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -77,7 +77,7 @@ def temp_dir(suffix=""):
     c_dir = tempfile.mkdtemp(suffix)
     try:
         yield c_dir
-    except:
+    finally:
         shutil.rmtree(c_dir)
 
 @contextlib.contextmanager


### PR DESCRIPTION
Locally the tests using singularity for initial working directories would not fail without the fix (as they should)