### PR TITLE
Use schema_salad.avro.schema.Name according to docs

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -255,14 +255,14 @@ class Builder(HasReqsHints):
             bound_input = False
             for t in schema["type"]:
                 avsc = None  # type: Optional[Schema]
-                if isinstance(t, str) and self.names.has_name(t, ""):
-                    avsc = self.names.get_name(t, "")
+                if isinstance(t, str) and self.names.has_name(t, None):
+                    avsc = self.names.get_name(t, None)
                 elif (
                     isinstance(t, MutableMapping)
                     and "name" in t
-                    and self.names.has_name(t["name"], "")
+                    and self.names.has_name(t["name"], None)
                 ):
-                    avsc = self.names.get_name(t["name"], "")
+                    avsc = self.names.get_name(t["name"], None)
                 if not avsc:
                     avsc = make_avsc_object(convert_to_dict(t), self.names)
                 if validate.validate(avsc, datum):

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -852,7 +852,7 @@ class CommandLineTool(Process):
                 if compute_checksum:
                     adjustFileObjs(ret, partial(compute_checksums, fs_access))
             expected_schema = cast(
-                Schema, self.names.get_name("outputs_record_schema", "")
+                Schema, self.names.get_name("outputs_record_schema", None)
             )
             validate.validate_ex(
                 expected_schema, ret, strict=False, logger=_logger_validation_warnings

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -730,7 +730,7 @@ class Process(HasReqsHints, metaclass=abc.ABCMeta):
             fill_in_defaults(self.tool["inputs"], job, fs_access)
 
             normalizeFilesDirs(job)
-            schema = self.names.get_name("input_record_schema", "")
+            schema = self.names.get_name("input_record_schema", None)
             if schema is None:
                 raise WorkflowException(
                     "Missing input record schema: " "{}".format(self.names)
@@ -965,7 +965,7 @@ hints:
             sl = SourceLine(hints, i, validate.ValidationException)
             with sl:
                 if (
-                    avsc_names.get_name(r["class"], "") is not None
+                    avsc_names.get_name(r["class"], None) is not None
                     and self.doc_loader is not None
                 ):
                     plain_hint = dict(
@@ -974,7 +974,7 @@ hints:
                         if key not in self.doc_loader.identifiers
                     )  # strip identifiers
                     validate.validate_ex(
-                        avsc_names.get_name(plain_hint["class"], ""),
+                        avsc_names.get_name(plain_hint["class"], None),
                         plain_hint,
                         strict=strict,
                     )


### PR DESCRIPTION
Apropos my PR on the schema_salad repo (https://github.com/common-workflow-language/schema_salad/pull/324) make cwltool supply `Optional[str]` args as `None` when they are absent instead of `""`.

This change does NOT require a version bump of schema_salad in requirements.txt