### PR TITLE
"checklinks" flag should not be based on do_validate

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -677,8 +677,8 @@ class CommandLineTool(Process):
                             globpatterns.extend(aslist(gb))
 
                     for gb in globpatterns:
-                        if gb.startswith(outdir):
-                            gb = gb[len(outdir) + 1:]
+                        if gb.startswith(builder.outdir):
+                            gb = gb[len(builder.outdir) + 1:]
                         elif gb == ".":
                             gb = outdir
                         elif gb.startswith("/"):

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -282,8 +282,7 @@ def resolve_and_validate_document(loadingContext,
         _add_blank_ids(workflowobj)
 
     workflowobj["id"] = fileuri
-    processobj, metadata = document_loader.resolve_all(
-        workflowobj, fileuri, checklinks=loadingContext.do_validate)
+    processobj, metadata = document_loader.resolve_all(workflowobj, fileuri)
     if loadingContext.metadata:
         metadata = loadingContext.metadata
     if not isinstance(processobj, (CommentedMap, CommentedSeq)):

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -286,7 +286,7 @@ def resolve_and_validate_document(loadingContext,
     if cwlVersion == "v1.0":
         _add_blank_ids(workflowobj)
 
-    processobj, metadata = document_loader.resolve_all(workflowobj, fileuri)
+    processobj, metadata = document_loader.resolve_all(workflowobj, uri)
     if loadingContext.metadata:
         metadata = loadingContext.metadata
     if not isinstance(processobj, (CommentedMap, CommentedSeq)):
@@ -313,7 +313,7 @@ def resolve_and_validate_document(loadingContext,
             for po in processobj:
                 document_loader.idx[po["id"]] = po
         else:
-            raise Exception("Whoops processobj was not MutableMapping or MutableSequence %s", type(processobj))
+            raise Exception("'processobj' was not MutableMapping or MutableSequence %s" % type(processobj))
 
     if jobobj is not None:
         loadingContext.jobdefaults = jobobj

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -286,7 +286,7 @@ def resolve_and_validate_document(loadingContext,
     if cwlVersion == "v1.0":
         _add_blank_ids(workflowobj)
 
-    processobj, metadata = document_loader.resolve_all(workflowobj, uri)
+    processobj, metadata = document_loader.resolve_all(workflowobj, fileuri)
     if loadingContext.metadata:
         metadata = loadingContext.metadata
     if not isinstance(processobj, (CommentedMap, CommentedSeq)):

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -208,7 +208,7 @@ def resolve_and_validate_document(loadingContext,
 
     jobobj = None
     if "cwl:tool" in workflowobj:
-        jobobj, _ = loadingContext.loader.resolve_all(workflowobj, uri, checklinks=loadingContext.do_validate)
+        jobobj, _ = loadingContext.loader.resolve_all(workflowobj, uri)
         uri = urllib.parse.urljoin(uri, workflowobj["https://w3id.org/cwl/cwl#tool"])
         del cast(dict, jobobj)["https://w3id.org/cwl/cwl#tool"]
 

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -221,7 +221,7 @@ def resolve_and_validate_document(loadingContext,
         cwlVersion = workflowobj.get("cwlVersion")
     if not cwlVersion and fileuri != uri:
         # The tool we're loading is a fragment of a bigger file.  Get
-        # the document root element and look for cwlVersion there
+        # the document root element and look for cwlVersion there.
         metadata = fetch_document(fileuri, loadingContext)[1]
         cwlVersion = metadata.get("cwlVersion")
     if not cwlVersion:
@@ -304,6 +304,8 @@ def resolve_and_validate_document(loadingContext,
 
     # None means default behavior (do update)
     if loadingContext.do_update in (True, None):
+        if "cwlVersion" not in metadata:
+            metadata["cwlVersion"] = cwlVersion
         processobj = cast(CommentedMap, cmap(update.update(
             processobj, document_loader, fileuri, loadingContext.enable_dev, metadata)))
         if isinstance(processobj, MutableMapping):

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -27,11 +27,11 @@ def v1_0to1_1_0dev1(doc, loader, baseuri):  # pylint: disable=unused-argument
 
     rewrite = {
         "http://commonwl.org/cwltool#WorkReuse": "WorkReuse",
+        "http://arvados.org/cwl#ReuseRequirement": "WorkReuse",
         "http://commonwl.org/cwltool#TimeLimit": "ToolTimeLimit",
         "http://commonwl.org/cwltool#NetworkAccess": "NetworkAccess",
         "http://commonwl.org/cwltool#InplaceUpdateRequirement": "InplaceUpdateRequirement",
-        "http://commonwl.org/cwltool#LoadListingRequirement": "LoadListingRequirement",
-        "http://commonwl.org/cwltool#WorkReuse": "WorkReuse",
+        "http://commonwl.org/cwltool#LoadListingRequirement": "LoadListingRequirement"
     }
     def rewrite_requirements(t):
         if "requirements" in t:

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -73,6 +73,8 @@ def v1_0to1_1_0dev1(doc, loader, baseuri):  # pylint: disable=unused-argument
         proc.setdefault("hints", [])
         proc["hints"].insert(0, {"class": "NetworkAccess", "networkAccess": True})
         proc["hints"].insert(0, {"class": "LoadListingRequirement", "loadListing": "deep_listing"})
+        if "cwlVersion" in proc:
+            del proc["cwlVersion"]
 
     return (doc, "v1.1.0-dev1")
 

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -42,3 +42,17 @@ def test_use_metadata():
     tooldata = tool.tool.copy()
     del tooldata["cwlVersion"]
     tool2 = load_tool(tooldata, loadingContext)
+
+def test_checklink_outputSource():
+    """Test that outputSource is resolved correctly independent of value
+    of do_validate.
+
+    """
+
+    loadingContext = LoadingContext({"do_validate": True})
+    tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
+    assert tool.tool["outputs"][0]["outputSource"] == "file://"+get_data("tests/wf/1st-workflow.cwl")+"#argument/classfile"
+
+    loadingContext = LoadingContext({"do_validate": False})
+    tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
+    assert tool.tool["outputs"][0]["outputSource"] == "file://"+get_data("tests/wf/1st-workflow.cwl")+"#argument/classfile"

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -55,8 +55,8 @@ def test_checklink_outputSource():
 
     loadingContext = LoadingContext({"do_validate": True})
     tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
-    assert tool.tool["outputs"][0]["outputSource"] == outsrc
+    assert norm(tool.tool["outputs"][0]["outputSource"]) == outsrc
 
     loadingContext = LoadingContext({"do_validate": False})
     tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
-    assert tool.tool["outputs"][0]["outputSource"] == outsrc
+    assert norm(tool.tool["outputs"][0]["outputSource"]) == outsrc

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -7,6 +7,8 @@ from .util import (get_data, get_main_output,
                    needs_docker, working_directory,
                    needs_singularity, temp_dir,
                    windows_needs_docker)
+from cwltool.resolver import Path, resolve_local
+from .test_fetch import norm
 
 @windows_needs_docker
 def test_check_version():
@@ -49,10 +51,12 @@ def test_checklink_outputSource():
 
     """
 
+    outsrc = norm(Path(get_data("tests/wf/1st-workflow.cwl")).as_uri())+"#argument/classfile"
+
     loadingContext = LoadingContext({"do_validate": True})
     tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
-    assert tool.tool["outputs"][0]["outputSource"] == "file://"+get_data("tests/wf/1st-workflow.cwl")+"#argument/classfile"
+    assert tool.tool["outputs"][0]["outputSource"] == outsrc
 
     loadingContext = LoadingContext({"do_validate": False})
     tool = load_tool(get_data("tests/wf/1st-workflow.cwl"), loadingContext)
-    assert tool.tool["outputs"][0]["outputSource"] == "file://"+get_data("tests/wf/1st-workflow.cwl")+"#argument/classfile"
+    assert tool.tool["outputs"][0]["outputSource"] == outsrc


### PR DESCRIPTION
This flag is used internally by schema salad to determine when it is
appropriate to run checklinks, but checklinks must not be skipped
entirely as it includes updating fields in certain circumstances.