### PR TITLE
RFC: first draft of running tools via MPI

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -608,6 +608,38 @@ def arg_parser() -> argparse.ArgumentParser:
         "listed targets (can provide more than once).",
     )
 
+    mpigroup = parser.add_argument_group("Options for controlling parallel execution")
+    mpigroup.add_argument(
+        "--mpi",
+        action="store_true",
+        dest="mpi_on",
+        help="Run with MPI"
+    )
+    mpigroup.add_argument(
+        "--mpi-run",
+        type=str,
+        default=None,
+        help="Command to launch MPI jobs"
+    )
+    mpigroup.add_argument(
+        "--mpi-tasks-flag",
+        type=str,
+        default=None,
+        help="Flag to specify number of MPI tasks"
+    )
+    mpigroup.add_argument(
+        "--mpi-tasks",
+        type=int,
+        default=1,
+        help="Number of MPI tasks to use"
+    )
+    mpigroup.add_argument(
+        "--mpi-extra",
+        action="append",
+        default=[],
+        help="Extra argument to the MPI command"
+    )
+
     parser.add_argument(
         "workflow",
         type=str,

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -40,6 +40,7 @@ from schema_salad.utils import json_dumps
 from .builder import Builder, content_limit_respected_read_bytes, substitute
 from .context import LoadingContext, RuntimeContext, getdefault
 from .docker import DockerCommandLineJob
+from .mpi import MpiCommandLineJob
 from .errors import WorkflowException
 from .flatten import flatten
 from .job import CommandLineJob, JobBase
@@ -354,6 +355,8 @@ class CommandLineTool(Process):
                     "--no-container, but this CommandLineTool has "
                     "DockerRequirement under 'requirements'."
                 )
+        if runtimeContext.mpi_on:
+            return MpiCommandLineJob
         return CommandLineJob
 
     def make_path_mapper(self, reffiles, stagedir, runtimeContext, separateDirs):

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -145,6 +145,13 @@ class RuntimeContext(ContextBase):
         self.cwl_full_name = ""  # type: str
         self.process_run_id = None  # type: Optional[str]
         self.prov_obj = None  # type: Optional[ProvenanceProfile]
+
+        self.mpi_on = False # type: bool
+        self.mpi_run = None # type: Optional[str]
+        self.mpi_tasks_flag = None # type: Optional[str]
+        self.mpi_tasks = None # type: Optional[int]
+        self.mpi_extra = [] # type: List[str]
+
         super(RuntimeContext, self).__init__(kwargs)
 
     def copy(self):

--- a/cwltool/mpi.py
+++ b/cwltool/mpi.py
@@ -1,0 +1,32 @@
+from typing import List, MutableMapping
+from .context import RuntimeContext
+from .job import CommandLineJob
+
+class MpiEnv:
+    def __init__(self, runtimeContext : RuntimeContext) -> None:
+        """Initialize."""
+        self.run = "mpirun" if runtimeContext.mpi_run is None else runtimeContext.mpi_run
+        self.tasks_flag = "-n" if runtimeContext.mpi_tasks_flag is None else runtimeContext.mpi_tasks_flag
+        self.tasks = 1 if runtimeContext.mpi_tasks is None else runtimeContext.mpi_tasks
+        self.extra = runtimeContext.mpi_extra
+
+class MpiCommandLineJob(CommandLineJob):
+    """Runs a CommandLineJob in parallel using mpirun or similar."""
+
+    # Really we should override run(), but all we need is to intercept
+    # the call to _execute, insert our mpirun -np n as the first (non
+    # self) argument and then call the base class _execute.
+    def _execute(
+        self,
+        runtime: List[str],
+        env: MutableMapping[str, str],
+        runtimeContext: RuntimeContext,
+        monitor_function=None,  # type: Optional[Callable[[subprocess.Popen[str]], None]]
+    ) -> None:
+        if runtimeContext.mpi_on:
+            assert runtime == [], "MPI command line job requires an empty runtime list"
+            menv = MpiEnv(runtimeContext)
+            mpiflags = [menv.run, menv.tasks_flag, menv.tasks] + menv.extra
+            runtime = mpiflags + runtime
+
+        super(MpiCommandLineJob, self)._execute(runtime, env, runtimeContext, monitor_function)


### PR DESCRIPTION
Dear cwltool maintainers,

This PR is not really intended for immediate acceptance, I'm really just soliciting comment on if this is something you might possibly accept and if so, is this the sort of approach you'd be happy with.

Use case: as part of a workflow, I need to run tools that are parallelised with MPI. These must be launched with an implementation-defined tool. E.g. the commonest is `mpirun`, but Cray machines use `aprun` and the SGI (now HP) use `mpt_mpiexec`. Hence I don't want to put them in the workflow definition.

My patch adds command line flags to cwl-runner which will prepend the appropriate `mpirun -n tasks` to the command executed.

Feedback gratefully received!