### PR TITLE
fix --single-step step2_tool error

### DIFF
--- a/cwltool/subgraph.py
+++ b/cwltool/subgraph.py
@@ -222,6 +222,8 @@ def get_step(
             del inport["linkMerge"]
 
     for outport in cast(List[str], step["out"]):
+        if isinstance(outport, Mapping) and "id" in outport:
+            outport = outport["id"]
         name = outport.split("#")[-1].split("/")[-1]
         extracted["outputs"].append(
             {

--- a/cwltool/subgraph.py
+++ b/cwltool/subgraph.py
@@ -221,10 +221,12 @@ def get_step(
         if "linkMerge" in inport:
             del inport["linkMerge"]
 
-    for outport in cast(List[str], step["out"]):
-        if isinstance(outport, Mapping) and "id" in outport:
-            outport = outport["id"]
-        name = outport.split("#")[-1].split("/")[-1]
+    for outport in cast(List[Union[str, Mapping[str, Any]]], step["out"]):
+        if isinstance(outport, Mapping):
+            outport_id = cast(str, outport["id"])
+        else:
+            outport_id = outport
+        name = outport_id.split("#")[-1].split("/")[-1]
         extracted["outputs"].append(
             {
                 "id": name,

--- a/tests/subgraph/env-wf2_long.cwl
+++ b/tests/subgraph/env-wf2_long.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+class: Workflow
+cwlVersion: v1.2
+
+inputs:
+    in: string
+
+outputs:
+    out:
+      type: File
+      outputSource: step1/out
+
+requirements:
+  EnvVarRequirement:
+    envDef:
+      TEST_ENV: override
+
+steps:
+  step1:
+    run: env-tool2.cwl
+    in:
+      in: in
+    out:
+     - id: out

--- a/tests/subgraph/env-wf2_subwf_b.cwl
+++ b/tests/subgraph/env-wf2_subwf_b.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+class: Workflow
+cwlVersion: v1.2
+
+inputs:
+    in: string
+
+outputs:
+    out:
+      type: File
+      outputSource: sub_wf/out
+
+requirements:
+  SubworkflowFeatureRequirement: {}
+  EnvVarRequirement:
+    envDef:
+      TEST_ENV: override_super
+
+steps:
+  sub_wf:
+    run: env-wf2_long.cwl
+    in:
+      in: in
+    out: [out]

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -241,6 +241,23 @@ def test_single_step_subwf_step() -> None:
     )
 
 
+def test_single_step_wfstep_long_out() -> None:
+    """Support long form of step.out with --single-step."""
+    err_code, stdout, stderr = get_main_output(
+        [
+            "--single-step",
+            "sub_wf/step1",
+            get_data("tests/subgraph/env-wf2_subwf_b.cwl"),
+            get_data("tests/subgraph/env-job.json"),
+        ]
+    )
+    assert err_code == 0
+    assert (
+        json.loads(stdout)["out"]["checksum"]
+        == "sha1$7608e5669ba454c61fab01c9b133b52a9a7de68c"
+    )
+
+
 def test_single_step_packed_subwf_step() -> None:
     """Inherit reqs and hints --single-step on packed sub-workflow step."""
     err_code, stdout, stderr = get_main_output(


### PR DESCRIPTION
when use --single-step step2_tool parameter to run step in workflow meet this error
```
Traceback (most recent call last):
  File "/d/project/cwltool-main/cwltool/main.py", line 1181, in main
    ctool = choose_step(args, tool, loadingContext)
  File "/d/project/cwltool-main/cwltool/main.py", line 861, in choose_step
    extracted = get_step(tool, step_id, loading_context)
  File "/d/project/cwltool-main/cwltool/subgraph.py", line 225, in get_step
    name = outport.split("#")[-1].split("/")[-1]
AttributeError: 'CommentedMap' object has no attribute 'split'
```