### PR TITLE
Add an option to mount the docker socket volume.

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -292,6 +292,10 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     parser.add_argument("--force-docker-pull", action="store_true",
                         default=False, help="Pull latest docker image even if"
                                             " it is locally present", dest="force_docker_pull")
+    parser.add_argument("--mount-docker-socket-volume", action="store_true",
+                        default=False, help="Mount the /var/run/docker.sock volume when running the "
+                                            "docker image. This is needed if the docker image "
+                                            "calls another docker image within it.", dest="mount_docker_socket_volume")
     parser.add_argument("--no-read-only", action="store_true",
                         default=False, help="Do not set root directory in the"
                                             " container as read-only", dest="no_read_only")

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -87,6 +87,7 @@ class RuntimeContext(ContextBase):
         self.preserve_entire_environment = False  # type: bool
         self.use_container = True       # type: bool
         self.force_docker_pull = False  # type: bool
+        self.mount_docker_socket_volume = False  # type: bool
 
         self.tmp_outdir_prefix = DEFAULT_TMP_PREFIX  # type: Text
         self.tmpdir_prefix = DEFAULT_TMP_PREFIX  # type: Text

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -294,6 +294,8 @@ class DockerCommandLineJob(ContainerCommandLineJob):
                 runtime = [user_space_docker_cmd, u"run"]
         else:
             runtime = [u"docker", u"run", u"-i"]
+        if runtimeContext.mount_docker_socket_volume:
+            runtime.append(u"--volume=/var/run/docker.sock:/var/run/docker.sock")
         self.append_volume(runtime, os.path.realpath(self.outdir),
                            self.builder.outdir, writable=True)
         tmpdir = "/tmp"  # nosec


### PR DESCRIPTION
This is useful for running docker within a docker image through sibling containers.

I realize that the nested docker run command can be implemented as a separate task, but there are situations where having this feature dramatically simplifies the pipeline.
Example use case: one of the tasks in a large pipeline calls a script that's packaged inside another docker image. The inputs/outputs are complex and the docker script needs to run several times for each task. Extracting the inner docker call to its own task adds a lot of unnecessary overhead to both the pipeline (passing many inputs/outputs that are not needed by other parts of the pipeline) and the workflow engine (needs to keep track of many additional smaller tasks for each input).