### PR TITLE
WIP: Avoid file location conflicts in output

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -406,11 +406,11 @@ class CommandLineJob(JobBase):
             env["SYSTEMROOT"] = str(os.environ["SYSTEMROOT"]) if onWindows() \
                     else os.environ["SYSTEMROOT"]
 
-        stage_files(self.pathmapper, ignore_writable=True, symlink=True,
+        stage_files(self.pathmapper, ignore_writable=True,
                     secret_store=runtimeContext.secret_store)
         if self.generatemapper is not None:
             stage_files(self.generatemapper, ignore_writable=self.inplace_update,
-                        symlink=True, secret_store=runtimeContext.secret_store)
+                        secret_store=runtimeContext.secret_store)
             relink_initialworkdir(
                 self.generatemapper, self.outdir, self.builder.outdir,
                 inplace_update=self.inplace_update)

--- a/tests/echo.cwl
+++ b/tests/echo.cwl
@@ -6,11 +6,13 @@ inputs:
     type: string
     inputBinding: {}
 outputs:
-  - id: out
+  out:
     type: string
     outputBinding:
       glob: out.txt
       loadContents: true
       outputEval: $(self[0].contents)
+  stdout:
+    type: stdout
 baseCommand: echo
 stdout: out.txt

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -145,7 +145,8 @@ def test_factory():
     factory = get_windows_safe_factory()
     echo = factory.make(get_data("tests/echo.cwl"))
 
-    assert echo(inp="foo") == {"out": "foo\n"}
+    outputs = echo(inp='foo')
+    assert outputs.get('out', '') == "foo\n"
 
 def test_factory_bad_outputs():
     factory = cwltool.factory.Factory()
@@ -366,7 +367,7 @@ def test_input_deps_cmdline_opts_relative_deps_cwd():
         stream = BytesIO()
     else:
         stream = StringIO()
-    
+
     data_path = get_data("tests/wf/whale.txt")
     main(["--print-input-deps", "--relative-deps", "cwd",
           get_data("tests/wf/count-lines1-wf.cwl"),

--- a/tests/test_path_conflict.py
+++ b/tests/test_path_conflict.py
@@ -1,0 +1,23 @@
+from os import listdir
+
+from cwltool.main import main
+from .util import get_data, temp_dir, needs_docker, windows_needs_docker
+
+@needs_docker
+def test_same_content():
+
+    with temp_dir() as tmpdir:
+        params = ['--outdir', tmpdir, get_data('tests/wf/path-conflict-same-content.cwl')]
+
+        assert main(params) == 0
+        assert len(listdir(tmpdir)) in [1, 2],\
+            'One or two files must be present since their contents are the same'
+
+@windows_needs_docker
+def test_different_content():
+    with temp_dir() as tmpdir:
+        params = ['--outdir', tmpdir, get_data('tests/wf/path-conflict-different-content.cwl')]
+
+        assert main(params) == 0
+        assert len(listdir(tmpdir)) == 2,\
+            'Two files must be present since their contents are differents'

--- a/tests/wf/path-conflict-different-content.cwl
+++ b/tests/wf/path-conflict-different-content.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+inputs: {}
+
+outputs:
+  first_file:
+    type: File
+    outputSource: first/stdout
+  second_file:
+    type: File
+    outputSource: second/stdout
+
+steps:
+  first:
+    run: ../echo.cwl
+    in:
+      inp:
+        default: 'foo'
+    out: [stdout]
+
+  second:
+    run: ../echo.cwl
+    in:
+      inp:
+        default: 'bar'
+    out: [stdout]

--- a/tests/wf/path-conflict-same-content.cwl
+++ b/tests/wf/path-conflict-same-content.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+inputs: {}
+
+outputs:
+  first_file:
+    type: File
+    outputSource: first/out
+  second_file:
+    type: File
+    outputSource: second/out
+
+steps:
+  first:
+    run: touch_tool.cwl
+    in:
+      message:
+        default: 'foo.txt'
+    out: [out]
+
+  second:
+    run: touch_tool.cwl
+    in:
+      message:
+        default: 'foo.txt'
+    out: [out]

--- a/tests/wf/touch_tool.cwl
+++ b/tests/wf/touch_tool.cwl
@@ -15,4 +15,4 @@ outputs:
   - id: out
     type: File
     outputBinding:
-      glob: "*"
+      glob: $(inputs.message)


### PR DESCRIPTION
Right now if two outputs have the same location, only one is written to disk: closes #925 