### PR TITLE
Don't resolve format fields on initial load of job order object.

### DIFF
--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -40,7 +40,6 @@ jobloaderctx = {
     u"cwltool": "http://commonwl.org/cwltool#",
     u"path": {u"@type": u"@id"},
     u"location": {u"@type": u"@id"},
-    u"format": {u"@type": u"@id"},
     u"id": u"@id"
 }  # type: ContextType
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -358,6 +358,7 @@ def init_job_order(job_order_object,        # type: Optional[MutableMapping[Text
             del p["path"]
 
     ns = {}  # type: Dict[Text, Union[Dict[Any, Any], Text, Iterable[Text]]]
+    ns.update(job_order_object.get("$namespaces", {}))
     ns.update(process.metadata.get("$namespaces", {}))
     ld = Loader(ns)
 


### PR DESCRIPTION
Eliminate spurious warning when input document has a format identifier with a prefix only defined in the tool document.  Also fixes behavior of applying resolution to other fields called "format" that are not actually supposed to be file formats.