### PR TITLE
Resolve software requirements using Environment Modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='cwltool',
           ':os.name=="posix"': ['subprocess32 >= 3.5.0'],
           ':python_version<"3"': ['pathlib2 == 2.3.2'],
           ':python_version<"3.6"': ['typing >= 3.5.3'],
-          'deps': ["galaxy-lib >= 17.09.3"]
+          'deps': ["galaxy-lib >= 17.09.9"]
       },
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
       setup_requires=[] + pytest_runner,

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -31,3 +31,16 @@ def test_bioconda():
         ["--beta-conda-dependencies", "--debug", wflow, job])
 
     assert error_code == 0, stderr
+
+import os
+from distutils import spawn
+@pytest.mark.skipif(not spawn.find_executable("modulecmd"), reason="modulecmd not installed")
+def test_modules():
+    wflow = get_data("tests/random_lines.cwl")
+    job = get_data("tests/random_lines_job.json")
+    os.environ["MODULEPATH"] = os.path.join(os.getcwd(), 'tests/test_deps_env/modulefiles')
+    error_code, _, stderr = get_main_output(
+        ["--beta-dependency-resolvers-configuration",
+             "tests/test_deps_env_modules_resolvers_conf.yml", "--debug", wflow, job])
+
+    assert error_code == 0, stderr

--- a/tests/test_deps_env/modulefiles/random-lines/1.0
+++ b/tests/test_deps_env/modulefiles/random-lines/1.0
@@ -1,0 +1,15 @@
+#%Module -*- tcl -*-
+
+set name        random-lines
+set version     1.0
+set prefix      [file normalize [file join [file dirname ${ModulesCurrentModulefile}] ../../${name}/${version}]]
+
+module-whatis "Selects N random lines from a file and outputs to another file, maintaining original line order"
+
+if {![file exists $prefix]} {
+    puts stderr "\t[module-info name] Load Error: $prefix does not exist"
+    break
+    exit 1
+}
+
+prepend-path PATH ${prefix}/scripts

--- a/tests/test_deps_env_modules_resolvers_conf.yml
+++ b/tests/test_deps_env_modules_resolvers_conf.yml
@@ -1,0 +1,3 @@
+- type: modules
+  prefetch: false
+  find_by: directory


### PR DESCRIPTION
This PR adds a test for resolving software requirements using [Environment Modules](http://modules.sourceforge.net). This is a basic service of **galaxy-lib**, but only works since galaxyproject/galaxy@69a87003f70e3925554fcc88fd2080edab619ed1, available in 17.09.9 dated 2017-09-21. The test demonstrates that version 17.09.3 of galaxy-lib is inadequate. See #983

Specifically this PR:
* Adds a test using type `modules` for dependency resolvers configuration
* Specifies that the resolver use the find by directory strategy
* Adds a modulefile for random-lines in tests/test_deps_env/
* Bumps galaxy-lib to minimum **17.09.9**

The test is skipped if the command `modulecmd` is not available. To test this PR in CI one must add environment modules to the configuration of the build node.