### PR TITLE
Add test for packing a fragment of a document & fix.

### DIFF
--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -333,7 +333,8 @@ def resolve_and_validate_document(
     if cwlVersion == "v1.0":
         _add_blank_ids(workflowobj)
 
-    processobj, metadata = document_loader.resolve_all(workflowobj, fileuri)
+    document_loader.resolve_all(workflowobj, fileuri)
+    processobj, metadata = document_loader.resolve_ref(uri)
     if loadingContext.metadata:
         metadata = loadingContext.metadata
     if not isinstance(processobj, (CommentedMap, CommentedSeq)):

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -555,12 +555,11 @@ def find_deps(
 
 def print_pack(
     document_loader,  # type: Loader
-    processobj,  # type: CommentedMap
     uri,  # type: str
     metadata,  # type: Dict[str, Any]
 ):  # type: (...) -> str
     """Return a CWL serialization of the CWL document in JSON."""
-    packed = pack(document_loader, processobj, uri, metadata)
+    packed = pack(document_loader, uri, metadata)
     if len(packed["$graph"]) > 1:
         return json_dumps(packed, indent=4)
     return json_dumps(packed["$graph"][0], indent=4)
@@ -918,14 +917,14 @@ def main(
             processobj = cast(CommentedMap, processobj)
             if args.pack:
                 stdout.write(
-                    print_pack(loadingContext.loader, processobj, uri, metadata)
+                    print_pack(loadingContext.loader, uri, metadata)
                 )
                 return 0
 
             if args.provenance and runtimeContext.research_obj:
                 # Can't really be combined with args.pack at same time
                 runtimeContext.research_obj.packed_workflow(
-                    print_pack(loadingContext.loader, processobj, uri, metadata)
+                    print_pack(loadingContext.loader, uri, metadata)
                 )
 
             if args.print_pre:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -159,7 +159,7 @@ def generate_example_input(
                 else:
                     comment = "optional"
         else:
-            example = yaml.comments.CommentedSeq()
+            example = CommentedSeq()
             for index, entry in enumerate(inptype):
                 value, e_comment = generate_example_input(entry, default)
                 example.append(value)
@@ -916,9 +916,7 @@ def main(
             processobj, metadata = loadingContext.loader.resolve_ref(uri)
             processobj = cast(CommentedMap, processobj)
             if args.pack:
-                stdout.write(
-                    print_pack(loadingContext.loader, uri, metadata)
-                )
+                stdout.write(print_pack(loadingContext.loader, uri, metadata))
                 return 0
 
             if args.provenance and runtimeContext.research_obj:

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -123,7 +123,6 @@ def import_embed(d, seen):
 
 def pack(
     document_loader: Loader,
-    startingobj,  # type: Union[Dict[str, Any], List[Dict[str, Any]]]
     uri,  # type: str
     metadata,  # type: Dict[str, str]
     rewrite_out=None,  # type: Optional[Dict[str, str]]
@@ -146,7 +145,7 @@ def pack(
     loadingContext.loader.idx = {}
     loadingContext.metadata = {}
     loadingContext, docobj, uri = fetch_document(uri, loadingContext)
-    loadingContext, uri = resolve_and_validate_document(
+    loadingContext, fileuri = resolve_and_validate_document(
         loadingContext, docobj, uri, preprocess_only=True
     )
     if loadingContext.loader is None:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ PYTEST_RUNNER = ["pytest-runner", "pytest-cov"] if NEEDS_PYTEST else []
 
 setup(
     name="cwltool",
-    version="2.0",
+    version="3.0",
     description="Common workflow language reference implementation",
     long_description=open(README).read(),
     long_description_content_type="text/x-rst",

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -163,9 +163,11 @@ def _pack_idempotently(document):
     packed_text = print_pack(loadingContext.loader, uri, loadingContext.metadata)
     packed = json.loads(packed_text)
 
-    with NamedTemporaryFile() as tmp:
-        tmp.write(packed_text.encode("utf-8"))
+    tmp = NamedTemporaryFile(mode="w", delete=False)
+    try:
+        tmp.write(packed_text)
         tmp.flush()
+        tmp.close()
 
         loadingContext, workflowobj, uri2 = fetch_document(tmp.name)
         loadingContext.do_update = False
@@ -177,6 +179,8 @@ def _pack_idempotently(document):
         # generate pack output dict
         packed_text = print_pack(loadingContext.loader, uri2, loadingContext.metadata)
         double_packed = json.loads(packed_text)
+    finally:
+        os.remove(tmp.name)
 
     assert uri != uri2
     assert packed == double_packed

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -26,9 +26,7 @@ def test_pack():
     with open(get_data("tests/wf/expect_packed.cwl")) as packed_file:
         expect_packed = yaml.safe_load(packed_file)
 
-    packed = cwltool.pack.pack(
-        loadingContext.loader, uri, loadingContext.metadata
-    )
+    packed = cwltool.pack.pack(loadingContext.loader, uri, loadingContext.metadata)
     adjustFileObjs(
         packed, partial(make_relative, os.path.abspath(get_data("tests/wf")))
     )
@@ -55,9 +53,7 @@ def test_pack_input_named_name():
     with open(get_data("tests/wf/expect_trick_packed.cwl")) as packed_file:
         expect_packed = yaml.round_trip_load(packed_file)
 
-    packed = cwltool.pack.pack(
-        loadingContext.loader, uri, loadingContext.metadata
-    )
+    packed = cwltool.pack.pack(loadingContext.loader, uri, loadingContext.metadata)
     adjustFileObjs(
         packed, partial(make_relative, os.path.abspath(get_data("tests/wf")))
     )
@@ -81,9 +77,7 @@ def test_pack_single_tool():
     )
     processobj = loadingContext.loader.resolve_ref(uri)[0]
 
-    packed = cwltool.pack.pack(
-        loadingContext.loader, uri, loadingContext.metadata
-    )
+    packed = cwltool.pack.pack(loadingContext.loader, uri, loadingContext.metadata)
     assert "$schemas" in packed
 
 
@@ -93,14 +87,16 @@ def test_pack_fragment():
 
     loadingContext, workflowobj, uri = fetch_document(get_data("tests/wf/scatter2.cwl"))
     packed = cwltool.pack.pack(
-        loadingContext.loader, uri+"#scatterstep/mysub", loadingContext.metadata
+        loadingContext.loader, uri + "#scatterstep/mysub", loadingContext.metadata
     )
     adjustFileObjs(
         packed, partial(make_relative, os.path.abspath(get_data("tests/wf")))
     )
     adjustDirObjs(packed, partial(make_relative, os.path.abspath(get_data("tests/wf"))))
 
-    assert json.dumps(packed, sort_keys=True, indent=2) == json.dumps(expect_packed, sort_keys=True, indent=2)
+    assert json.dumps(packed, sort_keys=True, indent=2) == json.dumps(
+        expect_packed, sort_keys=True, indent=2
+    )
 
 
 def test_pack_rewrites():
@@ -116,10 +112,7 @@ def test_pack_rewrites():
     processobj = loadingContext.loader.resolve_ref(uri)[0]
 
     cwltool.pack.pack(
-        loadingContext.loader,
-        uri,
-        loadingContext.metadata,
-        rewrite_out=rewrites,
+        loadingContext.loader, uri, loadingContext.metadata, rewrite_out=rewrites,
     )
 
     assert len(rewrites) == 6
@@ -143,9 +136,7 @@ def test_pack_missing_cwlVersion(cwl_path):
     processobj = loadingContext.loader.resolve_ref(uri)[0]
 
     # generate pack output dict
-    packed = json.loads(
-        print_pack(loadingContext.loader, uri, loadingContext.metadata)
-    )
+    packed = json.loads(print_pack(loadingContext.loader, uri, loadingContext.metadata))
 
     assert packed["cwlVersion"] == "v1.0"
 
@@ -173,7 +164,7 @@ def _pack_idempotently(document):
     packed = json.loads(packed_text)
 
     with NamedTemporaryFile() as tmp:
-        tmp.write(packed_text.encode('utf-8'))
+        tmp.write(packed_text.encode("utf-8"))
         tmp.flush()
 
         loadingContext, workflowobj, uri2 = fetch_document(tmp.name)
@@ -208,9 +199,7 @@ def test_packed_workflow_execution(wf_path, job_path, namespaced, tmpdir):
         loadingContext, workflowobj, uri
     )
     processobj = loadingContext.loader.resolve_ref(uri)[0]
-    packed = json.loads(
-        print_pack(loadingContext.loader, uri, loadingContext.metadata)
-    )
+    packed = json.loads(print_pack(loadingContext.loader, uri, loadingContext.metadata))
 
     assert not namespaced or "$namespaces" in packed
 

--- a/tests/test_procgenerator.py
+++ b/tests/test_procgenerator.py
@@ -35,5 +35,5 @@ def test_missing_enable_ext():
     finally:
         if opt is not None:
             os.environ["CWLTOOL_OPTIONS"] = opt
-        else:
+        elif "CWLTOOL_OPTIONS" in os.environ:
             del os.environ["CWLTOOL_OPTIONS"]

--- a/tests/wf/scatter2.cwl
+++ b/tests/wf/scatter2.cwl
@@ -1,0 +1,68 @@
+# Copyright (C) The Arvados Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class: Workflow
+cwlVersion: v1.0
+$namespaces:
+  arv: "http://arvados.org/cwl#"
+inputs:
+  sleeptime:
+    type: int[]
+    default: [5]
+  fileblub:
+    type: File
+    default:
+      class: File
+      location: keep:99999999999999999999999999999999+118/token.txt
+outputs:
+  out:
+    type: string[]
+    outputSource: scatterstep/out
+requirements:
+  SubworkflowFeatureRequirement: {}
+  ScatterFeatureRequirement: {}
+  InlineJavascriptRequirement: {}
+  StepInputExpressionRequirement: {}
+steps:
+  scatterstep:
+    in:
+      sleeptime: sleeptime
+      fileblub: fileblub
+    out: [out]
+    scatter: sleeptime
+    hints:
+      - class: arv:RunInSingleContainer
+    run:
+      class: Workflow
+      id: mysub
+      inputs:
+        sleeptime: int
+        fileblub: File
+      outputs:
+        out:
+          type: string
+          outputSource: sleep1/out
+      steps:
+        sleep1:
+          in:
+            sleeptime: sleeptime
+            blurb:
+              valueFrom: |
+                ${
+                  return String(inputs.sleeptime) + "b";
+                }
+          out: [out]
+          run:
+            class: CommandLineTool
+            id: subtool
+            inputs:
+              sleeptime:
+                type: int
+                inputBinding: {position: 1}
+            outputs:
+              out:
+                type: string
+                outputBinding:
+                  outputEval: "out"
+            baseCommand: sleep

--- a/tests/wf/scatter2_subwf.cwl
+++ b/tests/wf/scatter2_subwf.cwl
@@ -1,0 +1,75 @@
+# Copyright (C) The Arvados Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  "$graph": [
+    {
+      "$namespaces": {
+        "arv": "http://arvados.org/cwl#"
+      },
+      "class": "Workflow",
+      "cwlVersion": "v1.0",
+      "id": "#main",
+      "inputs": [
+        {
+          "id": "#main/fileblub",
+          "type": "File"
+        },
+        {
+          "id": "#main/sleeptime",
+          "type": "int"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "#main/out",
+          "outputSource": "#main/sleep1/out",
+          "type": "string"
+        }
+      ],
+      "steps": [
+        {
+          "id": "#main/sleep1",
+          "in": [
+            {
+              "id": "#main/sleep1/blurb",
+              "valueFrom": "${\n  return String(inputs.sleeptime) + \"b\";\n}\n"
+            },
+            {
+              "id": "#main/sleep1/sleeptime",
+              "source": "#main/sleeptime"
+            }
+          ],
+          "out": [
+            "#main/sleep1/out"
+          ],
+          "run": {
+            "baseCommand": "sleep",
+            "class": "CommandLineTool",
+            "id": "#main/sleep1/subtool",
+            "inputs": [
+              {
+                "id": "#main/sleep1/subtool/sleeptime",
+                "inputBinding": {
+                  "position": 1
+                },
+                "type": "int"
+              }
+            ],
+            "outputs": [
+              {
+                "id": "#main/sleep1/subtool/out",
+                "outputBinding": {
+                  "outputEval": "out"
+                },
+                "type": "string"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "cwlVersion": "v1.0"
+}


### PR DESCRIPTION
Bump version to 3.0 because pack() API was changed in non-backwards
compatible way.