### PR TITLE
Protect ruamel from blank comment strings when making templates

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -230,6 +230,8 @@ def generate_example_input(
             example = ruamel.yaml.comments.CommentedMap()
             if "name" in inptype:
                 comment = '"{}" record type.'.format(inptype["name"])
+            else:
+                comment = "Anonymous record type."
             for field in cast(List[CWLObjectType], inptype["fields"]):
                 value, f_comment = generate_example_input(field["type"], None)
                 example.insert(0, shortname(cast(str, field["name"])), value, f_comment)

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -29,7 +29,6 @@ from typing import (
     Sized,
     TextIO,
     Tuple,
-    TypeVar,
     Union,
     cast,
 )

--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -13,7 +13,6 @@ from schema_salad.sourceline import SourceLine
 
 from .builder import Builder
 from .context import RuntimeContext
-from .cuda import cuda_check
 from .errors import WorkflowException
 from .job import ContainerCommandLineJob
 from .loghandler import _logger

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -2,8 +2,6 @@ from cwltool.cuda import cuda_version_and_device_count
 from cwltool.main import main
 from .util import (
     get_data,
-    get_main_output,
-    get_tool_env,
     needs_docker,
     needs_singularity_3_or_newer,
 )

--- a/tests/test_make_template.py
+++ b/tests/test_make_template.py
@@ -1,20 +1,7 @@
 """Tests for --make-template."""
-import json
-import logging
-import os
-import re
-import shutil
-import stat
-import subprocess
-import sys
-from io import StringIO
-from pathlib import Path
-from typing import Any, Dict, List, Union, cast
-from urllib.parse import urlparse
 
 from schema_salad.sourceline import cmap
 from cwltool import main
-from .util import get_data, get_main_output, needs_docker, working_directory
 
 
 def test_anonymous_record() -> None:

--- a/tests/test_make_template.py
+++ b/tests/test_make_template.py
@@ -1,0 +1,22 @@
+"""Tests for --make-template."""
+import json
+import logging
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Union, cast
+from urllib.parse import urlparse
+
+from schema_salad.sourceline import cmap
+from cwltool import main
+from .util import get_data, get_main_output, needs_docker, working_directory
+
+
+def test_anonymous_record() -> None:
+    inputs = cmap([{"type": "record", "fields": []}])
+    assert main.generate_example_input(inputs, None) == ({}, "Anonymous record type.")

--- a/tests/test_relocate.py
+++ b/tests/test_relocate.py
@@ -1,12 +1,8 @@
 import json
 import sys
 from pathlib import Path
-import tempfile
 
 from cwltool.main import main
-from cwltool.process import relocateOutputs
-from cwltool.stdfsaccess import StdFsAccess
-from cwltool.pathmapper import PathMapper
 
 from .util import get_data, needs_docker
 


### PR DESCRIPTION
If Ruamel encounters a blank comment string "" instead of None it throws a hissy fit. This happened for me when an input was of type 'Record' using `--make-template`
```
  read_names:
    type:
      - type: record
```

```
Traceback (most recent call last):
  File "~/dev/capanno-utils/lib/python3.6/site-packages/cwltool/main.py", line 972, in main
    make_template(tool)
  File "~/dev/capanno-utils/lib/python3.6/site-packages/cwltool/main.py", line 732, in make_template
    generate_input_template(tool),
  File "~/dev/capanno-utils/lib/python3.6/site-packages/cwltool/main.py", line 299, in generate_input_template
    template.insert(0, name, value, comment)
  File "~/dev/capanno-utils/lib/python3.6/site-packages/ruamel/yaml/comments.py", line 722, in insert
    self.yaml_add_eol_comment(comment, key=key)
  File "~/dev/capanno-utils/lib/python3.6/site-packages/ruamel/yaml/comments.py", line 294, in yaml_add_eol_comment
    if comment[0] != '#':
```