### PR TITLE
set minimum version of galaxy-tool-util that copes with relaxed path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "argcomplete",
     ],
     extras_require={
-        "deps": ["galaxy-tool-util"],
+        "deps": ["galaxy-tool-util >= 21.1.0"],
         "docs": [
             "sphinx >= 2.2",
             "sphinx-rtd-theme",

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
   py{36,37,38,39}-{unit,lint,bandit,mypy}: -rrequirements.txt
   py{36,37,38,39}-unit: codecov
   py{36,37,38,39}-{unit,mypy}: -rtest-requirements.txt
-  py{36,37,38,39}-unit: galaxy-tool-util
+  py{36,37,38,39}-unit: galaxy-tool-util>=21.1.0
   py{36,37,38,39}-lint: flake8-bugbear
   py{36,37,38,39}-lint: black
   py{36,37,38,39}-bandit: bandit


### PR DESCRIPTION
My bug fix here
https://github.com/common-workflow-language/cwltool/pull/1424
broke galaxy, which I fixed here
https://github.com/galaxyproject/galaxy/pull/11655
This PR updates tox config to install an appropriate version of `galaxy-tool-util`