### PR TITLE
Push conformance badges to commonwl/conformance repository

### DIFF
--- a/jenkins.bash
+++ b/jenkins.bash
@@ -86,10 +86,8 @@ EOF
 		rm -Rf conformance
 		git clone http://${jenkins_cwl_conformance}@github.com/common-workflow-language/conformance.git
 
-		pushd conformance
-		git config user.email "cwl-bot@users.noreply.github.com"
-		git config user.name "CWL Jenkins build bot"
-		popd
+		git -C conformance config user.email "cwl-bot@users.noreply.github.com"
+		git -C conformance config user.name "CWL Jenkins build bot"
 
 		tool_ver=$(cwltool --version | awk '{ print $2 }')
 		badgedir=${PWD}/conformance/cwltool/cwl_${version}/cwltool_${tool_ver}
@@ -109,11 +107,9 @@ EOF
 
 	if [ -d conformance ]
 	then
-		pushd conformance
-		git add --all
-		git diff-index --quiet HEAD || git commit -m "CWL Jenkins Build bot"
-		git push http://${jenkins_cwl_conformance}:x-oauth-basic@github.com/common-workflow-language/conformance.git
-		popd
+		git -C conformance add --all
+		git -C conformance diff-index --quiet HEAD || git -C conformance commit -m "CWL Jenkins Build bot"
+		git -C conformance push http://${jenkins_cwl_conformance}:x-oauth-basic@github.com/common-workflow-language/conformance.git
 	fi
 
 	deactivate

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -88,6 +88,13 @@ EOF
 
 		git -C conformance config user.email "cwl-bot@users.noreply.github.com"
 		git -C conformance config user.name "CWL Jenkins build bot"
+		CONFORMANCE_MSG=$(cat << EOM
+Conformance test of cwltool ${tool_ver} for CWL ${version}
+Commit: ${GIT_COMMIT}
+Python version: ${PYTHON_VERSION}
+Container: ${CONTAINER}
+EOM
+)
 
 		tool_ver=$(cwltool --version | awk '{ print $2 }')
 		badgedir=${PWD}/conformance/cwltool/cwl_${version}/cwltool_${tool_ver}
@@ -108,7 +115,7 @@ EOF
 	if [ -d conformance ]
 	then
 		git -C conformance add --all
-		git -C conformance diff-index --quiet HEAD || git -C conformance commit -m "CWL Jenkins Build bot"
+		git -C conformance diff-index --quiet HEAD || git -C conformance commit -m "${CONFORMANCE_MSG}"
 		git -C conformance push http://${jenkins_cwl_conformance}:x-oauth-basic@github.com/common-workflow-language/conformance.git
 	fi
 

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -81,7 +81,7 @@ EOF
 	then
 		EXTRA="EXTRA=${EXTRA}"
 	fi
-	if [[ "$version" = "v1.0" ]] && [[ "$CONTAINER" = "docker" ]] && [ $PYTHON_VERSION -eq 3 ]
+	if [ "$GIT_BRANCH" = "origin/master" ] && [[ "$version" = "v1.0" ]] && [[ "$CONTAINER" = "docker" ]] && [ $PYTHON_VERSION -eq 3 ]
 	then
 		rm -Rf conformance
 		git clone http://${jenkins_cwl_conformance}@github.com/common-workflow-language/conformance.git


### PR DESCRIPTION
This PR pushes the conformance badges generated in the Jenkins server to [common-workflow-language/conformance](https://github.com/common-workflow-language/conformance) repository.

These conformance badges are useful for users to check how a given engine satisfies CWL specification.