### PR TITLE
--validate works with $graph docs lacking a "main"

### DIFF
--- a/cwltool/errors.py
+++ b/cwltool/errors.py
@@ -8,3 +8,7 @@ class UnsupportedRequirement(WorkflowException):
 
 class ArgumentException(Exception):
     """Mismatched command line arguments provided."""
+
+
+class GraphTargetMissingException(WorkflowException):
+    """When a $graph is encountered and there is no target and no main/#main."""

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -34,7 +34,7 @@ from schema_salad.utils import (
 
 from . import CWL_CONTENT_TYPES, process, update
 from .context import LoadingContext
-from .errors import WorkflowException
+from .errors import GraphTargetMissingException
 from .loghandler import _logger
 from .process import Process, get_schema, shortname
 from .update import ALLUPDATES
@@ -455,7 +455,7 @@ def make_tool(
                 processobj = obj
                 break
         if not processobj:
-            raise WorkflowException(
+            raise GraphTargetMissingException(
                 "Tool file contains graph of multiple objects, must specify "
                 "one of #%s"
                 % ", #".join(

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -48,7 +48,12 @@ from . import CWL_CONTENT_TYPES, workflow
 from .argparser import arg_parser, generate_parser, get_default_args
 from .context import LoadingContext, RuntimeContext, getdefault
 from .cwlrdf import printdot, printrdf
-from .errors import ArgumentException, UnsupportedRequirement, WorkflowException
+from .errors import (
+    ArgumentException,
+    GraphTargetMissingException,
+    UnsupportedRequirement,
+    WorkflowException,
+)
 from .executors import JobExecutor, MultithreadedJobExecutor, SingleJobExecutor
 from .load_tool import (
     default_loader,
@@ -424,7 +429,7 @@ def init_job_order(
             input_required,
         )
         if args.tool_help:
-            toolparser.print_help()
+            toolparser.print_help(cast(IO[str], stdout))
             exit(0)
         cmd_line = vars(toolparser.parse_args(args.job_order))
         for record_name in records:
@@ -473,17 +478,6 @@ def init_job_order(
             if not job_order_object:
                 job_order_object = {}
             job_order_object[shortname(inp["id"])] = inp["default"]
-
-    if len(job_order_object) == 0:
-        if process.tool["inputs"]:
-            if toolparser is not None:
-                print(f"\nOptions for {args.workflow} ")
-                toolparser.print_help()
-            _logger.error("")
-            _logger.error("Input object required, use --help for details")
-            exit(1)
-        else:
-            job_order_object = {}
 
     def path_to_loc(p: CWLObjectType) -> None:
         if "location" not in p and "path" in p:
@@ -574,7 +568,7 @@ def printdeps(
     elif relative_deps == "cwd":
         base = os.getcwd()
     visit_class(deps, ("File", "Directory"), functools.partial(make_relative, base))
-    stdout.write(json_dumps(deps, indent=4, default=str))
+    print(json_dumps(deps, indent=4, default=str), file=stdout)
 
 
 def prov_deps(
@@ -946,10 +940,10 @@ def print_targets(
     for f in ("outputs", "inputs"):
         if tool.tool[f]:
             _logger.info("%s %s%s targets:", prefix[:-1], f[0].upper(), f[1:-1])
-            stdout.write(
+            print(
                 "  "
-                + "\n  ".join([f"{prefix}{shortname(t['id'])}" for t in tool.tool[f]])
-                + "\n"
+                + "\n  ".join([f"{prefix}{shortname(t['id'])}" for t in tool.tool[f]]),
+                file=stdout,
             )
     if "steps" in tool.tool:
         loading_context = copy.copy(loading_context)
@@ -957,7 +951,7 @@ def print_targets(
         loading_context.hints = tool.hints
         _logger.info("%s steps targets:", prefix[:-1])
         for t in tool.tool["steps"]:
-            stdout.write(f"  {prefix}{shortname(t['id'])}\n")
+            print(f"  {prefix}{shortname(t['id'])}", file=stdout)
             run: Union[str, Process, Dict[str, Any]] = t["run"]
             if isinstance(run, str):
                 process = make_tool(run, loading_context)
@@ -1040,12 +1034,12 @@ def main(
         )
 
         if args.version:
-            print(versionfunc())
+            print(versionfunc(), file=stdout)
             return 0
         _logger.info(versionfunc())
 
         if args.print_supported_versions:
-            print("\n".join(supported_cwl_versions(args.enable_dev)))
+            print("\n".join(supported_cwl_versions(args.enable_dev)), file=stdout)
             return 0
 
         if not args.workflow:
@@ -1053,7 +1047,7 @@ def main(
                 args.workflow = "CWLFile"
             else:
                 _logger.error("CWL document required, no input file was provided")
-                parser.print_help()
+                parser.print_help(stderr)
                 return 1
 
         if args.ga4gh_tool_registries:
@@ -1126,7 +1120,7 @@ def main(
             processobj, metadata = loadingContext.loader.resolve_ref(uri)
             processobj = cast(Union[CommentedMap, CommentedSeq], processobj)
             if args.pack:
-                stdout.write(print_pack(loadingContext, uri))
+                print(print_pack(loadingContext, uri), file=stdout)
                 return 0
 
             if args.provenance and runtimeContext.research_obj:
@@ -1136,29 +1130,45 @@ def main(
                 )
 
             if args.print_pre:
-                stdout.write(
+                print(
                     json_dumps(
                         processobj,
                         indent=4,
                         sort_keys=True,
                         separators=(",", ": "),
                         default=str,
-                    )
+                    ),
+                    file=stdout,
                 )
                 return 0
 
-            tool = make_tool(uri, loadingContext)
+            try:
+                tool = make_tool(uri, loadingContext)
+            except GraphTargetMissingException as main_missing_exc:
+                if args.validate:
+                    logging.warn(
+                        "File contains $graph of multiple objects and no default "
+                        "process (#main). Validating all objects:"
+                    )
+                    for entry in workflowobj["$graph"]:
+                        entry_id = entry["id"]
+                        make_tool(entry_id, loadingContext)
+                        print(f"{entry_id} is valid CWL.", file=stdout)
+                else:
+                    raise main_missing_exc
+
             if args.make_template:
                 make_template(tool)
                 return 0
 
             if args.validate:
-                print(f"{args.workflow} is valid CWL.")
+                print(f"{args.workflow} is valid CWL.", file=stdout)
                 return 0
 
             if args.print_rdf:
-                stdout.write(
-                    printrdf(tool, loadingContext.loader.ctx, args.rdf_serializer)
+                print(
+                    printrdf(tool, loadingContext.loader.ctx, args.rdf_serializer),
+                    file=stdout,
                 )
                 return 0
 
@@ -1194,14 +1204,15 @@ def main(
             if args.print_subgraph:
                 if "name" in tool.tool:
                     del tool.tool["name"]
-                stdout.write(
+                print(
                     json_dumps(
                         tool.tool,
                         indent=4,
                         sort_keys=True,
                         separators=(",", ": "),
                         default=str,
-                    )
+                    ),
+                    file=stdout,
                 )
                 return 0
 
@@ -1361,8 +1372,10 @@ def main(
                 # Unsetting the Generation from final output object
                 visit_class(out, ("File",), MutationManager().unset_generation)
 
-                stdout.write(json_dumps(out, indent=4, ensure_ascii=False, default=str))
-                stdout.write("\n")
+                print(
+                    json_dumps(out, indent=4, ensure_ascii=False, default=str),
+                    file=stdout,
+                )
                 if hasattr(stdout, "flush"):
                     stdout.flush()
 

--- a/tests/test_misc_cli.py
+++ b/tests/test_misc_cli.py
@@ -1,0 +1,68 @@
+"""Tests for various command line options."""
+
+from cwltool.utils import versionstring
+
+from .util import get_data, get_main_output
+
+
+def test_version() -> None:
+    """Test --version."""
+    return_code, stdout, stderr = get_main_output(["--version"])
+    assert return_code == 0
+    assert versionstring() in stdout
+
+
+def test_print_supported_versions() -> None:
+    """Test --print-supported-versions."""
+    return_code, stdout, stderr = get_main_output(["--print-supported-versions"])
+    assert return_code == 0
+    assert "v1.2" in stdout
+
+
+def test_empty_cmdling() -> None:
+    """Test empty command line."""
+    return_code, stdout, stderr = get_main_output([])
+    assert return_code == 1
+    assert "CWL document required, no input file was provided" in stderr
+
+
+def test_tool_help() -> None:
+    """Test --tool-help."""
+    return_code, stdout, stderr = get_main_output(
+        ["--tool-help", get_data("tests/echo.cwl")]
+    )
+    assert return_code == 0
+    assert "job_order   Job input json file" in stdout
+
+
+def test_basic_pack() -> None:
+    """Basic test of --pack. See test_pack.py for detailed testing."""
+    return_code, stdout, stderr = get_main_output(
+        ["--pack", get_data("tests/wf/revsort.cwl")]
+    )
+    assert return_code == 0
+    assert "$graph" in stdout
+
+
+def test_basic_print_subgraph() -> None:
+    """Basic test of --print-subgraph. See test_subgraph.py for detailed testing."""
+    return_code, stdout, stderr = get_main_output(
+        [
+            "--print-subgraph",
+            get_data("tests/subgraph/count-lines1-wf.cwl"),
+        ]
+    )
+    assert return_code == 0
+    assert "cwlVersion" in stdout
+
+
+def test_error_graph_with_no_default() -> None:
+    """Ensure a useful error is printed on $graph docs that lack a main/#main."""
+    exit_code, stdout, stderr = get_main_output(
+        ["--tool-help", get_data("tests/wf/packed_no_main.cwl")]
+    )  # could be any command except --validate
+    assert exit_code == 1
+    assert (
+        "Tool file contains graph of multiple objects, must specify one of #echo, #cat, #collision"
+        in stderr
+    )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,16 @@
+"""Tests --validation."""
+
+
+from .util import get_data, get_main_output
+
+
+def test_validate_graph_with_no_default() -> None:
+    """Ensure that --validate works on $graph docs that lack a main/#main."""
+    exit_code, stdout, stderr = get_main_output(
+        ["--validate", get_data("tests/wf/packed_no_main.cwl")]
+    )
+    assert exit_code == 0
+    assert "packed_no_main.cwl#echo is valid CWL" in stdout
+    assert "packed_no_main.cwl#cat is valid CWL" in stdout
+    assert "packed_no_main.cwl#collision is valid CWL" in stdout
+    assert "tests/wf/packed_no_main.cwl is valid CWL" in stdout

--- a/tests/wf/packed_no_main.cwl
+++ b/tests/wf/packed_no_main.cwl
@@ -1,0 +1,72 @@
+cwlVersion: v1.2
+$graph:
+- id: echo
+  class: CommandLineTool
+  inputs:
+    text:
+      type: string
+      inputBinding: {}
+
+  outputs:
+    fileout:
+      type: File
+      outputBinding:
+        glob: out.txt
+
+  baseCommand: echo
+  stdout: out.txt
+
+- id: cat
+  class: CommandLineTool
+  inputs:
+    file1:
+      type: File
+      inputBinding:
+        position: 1
+    file2:
+      type: File
+      inputBinding:
+        position: 2
+
+  outputs:
+    fileout:
+      type: File
+      outputBinding:
+        glob: out.txt
+
+  baseCommand: cat
+  stdout: out.txt
+
+- class: Workflow
+  id: collision
+
+  inputs:
+    input_1: string
+    input_2: string
+
+  outputs:
+    fileout:
+      type: File
+      outputSource: cat_step/fileout
+
+  steps:
+    echo_1:
+      run: "#echo"
+      in:
+        text: input_1
+      out: [fileout]
+
+    echo_2:
+      run: "#echo"
+      in:
+        text: input_2
+      out: [fileout]
+
+    cat_step:
+      run: "#cat"
+      in:
+        file1:
+          source: echo_1/fileout
+        file2:
+          source: echo_2/fileout
+      out: [fileout]


### PR DESCRIPTION
Should this be a new command line option `--validate-all`? That would make sense if users were using `--validate` to determine "is this URL a valid reference to a CWL Process" despite the option's help text being "Validate CWL document only"