### PR TITLE
handle error in cidfile removal more gracefully

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -707,7 +707,7 @@ class ContainerCommandLineJob(with_metaclass(ABCMeta, JobBase)):
                 if cleanup_cidfile:
                     try:
                         os.remove(cidfile)
-                    except PermissionError as exc:
+                    except OSError as exc:
                         _logger.warn("Ignored error cleaning up Docker cidfile: %s", exc)
                     return
             try:
@@ -725,7 +725,7 @@ class ContainerCommandLineJob(with_metaclass(ABCMeta, JobBase)):
                      cid], stdout=stats_file_handle, stderr=subprocess.DEVNULL)
                 process.wait()
                 stats_proc.kill()
-        except PermissionError as exc:
+        except OSError as exc:
             _logger.warn("Ignored error with docker stats: %s", exc)
             return
         max_mem_percent = 0

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -705,8 +705,11 @@ class ContainerCommandLineJob(with_metaclass(ABCMeta, JobBase)):
             time.sleep(1)
             if process.returncode is not None:
                 if cleanup_cidfile:
-                    os.remove(cidfile)
-                return
+                    try:
+                        os.remove(cidfile)
+                    except PermissionError as exc:
+                        _logger.warn("Ignored error cleaning up Docker cidfile: %s", exc)
+                    return
             try:
                 with open(cidfile) as cidhandle:
                     cid = cidhandle.readline().strip()

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -718,12 +718,16 @@ class ContainerCommandLineJob(with_metaclass(ABCMeta, JobBase)):
         max_mem = psutil.virtual_memory().total
         tmp_dir, tmp_prefix = os.path.split(tmpdir_prefix)
         stats_file = tempfile.NamedTemporaryFile(prefix=tmp_prefix, dir=tmp_dir)
-        with open(stats_file.name, mode="w") as stats_file_handle:
-            stats_proc = subprocess.Popen(
-                ['docker', 'stats', '--no-trunc', '--format', '{{.MemPerc}}',
-                 cid], stdout=stats_file_handle, stderr=subprocess.DEVNULL)
-            process.wait()
-            stats_proc.kill()
+        try:
+            with open(stats_file.name, mode="w") as stats_file_handle:
+                stats_proc = subprocess.Popen(
+                    ['docker', 'stats', '--no-trunc', '--format', '{{.MemPerc}}',
+                     cid], stdout=stats_file_handle, stderr=subprocess.DEVNULL)
+                process.wait()
+                stats_proc.kill()
+        except PermissionError as exc:
+            _logger.warn("Ignored error with docker stats: %s", exc)
+            return
         max_mem_percent = 0
         with open(stats_file.name, mode="r") as stats:
             for line in stats:

--- a/tests/test_udocker.py
+++ b/tests/test_udocker.py
@@ -10,7 +10,8 @@ from psutil.tests import TRAVIS
 LINUX = sys.platform in ('linux', 'linux2')
 
 
-@pytest.mark.skipif(not LINUX, reason="LINUX only")
+#@pytest.mark.skipif(not LINUX, reason="LINUX only")
+@pytest.mark.skip("Udocker install is broken, see https://github.com/indigo-dc/udocker/issues/221")
 class TestUdocker:
     udocker_path = None
 


### PR DESCRIPTION
Fixes #1182 by reducing to the real underlying error, Docker wasn't able to mount the path due to Windows system permission problems