### PR TITLE
Use existing location if a secondary file has one.

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -465,7 +465,7 @@ class Builder(HasReqsHints):
                                             + sfname
                                         )
                                     else:
-                                        sf_location = d_location + sfname
+                                        sf_location = f'{d_location}{sfname}'
                                 sfbasename = sfname
                             elif isinstance(sfname, MutableMapping):
                                 sf_location = sfname["location"]

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import math
+import os
 from typing import (
     IO,
     Any,
@@ -423,13 +424,30 @@ class Builder(HasReqsHints):
 
                             if isinstance(sfname, str):
                                 d_location = cast(str, datum["location"])
-                                if "/" in d_location:
-                                    sf_location = (
-                                        d_location[0 : d_location.rindex("/") + 1]
-                                        + sfname
-                                    )
-                                else:
-                                    sf_location = d_location + sfname
+                                sf_location = None
+                                for existing_processed_secondaryfile in datum.get(
+                                    "secondaryFiles", []
+                                ):
+                                    if (
+                                        os.path.basename(
+                                            existing_processed_secondaryfile.get(
+                                                "location", ""
+                                            )
+                                        )
+                                        == sfname
+                                    ):
+                                        # the secondary file has already been processed; use established location
+                                        sf_location = existing_processed_secondaryfile[
+                                            "location"
+                                        ]
+                                if not sf_location:
+                                    if "/" in d_location:
+                                        sf_location = (
+                                            d_location[0 : d_location.rindex("/") + 1]
+                                            + sfname
+                                        )
+                                    else:
+                                        sf_location = d_location + sfname
                                 sfbasename = sfname
                             elif isinstance(sfname, MutableMapping):
                                 sf_location = sfname["location"]

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -426,7 +426,10 @@ class Builder(HasReqsHints):
                             if isinstance(sfname, str):
                                 d_location = cast(str, datum["location"])
                                 sf_location = None
-                                if isinstance(datum, MutableMapping) and "secondaryFiles" in datum:
+                                if (
+                                    isinstance(datum, MutableMapping)
+                                    and "secondaryFiles" in datum
+                                ):
                                     if isinstance(datum["secondaryFiles"], Iterable):
                                         for existing_processed_secondaryfile in datum[
                                             "secondaryFiles"

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     MutableMapping,
     MutableSequence,
@@ -425,21 +426,35 @@ class Builder(HasReqsHints):
                             if isinstance(sfname, str):
                                 d_location = cast(str, datum["location"])
                                 sf_location = None
-                                for existing_processed_secondaryfile in datum.get(
-                                    "secondaryFiles", []
-                                ):
-                                    if (
-                                        os.path.basename(
-                                            existing_processed_secondaryfile.get(
-                                                "location", ""
-                                            )
-                                        )
-                                        == sfname
-                                    ):
-                                        # the secondary file has already been processed;  use established location
-                                        sf_location = existing_processed_secondaryfile[
-                                            "location"
-                                        ]
+                                if isinstance(datum, MutableMapping) and datum.get("secondaryFiles"):
+                                    if isinstance(datum["secondaryFiles"], Iterable):
+                                        for existing_processed_secondaryfile in datum[
+                                            "secondaryFiles"
+                                        ]:
+                                            if isinstance(
+                                                existing_processed_secondaryfile,
+                                                MutableMapping,
+                                            ):
+                                                existing_processed_location = existing_processed_secondaryfile.get(
+                                                    "location"
+                                                )
+                                                if (
+                                                    existing_processed_location
+                                                    and isinstance(
+                                                        existing_processed_location, str
+                                                    )
+                                                ):
+                                                    if (
+                                                        os.path.basename(
+                                                            existing_processed_location
+                                                        )
+                                                        == sfname
+                                                    ):
+                                                        # the secondary file has already been processed;
+                                                        # use established location
+                                                        sf_location = existing_processed_secondaryfile[
+                                                            "location"
+                                                        ]
                                 if not sf_location:
                                     if "/" in d_location:
                                         sf_location = (
@@ -490,7 +505,7 @@ class Builder(HasReqsHints):
                                         sfname,
                                     )
                                 elif discover_secondaryFiles and self.fs_access.exists(
-                                    sf_location
+                                    cast(str, sf_location)
                                 ):
                                     addsf(
                                         cast(

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -436,7 +436,7 @@ class Builder(HasReqsHints):
                                         )
                                         == sfname
                                     ):
-                                        # the secondary file has already been processed; use established location
+                                        # the secondary file has already been processed;  use established location
                                         sf_location = existing_processed_secondaryfile[
                                             "location"
                                         ]

--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -426,7 +426,7 @@ class Builder(HasReqsHints):
                             if isinstance(sfname, str):
                                 d_location = cast(str, datum["location"])
                                 sf_location = None
-                                if isinstance(datum, MutableMapping) and datum.get("secondaryFiles"):
+                                if isinstance(datum, MutableMapping) and "secondaryFiles" in datum:
                                     if isinstance(datum["secondaryFiles"], Iterable):
                                         for existing_processed_secondaryfile in datum[
                                             "secondaryFiles"


### PR DESCRIPTION
This allows Toil to pass v1.2 conformance test 307.

In Toil, we pass the following (example) inputs to the executor:

```
{
    "inputWithSecondary": {
        "class": "File",
        "location": "toilfs:0:files/no-job/file-1120f3b05d62444083a9ff5c60c7f772/secondary_file_test.txt",
        "size": 0,
        "basename": "secondary_file_test.txt",
        "nameroot": "secondary_file_test",
        "nameext": ".txt",
        "secondaryFiles": [
            {
                "location": "toilfs:0:files/no-job/file-ccead684521d44f98ff81b118f37159b/secondary_file_test.txt.accessory",
                "class": "File",
                "basename": "secondary_file_test.accessory",
                "nameroot": "secondary_file_test",
                "nameext": ".accessory",
                "size": 0
            }
        ]
    }
}
```

When cwltool makes its builder, it swaps:

toilfs:0:files/no-job/**file-ccead684521d44f98ff81b118f37159b**/secondary_file_test.txt.accessory

for

toilfs:0:files/no-job/**file-1120f3b05d62444083a9ff5c60c7f772**/secondary_file_test.txt.accessory

The bolded portion is the same basedir as the primary file, which creates a path to a file that does not exist.

It does this here: https://github.com/common-workflow-language/cwltool/blob/78fe9d41ee5a44f8725dfbd7028e4a5ee42949cf/cwltool/builder.py#L428

This seems to be because cwltool:
1. Assumes that primary and secondary files are in the same directory and thus have the same interchangeable basedir in the `toilfs:` schema.
1. Does not check to see if secondaryfiles have been resolved yet.  (the list has resolved secondary files in toil because we process with a builder already before it runs a builder again in cwltool)

Two possible proposed solutions:
 - The easier solution imo (this PR) is to check for an already processed secondary file before fabricating a new secondary file's entry.
 - An alternative solution might be to force toil to place secondary files at the same basedir as the primary file if the first solution isn't preferable.
