### PR TITLE
Fixed singularity user namespace feature detection

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -50,6 +50,7 @@ def _singularity_supports_userns() -> bool:
             _USERNS = (
                 "No valid /bin/sh" in result
                 or "/bin/sh doesn't exist in container" in result
+                or "executable file not found in" in result
             )
         except TimeoutExpired:
             _USERNS = False


### PR DESCRIPTION
Due a very long story (running `cwltool --singularity` on a FUSE mounted filesystem) I realized the detection of user namespaces feature on available singularity binary was broken. This pull request is a one-line addition which fixes it for at least singularity 3.5 and 3.7 .