### PR TITLE
Don't fail checksum calculation for missing File

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -975,10 +975,14 @@ def scandeps(base,                          # type: Text
 def compute_checksums(fs_access, fileobj):
     if "checksum" not in fileobj:
         checksum = hashlib.sha1()
-        with fs_access.open(fileobj["location"], "rb") as f:
-            contents = f.read(1024 * 1024)
-            while contents != b"":
-                checksum.update(contents)
+        try:
+            with fs_access.open(fileobj["location"], "rb") as f:
                 contents = f.read(1024 * 1024)
-        fileobj["checksum"] = "sha1$%s" % checksum.hexdigest()
-        fileobj["size"] = fs_access.size(fileobj["location"])
+                while contents != b"":
+                    checksum.update(contents)
+                    contents = f.read(1024 * 1024)
+            fileobj["checksum"] = "sha1$%s" % checksum.hexdigest()
+            fileobj["size"] = fs_access.size(fileobj["location"])
+        except IOError:
+            _logger.warning("IO error calculating checksum for %s.", fileobj,
+                            exc_info=_logger.isEnabledFor(logging.DEBUG))

--- a/tests/test_relocate.py
+++ b/tests/test_relocate.py
@@ -1,8 +1,15 @@
 from cwltool.main import main
+from cwltool.process import compute_checksums, StdFsAccess
 
 from .util import get_data, needs_docker
+
 
 @needs_docker
 def test_for_910():
     assert main([get_data('tests/wf/910.cwl')]) == 0
     assert main([get_data('tests/wf/910.cwl')]) == 0
+
+def test_checksum_missing_file(tmpdir):
+    compute_checksums(StdFsAccess(""),
+                      {"class": "File",
+                       "location": str(tmpdir.join("missing"))})


### PR DESCRIPTION
This can occur when a `WritableDirectory` has one of its components deleted.

Probably better to remove the entry altogether, though..