### PR TITLE
more expr parsing tests

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -827,6 +827,26 @@ def test_format_expr_error() -> None:
     )
 
 
+def test_format_expr_error2() -> None:
+    """Better format expression error, for a list of formats."""
+    error_code, _, stderr = get_main_output(
+        [
+            get_data("tests/wf/bad_formattest2.cwl"),
+            get_data("tests/wf/formattest-job.json"),
+        ]
+    )
+    assert error_code != 0
+    stderr = re.sub(r"\s\s+", " ", stderr)
+    assert (
+        "bad_formattest2.cwl:14:9: For inputs, 'format' field can either contain "
+        "a single CWL Expression or CWL Parameter Reference, a single format string, "
+        "or a list of format strings. But the list cannot contain CWL Expressions "
+        "or CWL Parameter References. List entry number 1 contains the following "
+        "unallowed CWL Parameter Reference or Expression: '${ return "
+        '["http://edamontology.org/format_2330", 42];}' in stderr
+    )
+
+
 def test_static_checker() -> None:
     # check that the static checker raises exception when a source type
     # mismatches its sink type.

--- a/tests/wf/bad_formattest2.cwl
+++ b/tests/wf/bad_formattest2.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+$namespaces:
+  edam: "http://edamontology.org/"
+cwlVersion: v1.0
+class: CommandLineTool
+requirements:
+  InlineJavascriptRequirement: {}
+doc: "Reverse each line using the `rev` command"
+inputs:
+  input:
+    type: File
+    inputBinding: {}
+    format:
+      - |
+        ${ return ["http://edamontology.org/format_2330", 42];}
+
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: output.txt
+    format: |
+      ${return "http://edamontology.org/format_2330";}
+
+baseCommand: rev
+stdout: output.txt


### PR DESCRIPTION
- [ ] Fix  https://github.com/common-workflow-language/cwltool/issues/1498
```
WARNING  salad:load_tool.py:381 URI prefix '${ return ["http' of '${ return ["http://edamontology.org/format_2330", 42];}
' not recognized, are you missing a $namespaces section?
WARNING  salad:load_tool.py:381 URI prefix '${ return ["http' of '${ return ["http://edamontology.org/format_2330", 42];}
' not recognized, are you missing a $namespaces section?
WARNING  salad:load_tool.py:381 URI prefix '${return "http' of '${return "http://edamontology.org/format_2330";}
' not recognized, are you missing a $namespaces section?
WARNING  salad:load_tool.py:381 URI prefix '${return "http' of '${return "http://edamontology.org/format_2330";}
' not recognized, are you missing a $namespaces section?
```