### PR TITLE
pack: add $namespaces to the (effective) root only

### DIFF
--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -268,6 +268,8 @@ def pack(
 
     if schemas:
         packed["$schemas"] = list(schemas)
+    if namespaces:
+        packed["$namespaces"] = namespaces
 
     for r in list(rewrite.keys()):
         v = rewrite[r]
@@ -276,14 +278,13 @@ def pack(
     import_embed(packed, set())
 
     if len(packed["$graph"]) == 1:
-        # duplicate 'cwlVersion' and $schemas inside $graph when there is only
-        # a single item because we will print the contents inside '$graph'
-        # rather than whole dict
+        # duplicate 'cwlVersion', '$schemas', and '$namespaces' inside '$graph'
+        # when there is only a single item because main.print_pack() will print
+        # the contents inside '$graph' rather than whole dict in this case
         packed["$graph"][0]["cwlVersion"] = packed["cwlVersion"]
         if schemas:
             packed["$graph"][0]["$schemas"] = list(schemas)
-    # always include $namespaces in the #main
-    if namespaces:
-        packed["$graph"][0]["$namespaces"] = namespaces
+        if namespaces:
+            packed["$graph"][0]["$namespaces"] = namespaces
 
     return packed

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -94,9 +94,10 @@ def test_pack_fragment() -> None:
     )
     adjustDirObjs(packed, partial(make_relative, os.path.abspath(get_data("tests/wf"))))
 
-    assert json.dumps(packed, sort_keys=True, indent=2) == json.dumps(
-        expect_packed, sort_keys=True, indent=2
-    )
+    packed_result = json.dumps(packed, sort_keys=True, indent=2)
+    expected = json.dumps(expect_packed, sort_keys=True, indent=2)
+
+    assert packed_result == expected
 
 
 def test_pack_rewrites() -> None:

--- a/tests/wf/expect_packed.cwl
+++ b/tests/wf/expect_packed.cwl
@@ -67,10 +67,7 @@
                     "id": "#main/sorted"
                 }
             ],
-            "id": "#main",
-            "$namespaces": {
-                "iana": "https://www.iana.org/assignments/media-types/"
-            }
+            "id": "#main"
         },
         {
             "class": "CommandLineTool",
@@ -133,5 +130,8 @@
     "$schemas": [
         "empty.ttl",
         "empty2.ttl"
-    ]
+    ],
+    "$namespaces": {
+        "iana": "https://www.iana.org/assignments/media-types/"
+    }
 }

--- a/tests/wf/expect_revsort_datetime_packed.cwl
+++ b/tests/wf/expect_revsort_datetime_packed.cwl
@@ -68,11 +68,7 @@
                 }
             ],
             "id": "#main",
-            "http://schema.org/dateCreated": "2020-10-08",
-            "$namespaces": {
-                "iana": "https://www.iana.org/assignments/media-types/",
-                "s": "http://schema.org/"
-            }
+            "http://schema.org/dateCreated": "2020-10-08"
         },
         {
             "class": "CommandLineTool",
@@ -136,5 +132,9 @@
         "empty2.ttl",
         "https://schema.org/version/latest/schemaorg-current-https.rdf",
         "empty.ttl"
-    ]
+    ],
+    "$namespaces": {
+        "iana": "https://www.iana.org/assignments/media-types/",
+        "s": "http://schema.org/"
+    }
 }

--- a/tests/wf/expect_trick_packed.cwl
+++ b/tests/wf/expect_trick_packed.cwl
@@ -21,10 +21,7 @@
             ],
             "baseCommand": "rev",
             "stdout": "output.txt",
-            "id": "#revtool.cwl",
-            "$namespaces": {
-                "iana": "https://www.iana.org/assignments/media-types/"
-            }
+            "id": "#revtool.cwl"
         },
         {
             "class": "CommandLineTool",
@@ -138,5 +135,8 @@
     "$schemas": [
         "empty2.ttl",
         "empty.ttl"
-    ]
+    ],
+    "$namespaces": {
+        "iana": "https://www.iana.org/assignments/media-types/"
+    }
 }

--- a/tests/wf/scatter2_subwf.cwl
+++ b/tests/wf/scatter2_subwf.cwl
@@ -72,5 +72,8 @@
       ]
     }
   ],
-  "cwlVersion": "v1.0"
+  "cwlVersion": "v1.0",
+  "$namespaces": {
+    "arv": "http://arvados.org/cwl#"
+  }
 }


### PR DESCRIPTION
As per schema-salad, `$namespaces` are only valid in the root document:

https://www.commonwl.org/v1.0/SchemaSalad.html#Explicit_context
https://www.commonwl.org/v1.1/SchemaSalad.html#Explicit_context (same as v1.0)
https://www.commonwl.org/v1.2/SchemaSalad.html#Explicit_context (same as v1.0, v1.1)

Inspired by (and partial fix for) https://github.com/common-workflow-language/cwl-utils/issues/71#issuecomment-912887777