### PR TITLE
Change from --volume to --mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Generated during tests
+pytestdebug.log
+tmp/
+
 # Python temps
 __pycache__/
 *.py[cod]

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -237,8 +237,8 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             "--mount={}".format(mount_arg)
         )
         # Unlike "--volume", "--mount" will fail if the volume doesn't already exist.
-        if not os.path.isdir(target):
-            os.mkdir(target)
+        if not os.path.isdir(source):
+            os.mkdir(source)
 
     def add_file_or_directory_volume(
         self, runtime: List[str], volume: MapperEnt, host_outdir_tgt: Optional[str]

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -1,6 +1,7 @@
 """Enables Docker software containers via the {dx-,u,}docker runtimes."""
 
 import datetime
+import csv
 import os
 import re
 import shutil
@@ -8,7 +9,7 @@ import sys
 import tempfile
 import threading
 from distutils import spawn
-from io import open  # pylint: disable=redefined-builtin
+from io import open, StringIO  # pylint: disable=redefined-builtin
 from typing import Dict, List, MutableMapping, Optional, Set, Tuple
 
 import requests
@@ -222,10 +223,18 @@ class DockerCommandLineJob(ContainerCommandLineJob):
     def append_volume(runtime, source, target, writable=False):
         # type: (List[str], str, str, bool) -> None
         """Add binding arguments to the runtime list."""
+        options = [
+            'type=bind',
+            'source=' + source,
+            'target=' + target,
+        ]
+        if not writable:
+            options.append('readonly')
+        output = StringIO()
+        csv.writer(output).writerow(options)
+        mount_arg = output.getvalue().strip()
         runtime.append(
-            "--volume={}:{}:{}".format(
-                docker_windows_path_adjust(source), target, "rw" if writable else "ro"
-            )
+            "--mount={}".format(mount_arg)
         )
 
     def add_file_or_directory_volume(

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -236,6 +236,9 @@ class DockerCommandLineJob(ContainerCommandLineJob):
         runtime.append(
             "--mount={}".format(mount_arg)
         )
+        # Unlike "--volume", "--mount" will fail if the volume doesn't already exist.
+        if not os.path.isdir(target):
+            os.mkdir(target)
 
     def add_file_or_directory_volume(
         self, runtime: List[str], volume: MapperEnt, host_outdir_tgt: Optional[str]

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -237,7 +237,7 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             "--mount={}".format(mount_arg)
         )
         # Unlike "--volume", "--mount" will fail if the volume doesn't already exist.
-        if not os.path.isdir(source):
+        if not os.path.exists(source):
             os.mkdir(source)
 
     def add_file_or_directory_volume(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -22,6 +22,7 @@ def test_docker_workflow(tmpdir):
         ]
     )
     assert "completed success" in stderr
+    assert (tmpdir / 'response.txt').read_text('utf-8') == 'hello'
     assert result_code == 0
 
 

--- a/tests/test_docker_paths_with_colons.py
+++ b/tests/test_docker_paths_with_colons.py
@@ -6,7 +6,8 @@ from cwltool.main import main
 from .util import needs_docker
 
 
-def test_docker_append_volume_read_only():
+def test_docker_append_volume_read_only(mocker):
+    mocker.patch('os.mkdir')
     runtime = ['runtime']
     characters = ':,"\''
     DockerCommandLineJob.append_volume(
@@ -22,7 +23,8 @@ def test_docker_append_volume_read_only():
         'readonly'
     ]
 
-def test_docker_append_volume_read_write():
+def test_docker_append_volume_read_write(mocker):
+    mocker.patch('os.mkdir')
     runtime = ['runtime']
     characters = ':,"\''
     DockerCommandLineJob.append_volume(

--- a/tests/test_docker_paths_with_colons.py
+++ b/tests/test_docker_paths_with_colons.py
@@ -1,0 +1,39 @@
+import pytest
+
+from cwltool.docker import DockerCommandLineJob
+from cwltool.main import main
+
+from .util import needs_docker
+
+
+def test_docker_append_volume_read_only():
+    runtime = ['runtime']
+    characters = ':,"\''
+    DockerCommandLineJob.append_volume(
+        runtime,
+        '/source' + characters,
+        '/target' + characters
+    )
+    assert runtime == [
+        'runtime',
+        '--mount=type=bind,'
+        '"source=/source:,""\'",'
+        '"target=/target:,""\'",'
+        'readonly'
+    ]
+
+def test_docker_append_volume_read_write():
+    runtime = ['runtime']
+    characters = ':,"\''
+    DockerCommandLineJob.append_volume(
+        runtime,
+        '/source' + characters,
+        '/target' + characters,
+        True
+    )
+    assert runtime == [
+        'runtime',
+        '--mount=type=bind,'
+        '"source=/source:,""\'",'
+        '"target=/target:,""\'"'
+    ]


### PR DESCRIPTION
This will fix #1250. Paths with colons can not be specified with the `--volume` syntax. They can, using `--mount`... and the parameter can also use CSV quoting in case there is a comma in a path.

- Would you like a test that actually runs docker, with a mounted path with weird characters?
- `--volume` will create the directory if it does not exist. `--mount` will not. [docker docs](https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior). I could add an `os.mkdir()` to handle this? 