### PR TITLE
Abstract operation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cwltool/schemas/v1.2-dev2"]
+	path = cwltool/schemas/v1.2-dev2
+	url = https://github.com/common-workflow-language/cwl-v1.2.git
+	branch = abstract-operation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "cwltool/schemas/v1.2.0-dev2"]
-	path = cwltool/schemas/v1.2.0-dev2
+[submodule "cwltool/schemas/v1.2.0-dev1"]
+	path = cwltool/schemas/v1.2.0-dev1
 	url = https://github.com/common-workflow-language/cwl-v1.2.git
-	branch = abstract-operation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "cwltool/schemas/v1.2-dev2"]
-	path = cwltool/schemas/v1.2-dev2
+[submodule "cwltool/schemas/v1.2.0-dev2"]
+	path = cwltool/schemas/v1.2.0-dev2
 	url = https://github.com/common-workflow-language/cwl-v1.2.git
 	branch = abstract-operation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,10 +24,10 @@ include cwltool/schemas/v1.1.0-dev1/*.yml
 include cwltool/schemas/v1.1.0-dev1/*.md
 include cwltool/schemas/v1.1.0-dev1/salad/schema_salad/metaschema/*.yml
 include cwltool/schemas/v1.1.0-dev1/salad/schema_salad/metaschema/*.md
-include cwltool/schemas/v1.2.0-dev2/*.yml
-include cwltool/schemas/v1.2.0-dev2/*.md
-include cwltool/schemas/v1.2.0-dev2/salad/schema_salad/metaschema/*.yml
-include cwltool/schemas/v1.2.0-dev2/salad/schema_salad/metaschema/*.md
+include cwltool/schemas/v1.2.0-dev1/*.yml
+include cwltool/schemas/v1.2.0-dev1/*.md
+include cwltool/schemas/v1.2.0-dev1/salad/schema_salad/metaschema/*.yml
+include cwltool/schemas/v1.2.0-dev1/salad/schema_salad/metaschema/*.md
 include cwltool/cwlNodeEngine.js
 include cwltool/cwlNodeEngineJSConsole.js
 include cwltool/cwlNodeEngineWithContext.js

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,10 @@ include cwltool/schemas/v1.1.0-dev1/*.yml
 include cwltool/schemas/v1.1.0-dev1/*.md
 include cwltool/schemas/v1.1.0-dev1/salad/schema_salad/metaschema/*.yml
 include cwltool/schemas/v1.1.0-dev1/salad/schema_salad/metaschema/*.md
+include cwltool/schemas/v1.2.0-dev2/*.yml
+include cwltool/schemas/v1.2.0-dev2/*.md
+include cwltool/schemas/v1.2.0-dev2/salad/schema_salad/metaschema/*.yml
+include cwltool/schemas/v1.2.0-dev2/salad/schema_salad/metaschema/*.md
 include cwltool/cwlNodeEngine.js
 include cwltool/cwlNodeEngineJSConsole.js
 include cwltool/cwlNodeEngineWithContext.js

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -882,7 +882,10 @@ class Operation(Process):
                ):  # type: (...) -> None
             _logger.warning(u"Can't execute abstract Operation %s",
                             Text(self.operation.tool["id"]), exc_info=runtimeContext.debug)
-            self.output_callback({}, "permanentFail")
+            # TODO: Support "default"?
+            out = dict((shortname(port["id"]), None)
+                        for port in self.operation.tool["outputs"])
+            self.output_callback(out, "permanentFail")
 
     def job(self,
             job_order,         # type: Mapping[Text, Text]

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -104,6 +104,7 @@ cwl_files = (
     "CommandLineTool.yml",
     "CommonWorkflowLanguage.yml",
     "Process.yml",
+    "Operation.yml",
     "concepts.md",
     "contrib.md",
     "intro.md",

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 import copy
 import re
-from typing import (Any, Callable, Dict, List, MutableMapping, MutableSequence,
+from typing import (Any, Callable, Dict, MutableMapping, MutableSequence,
                     Optional, Tuple, Union)
-
-from functools import partial
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad import validate
@@ -21,9 +19,26 @@ from .loghandler import _logger
 from .utils import visit_class, visit_field, aslist
 
 
+def v1_1to1_2(doc, loader, baseuri):  # pylint: disable=unused-argument
+    # type: (Any, Loader, Text) -> Tuple[Any, Text]
+    """Public updater for v1.1 to v1.2"""
+
+    doc = copy.deepcopy(doc)
+
+    upd = doc
+    if isinstance(upd, MutableMapping) and "$graph" in upd:
+        upd = upd["$graph"]
+    for proc in aslist(upd):
+        if "cwlVersion" in proc:
+            del proc["cwlVersion"]
+
+    return doc, "v1.2"
+
+
 def v1_0to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
     # type: (Any, Loader, Text) -> Tuple[Any, Text]
     """Public updater for v1.0 to v1.1."""
+
     doc = copy.deepcopy(doc)
 
     rewrite = {
@@ -34,101 +49,73 @@ def v1_0to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
         "http://commonwl.org/cwltool#InplaceUpdateRequirement": "InplaceUpdateRequirement",
         "http://commonwl.org/cwltool#LoadListingRequirement": "LoadListingRequirement"
     }
-    def rewrite_requirements(t):  # type: (MutableMapping[Text, Union[Text, Dict[Text, Any]]]) -> None
+    def rewrite_requirements(t):
         if "requirements" in t:
             for r in t["requirements"]:
-                if isinstance(r, MutableMapping):
-                    if r["class"] in rewrite:
-                        r["class"] = rewrite[r["class"]]
-                else:
-                    raise validate.ValidationException(
-                            "requirements entries must be dictionaries: {} {}.".format(
-                                type(r), r))
+                if r["class"] in rewrite:
+                    r["class"] = rewrite[r["class"]]
         if "hints" in t:
             for r in t["hints"]:
-                if isinstance(r, MutableMapping):
-                    if r["class"] in rewrite:
-                        r["class"] = rewrite[r["class"]]
-                else:
-                    raise validate.ValidationException(
-                        "hints entries must be dictionaries: {} {}.".format(
-                            type(r), r))
+                if r["class"] in rewrite:
+                    r["class"] = rewrite[r["class"]]
         if "steps" in t:
             for s in t["steps"]:
-                if isinstance(s, MutableMapping):
-                    rewrite_requirements(s)
-                else:
-                    raise validate.ValidationException(
-                        "steps entries must be dictionaries: {} {}.".format(
-                            type(s), s))
+                rewrite_requirements(s)
 
-
-    def update_secondaryFiles(t, top=False):
-        # type: (Any, bool) -> Union[MutableSequence[MutableMapping[Text, Text]], MutableMapping[Text, Text]]
-        if isinstance(t, CommentedSeq):
-            new_seq = copy.deepcopy(t)
-            for index, entry in enumerate(t):
-                new_seq[index] = update_secondaryFiles(entry)
-            return new_seq
-        elif isinstance(t, MutableSequence):
-            return CommentedSeq([update_secondaryFiles(p) for p in t])
-        elif isinstance(t, MutableMapping):
-            return t
-        elif top:
-            return CommentedSeq([CommentedMap([("pattern", t)])])
+    def update_secondaryFiles(t):
+        if isinstance(t, MutableSequence):
+            return [{"pattern": p} for p in t]
         else:
-            return CommentedMap([("pattern", t)])
+            return {"pattern": t}
 
-    def fix_inputBinding(t):  # type: (Dict[Text, Any]) -> None
+    def fix_inputBinding(t):
         for i in t["inputs"]:
             if "inputBinding" in i:
                 ib = i["inputBinding"]
                 for k in list(ib.keys()):
                     if k != "loadContents":
-                        _logger.warning(SourceLine(ib, k).makeError(
-                            "Will ignore field '{}' which is not valid in {} "
-                            "inputBinding".format(k, t["class"])))
+                        _logger.warning(SourceLine(ib, k).makeError("Will ignore field '%s' which is not valid in %s inputBinding" %
+                                                                    (k, t["class"])))
                         del ib[k]
 
     visit_class(doc, ("CommandLineTool","Workflow"), rewrite_requirements)
     visit_class(doc, ("ExpressionTool","Workflow"), fix_inputBinding)
-    visit_field(doc, "secondaryFiles", partial(update_secondaryFiles, top=True))
+    visit_field(doc, "secondaryFiles", update_secondaryFiles)
 
     upd = doc
     if isinstance(upd, MutableMapping) and "$graph" in upd:
         upd = upd["$graph"]
     for proc in aslist(upd):
-        proc.setdefault("hints", CommentedSeq())
-        proc["hints"].insert(0, CommentedMap([("class", "NetworkAccess"),( "networkAccess", True)]))
-        proc["hints"].insert(0, CommentedMap([("class", "LoadListingRequirement"),("loadListing", "deep_listing")]))
+        proc.setdefault("hints", [])
+        proc["hints"].insert(0, {"class": "NetworkAccess", "networkAccess": True})
+        proc["hints"].insert(0, {"class": "LoadListingRequirement", "loadListing": "deep_listing"})
         if "cwlVersion" in proc:
             del proc["cwlVersion"]
 
     return (doc, "v1.1")
 
 def v1_1_0dev1to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
-    # type: (Any, Loader, Text) -> Tuple[Any, Text]
     return (doc, "v1.1")
 
 UPDATES = {
     u"v1.0": v1_0to1_1,
-    u"v1.1": None
+    u"v1.1": v1_1to1_2,
+    u"v1.2": None
 }  # type: Dict[Text, Optional[Callable[[Any, Loader, Text], Tuple[Any, Text]]]]
 
 DEVUPDATES = {
-    u"v1.0": v1_0to1_1,
     u"v1.1.0-dev1": v1_1_0dev1to1_1,
-    u"v1.1": None
+    u"v1.2.0-dev2": None
 }  # type: Dict[Text, Optional[Callable[[Any, Loader, Text], Tuple[Any, Text]]]]
 
 ALLUPDATES = UPDATES.copy()
 ALLUPDATES.update(DEVUPDATES)
 
-INTERNAL_VERSION = u"v1.1"
+INTERNAL_VERSION = u"v1.2"
 
 def identity(doc, loader, baseuri):  # pylint: disable=unused-argument
     # type: (Any, Loader, Text) -> Tuple[Any, Union[Text, Text]]
-    """Default, do-nothing, CWL document upgrade function."""
+    """The default, do-nothing, CWL document upgrade function."""
     return (doc, doc["cwlVersion"])
 
 
@@ -136,11 +123,12 @@ def checkversion(doc,        # type: Union[CommentedSeq, CommentedMap]
                  metadata,   # type: CommentedMap
                  enable_dev  # type: bool
 ):
-    # type: (...) -> Tuple[CommentedMap, Text]
-    """Check the validity of the version of the give CWL document.
+    # type: (...) -> Tuple[Union[CommentedSeq, CommentedMap], Text]
+    """Checks the validity of the version of the give CWL document.
 
     Returns the document and the validated version string.
     """
+
     cdoc = None  # type: Optional[CommentedMap]
     if isinstance(doc, CommentedSeq):
         if not isinstance(metadata, CommentedMap):
@@ -179,15 +167,16 @@ def checkversion(doc,        # type: Union[CommentedSeq, CommentedMap]
 
 
 def update(doc, loader, baseuri, enable_dev, metadata):
-    # type: (Union[CommentedSeq, CommentedMap], Loader, Text, bool, Any) -> CommentedMap
+    # type: (Union[CommentedSeq, CommentedMap], Loader, Text, bool, Any) -> Union[CommentedSeq, CommentedMap]
 
-    if isinstance(doc, CommentedMap):
-            if metadata.get("http://commonwl.org/cwltool#original_cwlVersion") \
-                    or doc.get("http://commonwl.org/cwltool#original_cwlVersion"):
-                return doc
+    if (metadata.get("http://commonwl.org/cwltool#original_cwlVersion") or
+        (isinstance(doc, CommentedMap) and doc.get("http://commonwl.org/cwltool#original_cwlVersion"))):
+        return doc
+
+    (cdoc, originalversion) = checkversion(doc, metadata, enable_dev)
+    version = originalversion
 
     (cdoc, version) = checkversion(doc, metadata, enable_dev)
-    originalversion = copy.copy(version)
 
     nextupdate = identity  # type: Optional[Callable[[Any, Loader, Text], Tuple[Any, Text]]]
 

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -97,6 +97,10 @@ def v1_0to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
 def v1_1_0dev1to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
     return (doc, "v1.1")
 
+def v1_2_0dev2to1_2(doc, loader, baseuri):  # pylint: disable=unused-argument
+    return (doc, "v1.2")
+
+
 UPDATES = {
     u"v1.0": v1_0to1_1,
     u"v1.1": v1_1to1_2,
@@ -105,7 +109,7 @@ UPDATES = {
 
 DEVUPDATES = {
     u"v1.1.0-dev1": v1_1_0dev1to1_1,
-    u"v1.2.0-dev2": None
+    u"v1.2.0-dev2": v1_2_0dev2to1_2
 }  # type: Dict[Text, Optional[Callable[[Any, Loader, Text], Tuple[Any, Text]]]]
 
 ALLUPDATES = UPDATES.copy()

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -97,7 +97,7 @@ def v1_0to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
 def v1_1_0dev1to1_1(doc, loader, baseuri):  # pylint: disable=unused-argument
     return (doc, "v1.1")
 
-def v1_2_0dev2to1_2(doc, loader, baseuri):  # pylint: disable=unused-argument
+def v1_2_0dev1to1_2(doc, loader, baseuri):  # pylint: disable=unused-argument
     return (doc, "v1.2")
 
 
@@ -109,7 +109,7 @@ UPDATES = {
 
 DEVUPDATES = {
     u"v1.1.0-dev1": v1_1_0dev1to1_1,
-    u"v1.2.0-dev2": v1_2_0dev2to1_2
+    u"v1.2.0-dev1": v1_2_0dev1to1_2
 }  # type: Dict[Text, Optional[Callable[[Any, Loader, Text], Tuple[Any, Text]]]]
 
 ALLUPDATES = UPDATES.copy()

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -54,6 +54,8 @@ def default_make_tool(toolpath_object,      # type: MutableMapping[Text, Any]
             return command_line_tool.CommandLineTool(toolpath_object, loadingContext)
         if toolpath_object["class"] == "ExpressionTool":
             return command_line_tool.ExpressionTool(toolpath_object, loadingContext)
+        if toolpath_object["class"] == "Operation":
+            return command_line_tool.Operation(toolpath_object, loadingContext)
         if toolpath_object["class"] == "Workflow":
             return Workflow(toolpath_object, loadingContext)
         if toolpath_object["class"] == "ProcessGenerator":


### PR DESCRIPTION
Implements common-workflow-language/common-workflow-language#337 for abstract operations.

See corresponding pull request for cwl-v1.2, common-workflow-language/cwl-v1.2#3

note the use of `git submodule` to track the corresponding `abstract-operation` branch in cwl-v1.2 repo under `schemas/v1.2.0-dev2`, use `git submodule init` to fill in.