### PR TITLE
allow manual workflow triggering

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   singularity_version: 3.6.4


### PR DESCRIPTION
It would be handy to be able to trigger workflows manually, e.g. if you have a branch that's not ready for a PR. To enable this, GH requires that the default branch of your repo have a workflow with `workflow_dispatch` among its triggers.