### PR TITLE
Output destination

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -22,7 +22,7 @@ from .errors import WorkflowException
 from .job import JobBase  # pylint: disable=unused-import
 from .loghandler import _logger
 from .mutation import MutationManager
-from .process import Process  # pylint: disable=unused-import
+from .process import Process, shortname
 from .process import cleanIntermediate, relocateOutputs
 from .provenance import ProvenanceProfile
 from .utils import DEFAULT_TMP_PREFIX
@@ -109,16 +109,17 @@ class JobExecutor(with_metaclass(ABCMeta, object)):
         if self.final_output and self.final_output[0] is not None and finaloutdir is not None:
             outputdest, _ = process.get_requirement("http://commonwl.org/cwltool#OutputDestination")
             if outputdest:
+                ddict = {}
                 for d in outputdest["destinations"]:
                     if isinstance(d["destination"], MutableSequence):
-                        ddict[d["outputParam"]] = [do_eval(exp,
+                        ddict[shortname(d["outputParam"])] = [do_eval(exp,
                                                            job_order_object,
                                                            process.requirements,
                                                            finaloutdir,
                                                            None,
                                                            {}) for exp in d["destination"]]
                     else:
-                        ddict[d["outputParam"]] = do_eval(d["destination"],
+                        ddict[shortname(d["outputParam"])] = do_eval(d["destination"],
                                                           job_order_object,
                                                           process.requirements,
                                                           finaloutdir,

--- a/cwltool/extensions.yml
+++ b/cwltool/extensions.yml
@@ -154,3 +154,38 @@ $graph:
         _type: "@id"
       doc: |
         Specifies the process to run.
+
+- name: Destination
+  type: record
+  inVocab: false
+  fields:
+    outputParam:
+      type: string
+      jsonldPredicate:
+        "_type": "@id"
+        refScope: 2
+    destination:
+      type:
+        - string
+        - type: array
+          items: [string, Expression]
+
+- name: OutputDestination
+  type: record
+  inVocab: false
+  extends: cwl:ProcessRequirement
+  fields:
+    class:
+      type: string
+      doc: "Always 'OutputDestination"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    destinations:
+      type: Destination[]
+      doc: |
+        List one or more input parameters that are sensitive (such as passwords)
+        which will be deliberately obscured from logging.
+      jsonldPredicate:
+        mapSubject: outputParam
+        mapPredicate: destination

--- a/cwltool/extensions.yml
+++ b/cwltool/extensions.yml
@@ -168,7 +168,7 @@ $graph:
       type:
         - string
         - type: array
-          items: [string, Expression]
+          items: [string]
 
 - name: OutputDestination
   type: record

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -307,12 +307,13 @@ class PathMapper(object):
             self.visitlisting(obj.get("secondaryFiles", []), stagedir, basedir,
                               copy=copy, staged=staged)
 
-    def setup(self, referenced_files, basedir):
+    def setup(self, referenced_files, basedir, stagedir=None):
         # type: (List[Any], Text) -> None
 
         # Go through each file and set the target to its own directory along
         # with any secondary files.
-        stagedir = self.stagedir
+        if stagedir is None:
+            stagedir = self.stagedir
         for fob in referenced_files:
             if self.separateDirs:
                 stagedir = os.path.join(self.stagedir, "stg%s" % uuid.uuid4())

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -300,7 +300,7 @@ def relocateOutputs(outputObj,              # type: Union[Dict[Text, Any], List[
                     action,                 # type: Text
                     fs_access,              # type: StdFsAccess
                     compute_checksum=True,  # type: bool
-                    path_mapper=PathMapper  # type: Type[PathMapper]
+                    path_mapper=PathMapper, # type: Type[PathMapper]
                     destinations=None       # type: Dict[Text, Union[Text, List[Text]]]
                     ):
     # type: (...) -> Union[Dict[Text, Any], List[Dict[Text, Any]]]
@@ -362,9 +362,11 @@ def relocateOutputs(outputObj,              # type: Union[Dict[Text, Any], List[
     pm = path_mapper([], "", "", separateDirs=False)
     if destinations is None:
         destinations = {}
+    else:
+        _logger.debug("Destinations is %s", destinations)
     for param in outputObj.keys():
+        dirs = []
         if param in destinations:
-            dirs = []
             if isinstance(outputObj[param], MutableSequence):
                 if isinstance(destinations[param], MutableSequence):
                     if len(outputObj[param]) != len(destinations[param]):
@@ -397,7 +399,10 @@ def relocateOutputs(outputObj,              # type: Union[Dict[Text, Any], List[
         for i, d in enumerate(dirs):
             outfiles = list(_collectDirEntries(outvar[i]))
             visit_class(outfiles, ("File", "Directory"), _realpath)
-            pm.setup(outfiles, os.path.join(destination_path, d))
+            _logger.debug("Sending '%s' to '%s'", param, os.path.join(destination_path, d))
+            pm.setup(outfiles, "", stagedir=os.path.join(destination_path, d))
+
+    _logger.debug("Pathmap is '%s'", pm.items())
 
     stage_files(pm, stage_func=_relocate, symlink=False, fix_conflicts=True)
 


### PR DESCRIPTION
Experimental feature to set output destination of output files and directories.  Simplifies file renaming and organizing output into a desired directory structure.

Work in progress.

Example:

```
outputs:
  bar:
    type: File
    outputBinding:
      glob: foo
hints:
  cwltool:OutputDestination:
    destinations:
      bar: bar/
```

This causes the "foo" file to be placed in the subdirectory "bar" (relative to the base output directory) in the final output.
