### PR TITLE
Remove temporary directories when cache dir is empty string

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -158,7 +158,7 @@ class JobExecutor(metaclass=ABCMeta):
             )
 
         if runtime_context.rm_tmpdir:
-            if runtime_context.cachedir is None:
+            if not runtime_context.cachedir:
                 output_dirs = self.output_dirs  # type: Iterable[str]
             else:
                 output_dirs = filter(

--- a/tests/test_tmpdir.py
+++ b/tests/test_tmpdir.py
@@ -14,6 +14,7 @@ from cwltool.command_line_tool import CommandLineTool
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.docker import DockerCommandLineJob
 from cwltool.job import JobBase
+from cwltool.main import main
 from cwltool.pathmapper import MapperEnt, PathMapper
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.update import INTERNAL_VERSION, ORIGINAL_CWLVERSION
@@ -230,3 +231,20 @@ def test_runtimeContext_respects_tmp_outdir_prefix(tmp_path: Path) -> None:
     runtime_context = RuntimeContext({"tmp_outdir_prefix": tmpdir_prefix})
     assert runtime_context.get_outdir().startswith(tmpdir_prefix)
     assert runtime_context.create_outdir().startswith(tmpdir_prefix)
+
+
+def test_remove_tmpdirs(tmp_path: Path) -> None:
+    """Test that the tmpdirs are removed after the job execution."""
+    assert (
+        main(
+            [
+                "--tmpdir-prefix",
+                str(f"{tmp_path}/"),
+                get_data("tests/wf/hello_single_tool.cwl"),
+                "--message",
+                "Hello",
+            ]
+        )
+        == 0
+    )
+    assert len(list(tmp_path.iterdir())) == 0


### PR DESCRIPTION
For issue reported on Discourse: https://cwl.discourse.group/t/cwl-runner-tmpdir-not-deleted/401

When debugging the example from https://www.commonwl.org/user_guide/02-1st-example/index.html, with the command line `cwltool --tmpdir-prefix /tmp/cwl/ /tmp/1st-tool.cwl /tmp/echo-job.yml`, I noticed the `output_dirs` being set to an empty list.

The issue was because the `runtime_context.cachedir` was not `None`, but it was an empty string. So the value of `output_dirs` was incorrectly initialized.

Pending a unit/functional test as I have to learn how to write those for `cwltool` :grimacing: any pointers?

![image](https://user-images.githubusercontent.com/304786/135774535-69016b65-a644-4abf-bdea-160756106450.png)

Thanks