### PR TITLE
Added recursive_resolve_and_validate_document

### DIFF
--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -504,7 +504,7 @@ def recursive_resolve_and_validate_document(
     uri: str,
     preprocess_only: bool = False,
     skip_schemas: Optional[bool] = None,
-) -> Tuple[LoadingContext, str]:
+) -> Tuple[LoadingContext, str, Process]:
     """Validate a CWL document, checking that a tool object can be built."""
     loadingContext, uri = resolve_and_validate_document(
         loadingContext,

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -496,3 +496,22 @@ def resolve_overrides(
 def load_overrides(ov: str, base_url: str) -> List[CWLObjectType]:
     ovloader = Loader(overrides_ctx)
     return resolve_overrides(ovloader.fetch(ov), ov, base_url)
+
+
+def recursive_resolve_and_validate_document(
+    loadingContext: LoadingContext,
+    workflowobj: Union[CommentedMap, CommentedSeq],
+    uri: str,
+    preprocess_only: bool = False,
+    skip_schemas: Optional[bool] = None,
+) -> Tuple[LoadingContext, str]:
+    """Validate a CWL document, checking that a tool object can be built."""
+    loadingContext, uri = resolve_and_validate_document(
+        loadingContext,
+        workflowobj,
+        uri,
+        preprocess_only=preprocess_only,
+        skip_schemas=skip_schemas,
+    )
+    tool = make_tool(uri, loadingContext)
+    return loadingContext, uri, tool

--- a/tests/test_recursive_validation.py
+++ b/tests/test_recursive_validation.py
@@ -1,0 +1,12 @@
+from cwltool.load_tool import fetch_document, recursive_resolve_and_validate_document
+
+from .util import get_data
+
+
+def test_recursive_validation() -> None:
+    loadingContext, workflowobj, uri = fetch_document(
+        get_data("tests/wf/default_path.cwl")
+    )
+    loadingContext, uri, tool = recursive_resolve_and_validate_document(
+        loadingContext, workflowobj, uri
+    )

--- a/tests/test_recursive_validation.py
+++ b/tests/test_recursive_validation.py
@@ -1,9 +1,11 @@
+"""Test the recursive validation feature (validate document and try to build tool)."""
 from cwltool.load_tool import fetch_document, recursive_resolve_and_validate_document
 
 from .util import get_data
 
 
 def test_recursive_validation() -> None:
+    """Test the recursive_resolve_and_validate_document function."""
     loadingContext, workflowobj, uri = fetch_document(
         get_data("tests/wf/default_path.cwl")
     )


### PR DESCRIPTION
Like `resolve_and_validate_document`, but it also calls `make_tool`, bringing in additional validation.

Discussed in https://github.com/galaxyproject/gxformat2/issues/51.
