### PR TITLE
_terminate_processes for non-docker processes, like nodejs

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -120,7 +120,7 @@ def _terminate_processes() -> None:
         else:
             args = [process.args]
         cidfile = [str(arg).split("=")[1] for arg in args if "--cidfile" in str(arg)]
-        if cidfile:
+        if cidfile:  # Try to be nice
             try:
                 with open(cidfile[0]) as inp_stream:
                     p = subprocess.Popen(  # nosec
@@ -132,6 +132,10 @@ def _terminate_processes() -> None:
                         p.kill()
             except FileNotFoundError:
                 pass
+        if process.stdin:
+            process.stdin.close()
+        process.wait(10)
+        process.kill()  # Always kill, even if we tried with the cidfile
 
 
 def _signal_handler(signum: int, _: Any) -> None:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -134,7 +134,10 @@ def _terminate_processes() -> None:
                 pass
         if process.stdin:
             process.stdin.close()
-        process.wait(10)
+        try:
+            process.wait(10)
+        except subprocess.TimeoutExpired:
+            pass
         process.kill()  # Always kill, even if we tried with the cidfile
 
 


### PR DESCRIPTION
Fix for the `cwltool` side of https://github.com/DataBiosphere/toil/issues/3965