### PR TITLE
add pydot to requirements.txt, version as in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mypy-extensions
 psutil
 typing-extensions
 coloredlogs
+pydot>=1.4.1


### PR DESCRIPTION
Hi Michael-

Apropos enabling CI on Github Actions, I've looked over the requirements.txt etc.

(See also #1408)
I spotted that pydot was missing from requirements.txt, but unlike argcomplete, there is a clear version specifier in setup.py for this so I have added it.

Cheers