### PR TITLE
WIP fix #1330

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -775,6 +775,10 @@ class Process(HasReqsHints, metaclass=abc.ABCMeta):
             )
 
         job = copy.deepcopy(joborder)
+        if len(job.keys()) > 0:
+            for jo in joborder:
+                field = shortname(jo)
+                job[field] = joborder[jo]
 
         make_fs_access = getdefault(runtime_context.make_fs_access, StdFsAccess)
         fs_access = make_fs_access(runtime_context.basedir)

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -440,10 +440,11 @@ class WorkflowStep(Process):
             )
 
         step_input = {}
-        for inp in self.tool["inputs"]:
-            field = shortname(inp["id"])
-            if not inp.get("not_connected"):
-                step_input[field] = job_order[inp["id"]]
+        for inp in job_order:
+            field = shortname(inp)
+            step_input[field] = job_order[inp]
+            # if not inp.get("not_connected"):
+            #    step_input[field] = job_order[field]
 
         try:
             yield from self.embedded_tool.job(

--- a/cwltool/workflow_job.py
+++ b/cwltool/workflow_job.py
@@ -386,6 +386,8 @@ def object_from_state(
     incomplete: bool = False,
 ) -> Optional[CWLObjectType]:
     inputobj = {}  # type: CWLObjectType
+    for s in state.keys():
+        inputobj[s] = state[s].value
     for inp in parms:
         iid = original_id = cast(str, inp["id"])
         if frag_only:


### PR DESCRIPTION
#1330

At least workflow-dyn-res.cwl does not create error.

But this PR fail some tests.

```
(venv) ➜  cwltool git:(fix_issue_1330) ✗ python3 -m cwltool workflow-dyn-res.cwl         
INFO /Users/manabu/ghq/github.com/common-workflow-language/cwltool/cwltool/__main__.py 3.1.20211107152837
INFO Resolved 'workflow-dyn-res.cwl' to 'file:///Users/manabu/ghq/github.com/common-workflow-language/cwltool/workflow-dyn-res.cwl'
INFO [workflow ] start
INFO [workflow ] starting step one
INFO [step one] start
INFO [job one] /private/tmp/docker_tmpduee6x2k$ echo \
    4
4
INFO [job one] completed success
INFO [step one] completed success
INFO [workflow ] completed success
{
    "file:///Users/manabu/ghq/github.com/common-workflow-language/cwltool/workflow-dyn-res.cwl#threads_max": 4
}
INFO Final process status is success
```