### PR TITLE
Eliminate unnecessary deep copies of job order objects.

### DIFF
--- a/cwltool/__init__.py
+++ b/cwltool/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import absolute_import
-__author__ = 'peter.amstutz@curoverse.com'
+__author__ = 'pamstutz@veritasgenetics.com'

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -270,8 +270,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         dest="ga4gh_tool_registries", default=[])
 
     parser.add_argument("--on-error",
-                        help="Desired workflow behavior when a step fails.  One of 'stop' or 'continue'. "
-                             "Default is 'stop'.", default="stop", choices=("stop", "continue"))
+                        help="Desired workflow behavior when a step fails.  One of 'stop' (do not submit any more steps) or "
+                        "'continue' (may submit other steps that are not downstream from the error). Default is 'stop'.",
+                        default="stop", choices=("stop", "continue"))
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--compute-checksum", action="store_true", default=True,

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -12,7 +12,7 @@ import shutil
 import tempfile
 import threading
 from functools import cmp_to_key, partial
-from typing import (Any, Callable, Dict, Generator, List, MutableMapping,
+from typing import (Any, Callable, Dict, Generator, List, Mapping, MutableMapping,
                     MutableSequence, Optional, Set, Union, cast)
 
 import shellescape
@@ -102,7 +102,7 @@ class ExpressionTool(Process):
                 self.output_callback({}, "permanentFail")
 
     def job(self,
-            job_order,         # type: MutableMapping[Text, Text]
+            job_order,         # type: Mapping[Text, Text]
             output_callbacks,  # type: Callable[[Any, Any], Any]
             runtimeContext     # type: RuntimeContext
            ):
@@ -275,7 +275,7 @@ class CommandLineTool(Process):
             self.updatePathmap(os.path.join(outdir, fn["basename"]), pathmap, ls)
 
     def job(self,
-            job_order,         # type: MutableMapping[Text, Text]
+            job_order,         # type: Mapping[Text, Text]
             output_callbacks,  # type: Callable[[Any, Any], Any]
             runtimeContext     # RuntimeContext
            ):
@@ -402,7 +402,7 @@ class CommandLineTool(Process):
                           self.tool.get("id", ""),
                           u" as part of %s" % runtimeContext.part_of
                           if runtimeContext.part_of else "")
-            _logger.debug(u"[job %s] %s", j.name, json_dumps(job_order,
+            _logger.debug(u"[job %s] %s", j.name, json_dumps(builder.job,
                                                              indent=4))
 
         builder.pathmapper = self.make_path_mapper(

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -16,7 +16,7 @@ import uuid
 from collections import Iterable  # pylint: disable=unused-import
 from io import open
 from typing import (Any, Callable, Dict, Generator, Iterator, List,
-                    MutableMapping, MutableSequence, Optional, Set, Tuple,
+                    Mapping, MutableMapping, MutableSequence, Optional, Set, Tuple,
                     Union, cast)
 
 from pkg_resources import resource_stream
@@ -590,7 +590,7 @@ class Process(with_metaclass(abc.ABCMeta, HasReqsHints)):
             var_spool_cwl_detector(self.tool)
 
     def _init_job(self, joborder, runtime_context):
-        # type: (MutableMapping[Text, Text], RuntimeContext) -> Builder
+        # type: (Mapping[Text, Text], RuntimeContext) -> Builder
 
         job = cast(Dict[Text, Union[Dict[Text, Any], List[Any], Text, None]],
                    copy.deepcopy(joborder))
@@ -790,7 +790,7 @@ class Process(with_metaclass(abc.ABCMeta, HasReqsHints)):
 
     @abc.abstractmethod
     def job(self,
-            job_order,         # type: MutableMapping[Text, Text]
+            job_order,         # type: Mapping[Text, Text]
             output_callbacks,  # type: Callable[[Any, Any], Any]
             runtimeContext     # type: RuntimeContext
            ):  # type: (...) -> Generator[Any, None, None]

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -363,7 +363,8 @@ def cleanIntermediate(output_dirs):  # type: (Iterable[Text]) -> None
 def add_sizes(fsaccess, obj):  # type: (StdFsAccess, Dict[Text, Any]) -> None
     if 'location' in obj:
         try:
-            obj["size"] = fsaccess.size(obj["location"])
+            if "size" not in obj:
+                obj["size"] = fsaccess.size(obj["location"])
         except OSError:
             pass
     elif 'contents' in obj:


### PR DESCRIPTION
Tweak mypy annotations so the method parameter is a read-only Mapping.

Also includes efficiency tweak from #986 