### PR TITLE
Reduce bind mounting (and thus --bind args) in containers.

### DIFF
--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -247,8 +247,7 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             options.append("readonly")
         output = StringIO()
         csv.writer(output).writerow(options)
-        mount_arg = output.getvalue().strip()
-        runtime.append(f"--mount={mount_arg}")
+        runtime.append(f"--mount={output.getvalue().strip()}")
         # Unlike "--volume", "--mount" will fail if the volume doesn't already exist.
         if not os.path.exists(source):
             os.makedirs(source)

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -247,7 +247,8 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             options.append("readonly")
         output = StringIO()
         csv.writer(output).writerow(options)
-        runtime.append(f"--mount={output.getvalue().strip()}")
+        mount_arg = output.getvalue().strip()
+        runtime.append(f"--mount={mount_arg}")
         # Unlike "--volume", "--mount" will fail if the volume doesn't already exist.
         if not os.path.exists(source):
             os.makedirs(source)

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -701,14 +701,14 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
                 host_outdir_tgt = os.path.join(
                     self.outdir, vol.target[len(container_outdir) + 1 :]
                 )
-            if stage_source_dir and vol.resolved.startswith(stage_source_dir):
-                continue  # path is already staged; only mount the host directory
             if not host_outdir_tgt and not any_path_okay:
                 raise WorkflowException(
                     "No mandatory DockerRequirement, yet path is outside "
                     "the designated output directory, also know as "
                     "$(runtime.outdir): {}".format(vol)
                 )
+            if stage_source_dir and vol.resolved.startswith(stage_source_dir):
+                continue  # path is already staged; only mount the host directory (at the end of this function)
             if vol.type in ("File", "Directory"):
                 logging.critical(f'file/dir: {vol.target}')
                 self.add_file_or_directory_volume(runtime, vol, host_outdir_tgt)
@@ -728,8 +728,8 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
                     runtime, vol, host_outdir_tgt, secret_store, tmpdir_prefix
                 )
                 pathmapper.update(key, new_path, vol.target, vol.type, vol.staged)
-        # mount a single host directory for all staged source files
         if stage_source_dir and pathmapper.stagedir != container_outdir:
+            # mount a single host directory for all staged input files
             self.append_volume(runtime, stage_source_dir, pathmapper.stagedir, writable=True)
 
     def run(

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -710,20 +710,16 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
             if stage_source_dir and vol.resolved.startswith(stage_source_dir):
                 continue  # path is already staged; only mount the host directory (at the end of this function)
             if vol.type in ("File", "Directory"):
-                logging.critical(f'file/dir: {vol.target}')
                 self.add_file_or_directory_volume(runtime, vol, host_outdir_tgt)
             elif vol.type == "WritableFile":
-                logging.critical(f'wfile: {vol.target}')
                 self.add_writable_file_volume(
                     runtime, vol, host_outdir_tgt, tmpdir_prefix
                 )
             elif vol.type == "WritableDirectory":
-                logging.critical(f'wdir: {vol.target}')
                 self.add_writable_directory_volume(
                     runtime, vol, host_outdir_tgt, tmpdir_prefix
                 )
             elif vol.type in ["CreateFile", "CreateWritableFile"]:
-                logging.critical(f'cf: {vol.target}')
                 new_path = self.create_file_and_add_volume(
                     runtime, vol, host_outdir_tgt, secret_store, tmpdir_prefix
                 )

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -174,15 +174,16 @@ class PathMapper:
         # with any secondary files.
         stagedir = self.stagedir
         stage_source_dir = os.environ.get('STAGE_SRC_DIR', os.path.join(tempfile.gettempdir(), 'cwl-stg-src-dir'))
-        if stage_source_dir:
-            os.makedirs(stage_source_dir, exist_ok=True)
         for fob in referenced_files:
             staging_uuid = str(uuid.uuid4())
             if self.separateDirs:
                 # this is what the path will be inside of the container environment
                 stagedir = os.path.join(self.stagedir, "stg%s" % staging_uuid)
             # if STAGE_SRC_DIR is set, this is where input paths will be linked/staged at
-            unique_stage_source_dir = None if not stage_source_dir else os.path.join(stage_source_dir, "stg%s" % staging_uuid)
+            unique_stage_source_dir = None
+            if stage_source_dir:
+                unique_stage_source_dir = os.path.join(stage_source_dir, "stg%s" % staging_uuid)
+                os.makedirs(stage_source_dir, exist_ok=True)
             self.visit(
                 fob,
                 stagedir,

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import os
 import tempfile
+import shutil
 import stat
 import urllib
 import uuid
@@ -156,7 +157,10 @@ class PathMapper:
                             st = os.lstat(deref)
                     if stage_source_dir:
                         staged_source_file = os.path.join(stage_source_dir, os.path.basename(deref))
-                        os.link(deref, staged_source_file)
+                        try:
+                            os.link(deref, staged_source_file)
+                        except OSError:
+                            shutil.copyfile(deref, staged_source_file)
                         deref = staged_source_file
                     self._pathmap[path] = MapperEnt(
                         deref, tgt, "WritableFile" if copy else "File", staged


### PR DESCRIPTION
This is because there is a memory limit on the length of bind arguments one can pass in the CLI and we can hit that limit (particularly Toil, which handles directories differently and tries to export files individually).

I need to make a test.  Currently `os.environ.get('STAGE_SRC_DIR', os.path.join(tempfile.gettempdir(), 'cwl-stg-src-dir'))` is set just to have this run through CI/CD.  I'll change to `os.environ.get('STAGE_SRC_DIR', None)` once I make a test.