### PR TITLE
If document has an id: field, use it.

### DIFF
--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -291,6 +291,9 @@ def resolve_and_validate_document(loadingContext,
     if not isinstance(metadata, CommentedMap):
         raise ValidationException("metadata must be a CommentedMap, was %s" % type(metadata))
 
+    if isinstance(processobj, CommentedMap):
+        uri = processobj["id"]
+
     _convert_stdstreams_to_files(workflowobj)
 
     if preprocess_only:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -108,7 +108,7 @@ def _pack_idempotently(document):
     loadingContext.do_update = False
     loadingContext, uri2 = resolve_and_validate_document(
         loadingContext, workflowobj, uri)
-    processobj = loadingContext.loader.resolve_ref(uri)[0]
+    processobj = loadingContext.loader.resolve_ref(uri2)[0]
     double_packed = json.loads(print_pack(loadingContext.loader, processobj, uri2, loadingContext.metadata))
     assert packed == double_packed
 


### PR DESCRIPTION
From resolve_and_validate return uri with the added id fragment and
use it downstream to reference the document.