### PR TITLE
Tweak packing and scandeps

### DIFF
--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -8,6 +8,7 @@ from typing import (Any, Callable, Dict, List, MutableMapping, MutableSequence,
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.ref_resolver import Loader  # pylint: disable=unused-import
 from schema_salad.ref_resolver import SubLoader
+from schema_salad.sourceline import cmap
 from six import iteritems, string_types
 from six.moves import urllib
 from typing_extensions import Text  # pylint: disable=unused-import
@@ -170,8 +171,8 @@ def pack(document_loader,  # type: Loader
     for r in sortedids:
         rewrite_id(r, uri)
 
-    packed = {"$graph": [], "cwlVersion": metadata["cwlVersion"]
-              }  # type: Dict[Text, Any]
+    packed = CommentedMap((("$graph", CommentedSeq()),
+                           ("cwlVersion", metadata["cwlVersion"])))  # type: CommentedMap[Text, Any]
     namespaces = metadata.get('$namespaces', None)
 
     schemas = set()  # type: Set[Text]
@@ -217,6 +218,6 @@ def pack(document_loader,  # type: Loader
             packed["$graph"][0]["$schemas"] = list(schemas)
     # always include $namespaces in the #main
     if namespaces:
-        packed["$graph"][0]["$namespaces"] = dict(cast(Dict, namespaces))
+        packed["$graph"][0]["$namespaces"] = cmap(namespaces)
 
     return packed

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -172,7 +172,7 @@ def pack(document_loader,  # type: Loader
         rewrite_id(r, uri)
 
     packed = CommentedMap((("$graph", CommentedSeq()),
-                           ("cwlVersion", metadata["cwlVersion"])))  # type: CommentedMap[Text, Any]
+                           ("cwlVersion", metadata["cwlVersion"])))
     namespaces = metadata.get('$namespaces', None)
 
     schemas = set()  # type: Set[Text]

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -982,8 +982,12 @@ def scandeps(base,                          # type: Text
                             base, u, reffields, urlfields, loadref,
                             urljoin=urljoin, nestdirs=nestdirs))
                     else:
-                        sub = loadref(base, u)
                         subid = urljoin(base, u)
+                        basedf, _ = urllib.parse.urldefrag(base)
+                        subiddf, _ = urllib.parse.urldefrag(subid)
+                        if basedf == subiddf:
+                            continue
+                        sub = loadref(base, u)
                         deps = {
                             "class": "File",
                             "location": subid,


### PR DESCRIPTION
1) allows result from pack() to be re-run back through resolve_all

2) scandeps no longer adds dependencies for same-file cross references.