### PR TITLE
Add fs_access for unknown URIs in relocateOutputs() _realpath().

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -409,7 +409,7 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
                     )
                 else:
                     raise ValueError(
-                        "'lsiting' in self.generatefiles but no "
+                        "'listing' in self.generatefiles but no "
                         "generatemapper was setup."
                     )
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -404,7 +404,7 @@ def relocateOutputs(
             ob["location"] = file_uri(
                 os.path.realpath(uri_file_path(location))
             )
-        elif cast(str, ob["location"]).startswith("/"):
+        elif location.startswith("/"):
             ob["location"] = os.path.realpath(location)
         elif not location.startswith("_:") and ":" in location:
             ob["location"] = file_uri(fs_access.realpath(location))

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -399,14 +399,15 @@ def relocateOutputs(
     def _realpath(
         ob: CWLObjectType,
     ) -> None:  # should be type Union[CWLFile, CWLDirectory]
-        if cast(str, ob["location"]).startswith("file:"):
+        location = cast(str, ob["location"])
+        if location.startswith("file:"):
             ob["location"] = file_uri(
-                os.path.realpath(uri_file_path(cast(str, ob["location"])))
+                os.path.realpath(uri_file_path(location))
             )
         elif cast(str, ob["location"]).startswith("/"):
-            ob["location"] = os.path.realpath(cast(str, ob["location"]))
-        elif ":" in cast(str, ob["location"]):
-            ob["location"] = file_uri(fs_access.realpath(cast(str, ob["location"])))
+            ob["location"] = os.path.realpath(location)
+        elif not location.startswith("_:") and ":" in location:
+            ob["location"] = file_uri(fs_access.realpath(location))
 
     outfiles = list(_collectDirEntries(outputObj))
     visit_class(outfiles, ("File", "Directory"), _realpath)

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -401,9 +401,7 @@ def relocateOutputs(
     ) -> None:  # should be type Union[CWLFile, CWLDirectory]
         location = cast(str, ob["location"])
         if location.startswith("file:"):
-            ob["location"] = file_uri(
-                os.path.realpath(uri_file_path(location))
-            )
+            ob["location"] = file_uri(os.path.realpath(uri_file_path(location)))
         elif location.startswith("/"):
             ob["location"] = os.path.realpath(location)
         elif not location.startswith("_:") and ":" in location:

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -403,8 +403,10 @@ def relocateOutputs(
             ob["location"] = file_uri(
                 os.path.realpath(uri_file_path(cast(str, ob["location"])))
             )
-        if cast(str, ob["location"]).startswith("/"):
+        elif cast(str, ob["location"]).startswith("/"):
             ob["location"] = os.path.realpath(cast(str, ob["location"]))
+        elif ":" in cast(str, ob["location"]):
+            ob["location"] = file_uri(fs_access.realpath(cast(str, ob["location"])))
 
     outfiles = list(_collectDirEntries(outputObj))
     visit_class(outfiles, ("File", "Directory"), _realpath)


### PR DESCRIPTION
This was causing some errors attempting to resolve paths for `toilfs:{path}` paths in Toil, and this PR should resolve the issue.  Also fixes a spelling error.