### PR TITLE
Pin networkx so we don't install numpy, scipy and pandas by default.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PYTHON-NETWORKX-1062709:
+    - '*':
+        reason: Prov does not use the affected code path
+        expires: 2022-08-08T15:27:21.289Z
+        created: 2021-07-09T15:27:21.300Z
+patch: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ rdflib>=4.2.2,<5.1
 shellescape>=3.4.1,<3.9
 schema-salad>=8.1.20210627200047,<9
 prov==1.5.1
+networkx==2.5.1
 bagit==1.8.1
 mypy-extensions
 psutil>=5.6.6

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         "mypy-extensions",
         "psutil >= 5.6.6",
         "prov == 1.5.1",
+        "networkx < 2.6",
         "bagit >= 1.6.4",
         "typing-extensions",
         "coloredlogs",


### PR DESCRIPTION
The dependency chain is

cwltool -> prov -> networkx -> numpy

