### PR TITLE
Add `doc` field message to the output of `--help`

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -799,6 +799,7 @@ def generate_parser(
     records: List[str],
     input_required: bool = True,
 ) -> argparse.ArgumentParser:
+    toolparser.description = tool.tool.get("doc", None)
     toolparser.add_argument("job_order", nargs="?", help="Job input json file")
     namemap["job_order"] = "job_order"
 

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from io import BytesIO, StringIO
@@ -5,7 +6,10 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
+from cwltool.argparser import generate_parser
+from cwltool.context import LoadingContext
 import cwltool.executors
+from cwltool.load_tool import load_tool
 from cwltool.main import main
 
 from .util import get_data, needs_docker
@@ -162,3 +166,21 @@ def test_dont_require_inputs():
     finally:
         if script and script.name and os.path.exists(script.name):
             os.unlink(script.name)
+
+
+def test_argparser_with_doc():
+    """The `desription` field is set if `doc` field is provided."""
+    loadingContext = LoadingContext()
+    tool = load_tool(get_data("tests/with_doc.cwl"), loadingContext)
+    p = argparse.ArgumentParser()
+    parser = generate_parser(p, tool, {}, [], False)
+    assert(parser.description is not None)
+
+
+def test_argparser_without_doc():
+    """The `desription` field is None if `doc` field is not provided."""
+    loadingContext = LoadingContext()
+    tool = load_tool(get_data("tests/without_doc.cwl"), loadingContext)
+    p = argparse.ArgumentParser()
+    parser = generate_parser(p, tool, {}, [], False)
+    assert(parser.description is None)

--- a/tests/with_doc.cwl
+++ b/tests/with_doc.cwl
@@ -1,0 +1,7 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs: []
+baseCommand: echo
+outputs: []
+
+doc: This should be shown in help message

--- a/tests/without_doc.cwl
+++ b/tests/without_doc.cwl
@@ -1,0 +1,5 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs: []
+baseCommand: echo
+outputs: []


### PR DESCRIPTION
It would be nice if `--help` also shows the `doc` field in a given CWL doccument.

Example input(example.cwl):
```cwl
#!/usr/bin/env cwl-runner
cwlVersion: v1.0
class: CommandLineTool
baseCommand: echo
inputs:
  message:
    doc: message to be printed
    type: string
    inputBinding:
      position: 1
outputs: []

doc: Useful message for this tool
```

Before this PR:
```console
$ cwltool example.cwl --help
...
usage: example.cwl [-h] --message MESSAGE [job_order]

positional arguments:
  job_order          Job input json file

optional arguments:
  -h, --help         show this help message and exit
  --message MESSAGE  message to be printed
```

After merging this PR:
```console
$ cwltool example.cwl --help
...
usage: example.cwl [-h] --message MESSAGE [job_order]

Useful message for this tool     # <---- Added!

positional arguments:
  job_order          Job input json file

optional arguments:
  -h, --help         show this help message and exit
  --message MESSAGE  message to be printed
```
