### PR TITLE
Fix #816

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -344,6 +344,22 @@ class Builder(HasReqsHints):
                     )
                 )
         else:
+            if schema["type"] == "org.w3id.cwl.salad.Any":
+                if isinstance(datum, dict):
+                    if datum.get("class") == "File":
+                        schema["type"] = "org.w3id.cwl.cwl.File"
+                    elif datum.get("class") == "Directory":
+                        schema["type"] = "org.w3id.cwl.cwl.Directory"
+                    else:
+                        schema["type"] = "record"
+                        schema["fields"] = [
+                            {"name": field_name, "type": "Any"}
+                            for field_name in datum.keys()
+                        ]
+                elif isinstance(datum, list):
+                    schema["type"] = "array"
+                    schema["items"] = "Any"
+
             if schema["type"] in self.schemaDefs:
                 schema = self.schemaDefs[cast(str, schema["type"])]
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1568,3 +1568,11 @@ def test_bad_networkaccess_expr() -> None:
         "Got '42' for expression '${return 42;}" in stderr
     )
     assert err_code == 1
+
+
+def test_staging_files_in_any() -> None:
+    """Confirm that inputs of type File are staged, even if the schema is Any."""
+    err_code, _, stderr = get_main_output(
+        [get_data("tests/wf/816_wf.cwl"), "--file", get_data("tests/echo-job.yaml")]
+    )
+    assert err_code == 0

--- a/tests/wf/816_tool.cwl
+++ b/tests/wf/816_tool.cwl
@@ -1,0 +1,14 @@
+cwlVersion: v1.0
+class: CommandLineTool
+requirements:
+  - class: InlineJavascriptRequirement
+baseCommand: ['echo']
+
+inputs:
+  - id: file
+    type: Any
+    inputBinding:
+      valueFrom: "[$(self)]"
+
+outputs: []
+

--- a/tests/wf/816_wf.cwl
+++ b/tests/wf/816_wf.cwl
@@ -1,0 +1,12 @@
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  file:
+    type: File
+outputs: []
+steps:
+  - id: step
+    in:
+      file: file
+    out: []
+    run: 816_tool.cwl


### PR DESCRIPTION
Fixes #816 

This partially fills fills the type of parameters with type Any, so that the type can be used for bindings

(re-do of https://github.com/common-workflow-language/cwltool/pull/818)