### PR TITLE
use subprocess from stdlib on python>=3.5

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -23,10 +23,17 @@ from .pathmapper import PathMapper, MapperEnt  # pylint: disable=unused-import
 from .pathmapper import ensure_writable, ensure_non_writable
 from .process import UnsupportedRequirement
 from .utils import docker_windows_path_adjust
+
 if os.name == 'posix':
-    from subprocess32 import (  # pylint: disable=import-error,no-name-in-module
-        check_call, check_output, CalledProcessError, DEVNULL, PIPE, Popen,
-        TimeoutExpired)
+    if sys.version_info < (3, 5):
+        from subprocess32 import (  # pylint: disable=import-error,no-name-in-module
+            check_call, check_output, CalledProcessError, DEVNULL, PIPE, Popen,
+            TimeoutExpired)
+    else:
+        from subprocess import (  # pylint: disable=import-error,no-name-in-module
+            check_call, check_output, CalledProcessError, DEVNULL, PIPE, Popen,
+            TimeoutExpired)
+
 else:  # we're not on Unix, so none of this matters
     pass
 

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -22,7 +22,10 @@ from typing_extensions import Deque, Text  # pylint: disable=unused-import
 
 # no imports from cwltool allowed
 if os.name == 'posix':
-    import subprocess32 as subprocess  # pylint: disable=unused-import
+    if sys.version_info < (3, 5):
+        import subprocess32 as subprocess  # pylint: disable=unused-import
+    else:
+        import subprocess  # pylint: disable=unused-import
 else:
     import subprocess  # type: ignore
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ bagit==1.6.4
 mypy-extensions
 psutil
 scandir
-subprocess32 >= 3.5.0; os.name=="posix"
+subprocess32 >= 3.5.0; os.name=="posix" and python_version<"3.5"
 typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name='cwltool',
           'typing-extensions',
       ],
       extras_require={
-          ':os.name=="posix"': ['subprocess32 >= 3.5.0'],
+          ':os.name=="posix" and python_version<"3.5"': ['subprocess32 >= 3.5.0'],
           ':python_version<"3"': ['pathlib2 == 2.3.2'],
           ':python_version<"3.6"': ['typing >= 3.5.3'],
           'deps': ["galaxy-lib >= 17.09.9"]


### PR DESCRIPTION
This patch allows dropping the subprocess32 dependency for python>=3.5.

I do not have py3.2-3.5 here, so I haven't tested on those.