### PR TITLE
test with Python 3.8 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+
 install:
   - ps: 'Install-Product node 0.12 x64'
   - "set PATH=%PYTHON%\\Scripts;%PATH%"


### PR DESCRIPTION
- [x] Failing due to lack of MS Windows Python 3.8 wheel for `lxml`