### PR TITLE
Fix erroneous URL encoding of final output filenames

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -200,11 +200,7 @@ def revmap_file(
     outside the container. Recognizes files in the pathmapper or remaps
     internal output directories to the external directory.
     """
-    split = urllib.parse.urlsplit(outdir)
-    if not split.scheme:
-        outdir_uri, outdir_path = file_uri(str(outdir)), outdir
-    else:
-        outdir_uri, outdir_path = outdir, uri_file_path(str(outdir))
+    outdir_uri, outdir_path = file_uri(str(outdir)), outdir
 
     # builder.outdir is the inner (container/compute node) output directory
     # outdir is the outer (host/storage system) output directory
@@ -251,9 +247,6 @@ def revmap_file(
             joined_path = builder.fs_access.join(
                 outdir_path, path[len(builder.outdir) + 1 :]
             )
-            f["location"] = file_uri(joined_path)
-        elif not os.path.isabs(path):
-            joined_path = builder.fs_access.join(outdir_path, path)
             f["location"] = file_uri(joined_path)
         else:
             raise WorkflowException(

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1337,6 +1337,15 @@ class CommandLineTool(Process):
                             )
                         try:
                             prefix = fs_access.glob(outdir)
+                            sorted_glob_result = sorted(
+                                fs_access.glob(fs_access.join(outdir, gb)),
+                                key=cmp_to_key(
+                                    cast(
+                                        Callable[[str, str], int],
+                                        locale.strcoll,
+                                    )
+                                )
+                            )
                             r.extend(
                                 [
                                     {
@@ -1344,28 +1353,22 @@ class CommandLineTool(Process):
                                         "path": fs_access.join(
                                             builder.outdir,
                                             urllib.parse.unquote(
-                                                g[len(prefix[0]) + 1 :]
-                                            ),
+                                                g[len(prefix[0]) + 1:]
+                                            )
                                         ),
-                                        "basename": os.path.basename(g),
-                                        "nameroot": os.path.splitext(
-                                            os.path.basename(g)
-                                        )[0],
-                                        "nameext": os.path.splitext(
-                                            os.path.basename(g)
-                                        )[1],
+                                        "basename": decoded_basename,
+                                        "nameroot": os.path.splitext(decoded_basename)[0],
+                                        "nameext": os.path.splitext(decoded_basename)[1],
                                         "class": "File"
                                         if fs_access.isfile(g)
                                         else "Directory",
                                     }
-                                    for g in sorted(
-                                        fs_access.glob(fs_access.join(outdir, gb)),
-                                        key=cmp_to_key(
-                                            cast(
-                                                Callable[[str, str], int],
-                                                locale.strcoll,
-                                            )
-                                        ),
+                                    for g, decoded_basename in zip(
+                                        sorted_glob_result,
+                                        map(lambda x:
+                                            os.path.basename(urllib.parse.unquote(x)),
+                                            sorted_glob_result
+                                        )
                                     )
                                 ]
                             )

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -2,15 +2,15 @@ import pytest
 import urllib.parse
 
 from pathlib import Path
-from typing import cast, MutableMapping
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from typing import cast
+from ruamel.yaml.comments import CommentedMap
 from schema_salad.sourceline import cmap
 
 from cwltool.main import main
 from cwltool.command_line_tool import CommandLineTool
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.update import INTERNAL_VERSION
-from cwltool.utils import CWLObjectType, CWLOutputType
+from cwltool.utils import CWLObjectType
 from .util import needs_docker
 
 
@@ -144,7 +144,9 @@ def test_clt_returns_specialchar_names(tmp_path: Path) -> None:
 
     # Mock an "output" file with the above special characters in its name
     special = "".join(reserved)
-    output_schema = {"type": "File", "outputBinding": {"glob": special}}
+    output_schema = cast(
+        CWLObjectType, {"type": "File", "outputBinding": {"glob": special}}
+    )
     mock_output = tmp_path / special
     mock_output.touch()
 

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -1,10 +1,18 @@
-from pathlib import Path
-
 import pytest
+import urllib.parse
+
+from pathlib import Path
+from typing import cast, MutableMapping
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from schema_salad.sourceline import cmap
 
 from cwltool.main import main
-
+from cwltool.command_line_tool import CommandLineTool
+from cwltool.context import LoadingContext, RuntimeContext
+from cwltool.update import INTERNAL_VERSION
+from cwltool.utils import CWLObjectType, CWLOutputType
 from .util import needs_docker
+
 
 script = """
 #!/usr/bin/env cwl-runner
@@ -95,3 +103,64 @@ def test_unicode_in_output_files(tmp_path: Path, filename: str) -> None:
         filename,
     ]
     assert main(params) == 0
+
+
+def test_clt_returns_specialchar_names(tmp_path: Path) -> None:
+    loading_context = LoadingContext(
+        {
+            "metadata": {
+                "cwlVersion": INTERNAL_VERSION,
+                "http://commonwl.org/cwltool#original_cwlVersion": INTERNAL_VERSION,
+            }
+        }
+    )
+    clt = CommandLineTool(
+        cast(
+            CommentedMap,
+            cmap(
+                {
+                    "cwlVersion": INTERNAL_VERSION,
+                    "class": "CommandLineTool",
+                    "inputs": [],
+                    "outputs": [],
+                    "requirements": [],
+                }
+            ),
+        ),
+        loading_context,
+    )
+
+    # Reserved characters will be URL encoded during the creation of a file URI
+    # Internal references to files are in URI form, and are therefore URL encoded
+    # Final output files should not retain their URL encoded filenames
+    rfc_3986_gen_delims = [":", "/", "?", "#", "[", "]", "@"]
+    rfc_3986_sub_delims = ["!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="]
+    unix_reserved = ["/", "\0"]
+    reserved = [
+        special_char
+        for special_char in (rfc_3986_gen_delims + rfc_3986_sub_delims)
+        if special_char not in unix_reserved
+    ]
+
+    # Mock an "output" file with the above special characters in its name
+    special = "".join(reserved)
+    output_schema = {"type": "File", "outputBinding": {"glob": special}}
+    mock_output = tmp_path / special
+    mock_output.touch()
+
+    # Prepare minimal arguments for CommandLineTool.collect_output()
+    builder = clt._init_job({}, RuntimeContext())
+    builder.pathmapper = clt.make_path_mapper(
+        builder.files, builder.stagedir, RuntimeContext(), True
+    )
+    fs_access = builder.make_fs_access(str(tmp_path))
+
+    result = cast(
+        CWLObjectType,
+        clt.collect_output(output_schema, builder, str(tmp_path), fs_access),
+    )
+
+    assert result["class"] == "File"
+    assert result["basename"] == special
+    assert result["nameroot"] == special
+    assert str(result["location"]).endswith(urllib.parse.quote(special))

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -106,6 +106,7 @@ def test_unicode_in_output_files(tmp_path: Path, filename: str) -> None:
 
 
 def test_clt_returns_specialchar_names(tmp_path: Path) -> None:
+    """Confirm that special characters in filenames do not cause problems."""
     loading_context = LoadingContext(
         {
             "metadata": {


### PR DESCRIPTION
Fixes #1445; command_line_tool.collect_output() now URL decodes output file `basename`s, and uses the decoded result to determine the `nameroot` and `nameext` fields