### PR TITLE
maintenance: refactor code in provenance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -698,6 +698,6 @@ Workflow.make_workflow_step
   ::
 
     make_workflow_step(toolpath_object, pos, loadingContext, parentworkflowProv)
-      (Dict[Text, Any], int, LoadingContext, Optional[CreateProvProfile]) -> WorkflowStep
+      (Dict[Text, Any], int, LoadingContext, Optional[ProvenanceProfile]) -> WorkflowStep
 
   Create and return a workflow step object.

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -28,7 +28,7 @@ from .utils import aslist, docker_windows_path_adjust, json_dumps, onWindows
 
 
 if TYPE_CHECKING:
-    from .provenance import CreateProvProfile  # pylint: disable=unused-import
+    from .provenance import ProvenanceProfile  # pylint: disable=unused-import
 CONTENT_LIMIT = 64 * 1024
 
 
@@ -162,7 +162,7 @@ class Builder(HasReqsHints):
         self.stagedir = stagedir
 
         self.pathmapper = None  # type: Optional[PathMapper]
-        self.prov_obj = None  # type: Optional[CreateProvProfile]
+        self.prov_obj = None  # type: Optional[ProvenanceProfile]
         self.find_default_container = None  # type: Optional[Callable[[], Text]]
 
     def build_job_script(self, commands):

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -49,7 +49,7 @@ from .utils import (aslist, convert_pathsep_to_unix,
                     docker_windows_path_adjust, json_dumps, onWindows,
                     random_outdir, windows_default_container_id)
 if TYPE_CHECKING:
-    from .provenance import CreateProvProfile  # pylint: disable=unused-import
+    from .provenance import ProvenanceProfile  # pylint: disable=unused-import
 
 ACCEPTLIST_EN_STRICT_RE = re.compile(r"^[a-zA-Z0-9._+-]+$")
 ACCEPTLIST_EN_RELAXED_RE = re.compile(r".*")  # Accept anything
@@ -89,7 +89,7 @@ class ExpressionTool(Process):
             self.outdir = outdir
             self.tmpdir = tmpdir
             self.script = script
-            self.prov_obj = None  # type: Optional[CreateProvProfile]
+            self.prov_obj = None  # type: Optional[ProvenanceProfile]
 
         def run(self, runtimeContext):  # type: (RuntimeContext) -> None
             try:
@@ -179,7 +179,7 @@ class CallbackJob(object):
         self.output_callback = output_callback
         self.cachebuilder = cachebuilder
         self.outdir = jobcache
-        self.prov_obj = None  # type: Optional[CreateProvProfile]
+        self.prov_obj = None  # type: Optional[ProvenanceProfile]
 
     def run(self, runtimeContext):
         # type: (RuntimeContext) -> None

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -21,7 +21,7 @@ from .utils import DEFAULT_TMP_PREFIX
 if TYPE_CHECKING:
     from .process import Process
     from .provenance import (ResearchObject,  # pylint: disable=unused-import
-                             CreateProvProfile)
+                             ProvenanceProfile)
 
 class ContextBase(object):
     def __init__(self, kwargs=None):
@@ -63,7 +63,7 @@ class LoadingContext(ContextBase):
         self.cwl_full_name = ""            # type: str
         self.host_provenance = False       # type: bool
         self.user_provenance = False       # type: bool
-        self.prov_obj = None               # type: Optional[CreateProvProfile]
+        self.prov_obj = None               # type: Optional[ProvenanceProfile]
 
         super(LoadingContext, self).__init__(kwargs)
 
@@ -131,7 +131,7 @@ class RuntimeContext(ContextBase):
         self.orcid = ''                 # type: str
         self.cwl_full_name = ""         # type: str
         self.process_run_id = None      # type: Optional[str]
-        self.prov_obj = None            # type: Optional[CreateProvProfile]
+        self.prov_obj = None            # type: Optional[ProvenanceProfile]
         super(RuntimeContext, self).__init__(kwargs)
 
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -21,7 +21,7 @@ from .loghandler import _logger
 from .mutation import MutationManager
 from .process import Process  # pylint: disable=unused-import
 from .process import cleanIntermediate, relocateOutputs
-from .provenance import CreateProvProfile
+from .provenance import ProvenanceProfile
 from .utils import DEFAULT_TMP_PREFIX
 from .workflow import Workflow, WorkflowJob, WorkflowJobStep
 
@@ -134,7 +134,7 @@ class SingleJobExecutor(JobExecutor):
         # define provenance profile for single commandline tool
         if not isinstance(process, Workflow) \
                 and runtime_context.research_obj is not None:
-            process.provenance_object = CreateProvProfile(
+            process.provenance_object = ProvenanceProfile(
                 runtime_context.research_obj,
                 full_name=runtime_context.cwl_full_name,
                 host_provenance=False,
@@ -159,11 +159,12 @@ class SingleJobExecutor(JobExecutor):
                         else:
                             runtime_context.prov_obj = job.prov_obj
                         assert runtime_context.prov_obj
-                        process_run_id = \
-                            runtime_context.prov_obj.evaluate(
-                                process, job, job_order_object,
-                                runtime_context.make_fs_access,
-                                runtime_context.research_obj)
+                        runtime_context.prov_obj.evaluate(
+                            process, job, job_order_object,
+                            runtime_context.research_obj)
+                        process_run_id =\
+                            runtime_context.prov_obj.record_process_start(
+                                process, job)
                         runtime_context = runtime_context.copy()
                         runtime_context.process_run_id = process_run_id
                     job.run(runtime_context)

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -40,7 +40,7 @@ from .utils import (DEFAULT_TMP_PREFIX, Directory, copytree_with_merge,
                     subprocess)
 
 if TYPE_CHECKING:
-    from .provenance import CreateProvProfile  # pylint: disable=unused-import
+    from .provenance import ProvenanceProfile  # pylint: disable=unused-import
 needs_shell_quoting_re = re.compile(r"""(^$|[\s|&;()<>\'"$@])""")
 
 FORCE_SHELLED_POPEN = os.getenv("CWLTOOL_FORCE_SHELL_POPEN", "0") == "1"
@@ -194,8 +194,8 @@ class JobBase(with_metaclass(ABCMeta, HasReqsHints)):
         self.generatefiles = {"class": "Directory", "listing": [], "basename": ""}  # type: Directory
         self.stagedir = None  # type: Optional[Text]
         self.inplace_update = False
-        self.prov_obj = None   # type: Optional[CreateProvProfile]
-        self.parent_wf = None  # type: Optional[CreateProvProfile]
+        self.prov_obj = None   # type: Optional[ProvenanceProfile]
+        self.parent_wf = None  # type: Optional[ProvenanceProfile]
         self.timelimit = None  # type: Optional[int]
         self.networkaccess = False  # type: bool
 
@@ -344,11 +344,8 @@ class JobBase(with_metaclass(ABCMeta, HasReqsHints)):
         if runtimeContext.research_obj is not None and self.prov_obj is not None and \
                 runtimeContext.process_run_id is not None:
             #creating entities for the outputs produced by each step (in the provenance document)
-            self.prov_obj.generate_output_prov(
-                outputs, runtimeContext.process_run_id, str(self.name))
-            self.prov_obj.document.wasEndedBy(
-                runtimeContext.process_run_id, None, self.prov_obj.workflow_run_uri,
-                datetime.datetime.now())
+            self.prov_obj.record_process_end(str(self.name), runtimeContext.process_run_id,
+                                      outputs, datetime.datetime.now())
         if processStatus != "success":
             _logger.warning(u"[job %s] completed %s", self.name, processStatus)
         else:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -583,7 +583,7 @@ def main(argsl=None,                   # type: List[str]
             if not args.compute_checksum:
                 _logger.error("--provenance incompatible with --no-compute-checksum")
                 return 1
-            ro = ResearchObject(
+            ro = ResearchObject(runtimeContext.make_fs_access,
                 temp_prefix_ro=args.tmpdir_prefix, orcid=args.orcid,
                 full_name=args.cwl_full_name)
             runtimeContext.research_obj = ro
@@ -808,7 +808,8 @@ def main(argsl=None,                   # type: List[str]
 
             if out is not None:
                 if runtimeContext.research_obj is not None:
-                    runtimeContext.research_obj.create_job(out, None, True)
+                    runtimeContext.research_obj.create_job(
+                        out, None, True)
 
                 def loc_to_path(obj):
                     for field in ("path", "nameext", "nameroot", "dirname"):

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -583,7 +583,7 @@ def main(argsl=None,                   # type: List[str]
             if not args.compute_checksum:
                 _logger.error("--provenance incompatible with --no-compute-checksum")
                 return 1
-            ro = ResearchObject(runtimeContext.make_fs_access,
+            ro = ResearchObject(
                 temp_prefix_ro=args.tmpdir_prefix, orcid=args.orcid,
                 full_name=args.cwl_full_name)
             runtimeContext.research_obj = ro

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -52,7 +52,7 @@ try:
 except ImportError:
     from scandir import scandir  # type: ignore
 if TYPE_CHECKING:
-    from .provenance import CreateProvProfile  # pylint: disable=unused-import
+    from .provenance import ProvenanceProfile  # pylint: disable=unused-import
 
 
 class LogAsDebugFilter(logging.Filter):
@@ -453,8 +453,8 @@ class Process(with_metaclass(abc.ABCMeta, HasReqsHints)):
                  loadingContext        # type: LoadingContext
                 ):  # type: (...) -> None
         self.metadata = getdefault(loadingContext.metadata, {})  # type: Dict[Text,Any]
-        self.provenance_object = None  # type: Optional[CreateProvProfile]
-        self.parent_wf = None          # type: Optional[CreateProvProfile]
+        self.provenance_object = None  # type: Optional[ProvenanceProfile]
+        self.parent_wf = None          # type: Optional[ProvenanceProfile]
         global SCHEMA_FILE, SCHEMA_DIR, SCHEMA_ANY  # pylint: disable=global-statement
         if SCHEMA_FILE is None or SCHEMA_ANY is None or SCHEMA_DIR is None:
             get_schema("v1.0")

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -475,7 +475,7 @@ class ProvenanceProfile():
         return process_run_id
 
     def start_process(self, process_name, when, process_run_id=None):
-        # type: (Any, Text, datetime.datetime, Optional[str]) -> str
+        # type: (Text, datetime.datetime, Optional[str]) -> str
         """Record the start of each Process."""
         if process_run_id is None:
             process_run_id = uuid.uuid4().urn
@@ -1094,10 +1094,10 @@ class ResearchObject():
             self._file_provenance[rel_path] = {"createdOn": timestamp.isoformat()}
 
     def _ro_aggregates(self):
-        # type: () -> List[Dict[str,Any]]
+        # type: () -> List[Dict[str, Any]]
         """Gather dictionary of files to be added to the manifest."""
         def guess_mediatype(rel_path):
-            # type: (str) -> Dict[str,str]
+            # type: (str) -> Dict[str, str]
             """Return the mediatypes."""
             media_types = {
                 # Adapted from
@@ -1157,7 +1157,7 @@ class ResearchObject():
 
         aggregates = [] # type: List[Dict]
         for path in self.bagged_size.keys():
-            aggregate_dict = {}  # type: Dict[str,Any]
+            aggregate_dict = {}  # type: Dict[str, Any]
 
             (folder, filename) = posixpath.split(path)
 
@@ -1197,7 +1197,7 @@ class ResearchObject():
                 # aggregate it.
                 continue
 
-            rel_aggregates = {} # type: Dict[str,Any]
+            rel_aggregates = {} # type: Dict[str, Any]
             # These are local paths like metadata/provenance - but
             # we need to relativize them for our current directory for
             # as we are saved in metadata/manifest.json
@@ -1302,7 +1302,7 @@ class ResearchObject():
         # type: () -> None
 
         # Does not have to be this order, but it's nice to be consistent
-        manifest = OrderedDict()  # type: Dict[str,Any]
+        manifest = OrderedDict()  # type: Dict[str, Any]
         manifest["@context"] = [
             {"@base": "%s%s/" % (self.base_uri, _posix_path(METADATA))},
             "https://w3id.org/bundle/context"
@@ -1433,7 +1433,7 @@ class ResearchObject():
         return rel_path
 
     def _self_made(self, timestamp=None):
-        # type: (Optional[datetime.datetime]) -> Dict[str,Any]
+        # type: (Optional[datetime.datetime]) -> Dict[str, Any]
         if timestamp is None:
             timestamp = datetime.datetime.now()
         return {
@@ -1530,7 +1530,7 @@ class ResearchObject():
         return self.relativised_input_object
 
     def _relativise_files(self, structure):
-        # type: (Any, Dict[Any, Any]) -> None
+        # type: (Dict[Any, Any]) -> None
         """Save any file objects into the RO and update the local paths."""
         # Base case - we found a File we need to update
         _logger.debug(u"[provenance] Relativising: %s", structure)
@@ -1648,7 +1648,7 @@ def checksum_copy(src_file,            # type: IO
     return checksum.hexdigest().lower()
 
 def copy_job_order(job, job_order_object):
-    # type: (Any,Any) -> Any
+    # type: (Any, Any) -> Any
     """Create copy of job object for provenance."""
     if not hasattr(job, "tool"):
         # direct command line tool execution

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -514,8 +514,7 @@ class ProvenanceProfile():
         if not entity and 'location' in value:
             location = str(value['location'])
             # If we made it here, we'll have to add it to the RO
-            assert self.research_object.make_fs_access
-            fsaccess = self.research_object.make_fs_access("")
+            fsaccess = StdFsAccess("")
             with fsaccess.open(location, "rb") as fhandle:
                 relative_path = self.research_object.add_data_file(fhandle)
                 # FIXME: This naively relies on add_data_file setting hash as filename
@@ -605,8 +604,7 @@ class ProvenanceProfile():
         is_empty = True
 
         if not "listing" in value:
-            assert self.research_object.make_fs_access
-            fsaccess = self.research_object.make_fs_access("")
+            fsaccess = StdFsAccess("")
             get_listing(fsaccess, value)
         for entry in value.get("listing", []):
             is_empty = False
@@ -943,10 +941,9 @@ class ProvenanceProfile():
 class ResearchObject():
     """CWLProv Research Object."""
 
-    def __init__(self, make_fs_access, temp_prefix_ro="tmp", orcid='', full_name=''):
-        # type: (Callable[[Text], StdFsAccess], str, Text, Text) -> None
+    def __init__(self, temp_prefix_ro="tmp", orcid='', full_name=''):
+        # type: (str, Text, Text) -> None
 
-        self.make_fs_access = make_fs_access
         self.temp_prefix = temp_prefix_ro
         self.orcid = '' if not orcid else _valid_orcid(orcid)
         self.full_name = full_name
@@ -1553,7 +1550,7 @@ class ResearchObject():
                     # Register in RO; but why was this not picked
                     # up by used_artefacts?
                     _logger.info("[provenance] Adding to RO %s", structure["location"])
-                    fsaccess = self.make_fs_access("")
+                    fsaccess = StdFsAccess("")
                     with fsaccess.open(structure["location"], "rb") as fp:
                         relative_path = self.add_data_file(fp)
                         checksum = posixpath.basename(relative_path)

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -30,7 +30,7 @@ from .loghandler import _logger
 from .mutation import MutationManager  # pylint: disable=unused-import
 from .pathmapper import adjustDirObjs, get_listing
 from .process import Process, get_overrides, shortname, uniquename
-from .provenance import CreateProvProfile
+from .provenance import ProvenanceProfile
 from .software_requirements import (  # pylint: disable=unused-import
     DependenciesConfiguration)
 from .stdfsaccess import StdFsAccess
@@ -208,8 +208,8 @@ class WorkflowJob(object):
     def __init__(self, workflow, runtimeContext):
         # type: (Workflow, RuntimeContext) -> None
         self.workflow = workflow
-        self.prov_obj = None  # type: Optional[CreateProvProfile]
-        self.parent_wf = None  # type: Optional[CreateProvProfile]
+        self.prov_obj = None  # type: Optional[ProvenanceProfile]
+        self.parent_wf = None  # type: Optional[ProvenanceProfile]
         self.tool = workflow.tool
         if runtimeContext.research_obj is not None:
             self.prov_obj = workflow.provenance_object
@@ -500,14 +500,14 @@ class Workflow(Process):
                 ):  # type: (...) -> None
         super(Workflow, self).__init__(
             toolpath_object, loadingContext)
-        self.provenance_object = None  # type: Optional[CreateProvProfile]
+        self.provenance_object = None  # type: Optional[ProvenanceProfile]
         if loadingContext.research_obj is not None:
             run_uuid = None  # type: Optional[UUID]
-            is_master = not(loadingContext.prov_obj)  # Not yet set
+            is_master = not loadingContext.prov_obj  # Not yet set
             if is_master:
                 run_uuid = loadingContext.research_obj.ro_uuid
 
-            self.provenance_object = CreateProvProfile(
+            self.provenance_object = ProvenanceProfile(
                 loadingContext.research_obj,
                 full_name=loadingContext.cwl_full_name,
                 host_provenance=loadingContext.host_provenance,
@@ -528,7 +528,7 @@ class Workflow(Process):
         for index, step in enumerate(self.tool.get("steps", [])):
             try:
                 self.steps.append(self.make_workflow_step(step, index, loadingContext,
-                                               loadingContext.prov_obj))
+                                                          loadingContext.prov_obj))
             except validate.ValidationException as vexc:
                 if _logger.isEnabledFor(logging.DEBUG):
                     _logger.exception("Validation failed at")
@@ -559,7 +559,7 @@ class Workflow(Process):
                            toolpath_object,      # type: Dict[Text, Any]
                            pos,                  # type: int
                            loadingContext,       # type: LoadingContext
-                           parentworkflowProv=None  # type: Optional[CreateProvProfile]
+                           parentworkflowProv=None  # type: Optional[ProvenanceProfile]
     ):
         # (...) -> WorkflowStep
         return WorkflowStep(toolpath_object, pos, loadingContext, parentworkflowProv)
@@ -600,7 +600,7 @@ class WorkflowStep(Process):
                  toolpath_object,      # type: Dict[Text, Any]
                  pos,                  # type: int
                  loadingContext,       # type: LoadingContext
-                 parentworkflowProv=None  # type: Optional[CreateProvProfile]
+                 parentworkflowProv=None  # type: Optional[ProvenanceProfile]
                 ):  # type: (...) -> None
         if "id" in toolpath_object:
             self.id = toolpath_object["id"]
@@ -743,7 +743,7 @@ class WorkflowStep(Process):
                     oparam["type"] = {"type": "array", "items": oparam["type"]}
             self.tool["inputs"] = inputparms
             self.tool["outputs"] = outputparms
-        self.prov_obj = None  # type: Optional[CreateProvProfile]
+        self.prov_obj = None  # type: Optional[ProvenanceProfile]
         if loadingContext.research_obj is not None:
             self.prov_obj = parentworkflowProv
             if self.embedded_tool.tool["class"] == "Workflow":
@@ -775,7 +775,8 @@ class WorkflowStep(Process):
             self.embedded_tool.parent_wf = self.prov_obj
             process_name = self.tool["id"].split("#")[1]
             self.prov_obj.start_process(
-                process_name, self.embedded_tool.provenance_object.workflow_run_uri)
+                process_name, datetime.datetime.now(),
+                self.embedded_tool.provenance_object.workflow_run_uri)
         for inp in self.tool["inputs"]:
             field = shortname(inp["id"])
             if not inp.get("not_connected"):

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -572,8 +572,6 @@ class Workflow(Process):
         builder = self._init_job(job_order, runtimeContext)
         #relativeJob=copy.deepcopy(builder.job)
         if runtimeContext.research_obj is not None:
-            if not runtimeContext.research_obj.make_fs_access:
-                runtimeContext.research_obj.make_fs_access = runtimeContext.make_fs_access
             if runtimeContext.toplevel:
                 # Record primary-job.json
                 runtimeContext.research_obj.create_job(builder.job, self.job)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -6,6 +6,10 @@ import shutil
 import sys
 import tempfile
 from io import open
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 from six.moves import urllib
 
@@ -689,3 +693,7 @@ def test_whoami():
 def test_research_object():
     # TODO: Test ResearchObject methods
     pass
+
+# Reasearch object may need to be pickled (for Toil)
+def test_research_object_picklability(research_object):
+    assert pickle.dumps(research_object) is not None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -19,6 +19,7 @@ import bagit
 from cwltool import load_tool, provenance
 from cwltool.main import main
 from cwltool.resolver import Path
+from cwltool.context import RuntimeContext
 
 from .util import get_data, needs_docker, temp_dir, working_directory
 
@@ -528,7 +529,7 @@ def test_failing_path_conversion(path, from_type, to_type):
 
 @pytest.fixture
 def research_object():
-    re_ob = provenance.ResearchObject()
+    re_ob = provenance.ResearchObject(RuntimeContext().make_fs_access)
     yield re_ob
     re_ob.close()
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -533,7 +533,7 @@ def test_failing_path_conversion(path, from_type, to_type):
 
 @pytest.fixture
 def research_object():
-    re_ob = provenance.ResearchObject(RuntimeContext().make_fs_access)
+    re_ob = provenance.ResearchObject()
     yield re_ob
     re_ob.close()
 


### PR DESCRIPTION
Remove make_fs_access from ProvenanceProfile
Decouple adding start and stop times to profiles from the actual time it
happens
Decouple adding prospective provenance from the start of a process

This is preparatory work for https://github.com/DataBiosphere/toil/issues/2390