### PR TITLE
remove relaxed/strict path checking global state

### DIFF
--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -74,6 +74,7 @@ class LoadingContext(ContextBase):
         self.do_update = None  # type: Optional[bool]
         self.jobdefaults = None  # type: Optional[CommentedMap]
         self.doc_cache = True  # type: bool
+        self.relax_path_checks = False  # type: bool
 
         super().__init__(kwargs)
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -41,7 +41,7 @@ from schema_salad.ref_resolver import Loader, file_uri, uri_file_path
 from schema_salad.sourceline import strip_dup_lineno
 from schema_salad.utils import ContextType, FetcherCallableType, json_dumps
 
-from . import CWL_CONTENT_TYPES, command_line_tool, workflow
+from . import CWL_CONTENT_TYPES, workflow
 from .argparser import arg_parser, generate_parser, get_default_args
 from .builder import HasReqsHints
 from .context import LoadingContext, RuntimeContext, getdefault
@@ -949,8 +949,6 @@ def main(
                 _logger.error("CWL document required, no input file was provided")
                 parser.print_help()
                 return 1
-        if args.relax_path_checks:
-            command_line_tool.ACCEPTLIST_RE = command_line_tool.ACCEPTLIST_EN_RELAXED_RE
 
         if args.ga4gh_tool_registries:
             ga4gh_tool_registries[:] = args.ga4gh_tool_registries


### PR DESCRIPTION
In the course of updating the deps/env stuff, I noticed a test failing that I could not reproduce locally

https://github.com/rupertnash/cwltool/runs/2125145168?check_suite_focus=true#step:9:142

I figured out this was because the global variable `cwltool.command_line_tool.ACCEPTLIST_RE` gets set based on the command line args and this state leaks when running tests in-process (sorry)

In this commit I propose a fix 