### PR TITLE
change hardcoded path sep to os.sep

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1066,7 +1066,7 @@ class CommandLineTool(Process):
                         if isinstance(primary, MutableMapping):
                             primary.setdefault("secondaryFiles", [])
                             pathprefix = primary["path"][
-                                0 : primary["path"].rindex("/") + 1
+                                0 : primary["path"].rindex(os.sep) + 1
                             ]
                             for sf in aslist(schema["secondaryFiles"]):
                                 if "required" in sf:


### PR DESCRIPTION
This is a super simple fix to the issue on Windows 10 for collecting secondary files on outputs I described here: https://cwl.discourse.group/t/secondary-files-cannot-be-collected-by-cwltool-on-windows-10/158