### PR TITLE
Provide cwltool_latest for badges

### DIFF
--- a/jenkins.bash
+++ b/jenkins.bash
@@ -114,6 +114,7 @@ EOM
 
 	if [ -d conformance ]
 	then
+		cp -r conformance/cwltool/cwl_${version}/cwltool_${tool_ver} conformance/cwltool/cwl_${version}/cwltool_latest
 		git -C conformance add --all
 		git -C conformance diff-index --quiet HEAD || git -C conformance commit -m "${CONFORMANCE_MSG}"
 		git -C conformance push http://${jenkins_cwl_conformance}:x-oauth-basic@github.com/common-workflow-language/conformance.git

--- a/jenkins.bash
+++ b/jenkins.bash
@@ -114,6 +114,7 @@ EOM
 
 	if [ -d conformance ]
 	then
+		rm -rf conformance/cwltool/cwl_${version}/cwltool_latest
 		cp -r conformance/cwltool/cwl_${version}/cwltool_${tool_ver} conformance/cwltool/cwl_${version}/cwltool_latest
 		git -C conformance add --all
 		git -C conformance diff-index --quiet HEAD || git -C conformance commit -m "${CONFORMANCE_MSG}"


### PR DESCRIPTION
It just copy `cwltool_$version` to `cwltool_latest` generated in Jenkins CI because symlink does not work in Github.
It is not the best solution but it is enough as a workaround.