### PR TITLE
Handle URLs for command line inputs

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -12,6 +12,7 @@ from typing import (
     MutableSequence,
     Optional,
     Sequence,
+    Type,
     Union,
     cast,
 )
@@ -737,7 +738,7 @@ class FSAction(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: Union[AnyStr, Sequence[Any], None],
+        values: Union[str, Sequence[Any], None],
         option_string: Optional[str] = None,
     ) -> None:
         setattr(
@@ -745,7 +746,7 @@ class FSAction(argparse.Action):
             self.dest,
             {
                 "class": self.objclass,
-                "location": self.urljoin(self.base_uri, cast(AnyStr, values)),
+                "location": self.urljoin(self.base_uri, cast(str, values)),
             },
         )
 
@@ -773,7 +774,7 @@ class FSAppendAction(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: Union[AnyStr, Sequence[Any], None],
+        values: Union[str, Sequence[Any], None],
         option_string: Optional[str] = None,
     ) -> None:
         g = getattr(namespace, self.dest)
@@ -783,7 +784,7 @@ class FSAppendAction(argparse.Action):
         g.append(
             {
                 "class": self.objclass,
-                "location": self.urljoin(self.base_uri, cast(AnyStr, values)),
+                "location": self.urljoin(self.base_uri, cast(str, values)),
             }
         )
 
@@ -837,19 +838,19 @@ def add_argument(
             return None
 
     ahelp = description.replace("%", "%%")
-    action = None  # type: Optional[Union[argparse.Action, str]]
+    action = None  # type: Optional[Union[Type[argparse.Action], str]]
     atype = None  # type: Any
-    typekw = {}
+    typekw = {}  # type: Dict[str, Any]
 
     if inptype == "File":
-        action = cast(argparse.Action, FileAction)
+        action = FileAction
     elif inptype == "Directory":
-        action = cast(argparse.Action, DirectoryAction)
+        action = DirectoryAction
     elif isinstance(inptype, MutableMapping) and inptype["type"] == "array":
         if inptype["items"] == "File":
-            action = cast(argparse.Action, FileAppendAction)
+            action = FileAppendAction
         elif inptype["items"] == "Directory":
-            action = cast(argparse.Action, DirectoryAppendAction)
+            action = DirectoryAppendAction
         else:
             action = "append"
     elif isinstance(inptype, MutableMapping) and inptype["type"] == "enum":

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -278,7 +278,7 @@ class MultithreadedJobExecutor(JobExecutor):
         self.pending_jobs = []  # type: List[JobsType]
         self.pending_jobs_lock = threading.Lock()
 
-        self.max_ram = int(psutil.virtual_memory().available / 2 ** 20)  # type: ignore[no-untyped-call]
+        self.max_ram = int(psutil.virtual_memory().available / 2**20)  # type: ignore[no-untyped-call]
         self.max_cores = float(psutil.cpu_count())
         self.allocated_ram = float(0)
         self.allocated_cores = float(0)

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -221,6 +221,7 @@ class SingleJobExecutor(JobExecutor):
                 fsaccess=runtime_context.make_fs_access(""),
             )
             process.parent_wf = process.provenance_object
+
         jobiter = process.job(job_order_object, self.output_callback, runtime_context)
 
         try:
@@ -277,7 +278,7 @@ class MultithreadedJobExecutor(JobExecutor):
         self.pending_jobs = []  # type: List[JobsType]
         self.pending_jobs_lock = threading.Lock()
 
-        self.max_ram = int(psutil.virtual_memory().available / 2**20)  # type: ignore[no-untyped-call]
+        self.max_ram = int(psutil.virtual_memory().available / 2 ** 20)  # type: ignore[no-untyped-call]
         self.max_cores = float(psutil.cpu_count())
         self.allocated_ram = float(0)
         self.allocated_cores = float(0)

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -546,7 +546,7 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
             _logger.info(
                 "[job %s] Max memory used: %iMiB",
                 self.name,
-                round(memory_usage[0] / (2**20)),
+                round(memory_usage[0] / (2 ** 20)),
             )
         else:
             _logger.debug(
@@ -934,7 +934,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
         _logger.info(
             "[job %s] Max memory used: %iMiB",
             self.name,
-            int((max_mem_percent / 100 * max_mem) / (2**20)),
+            int((max_mem_percent / 100 * max_mem) / (2 ** 20)),
         )
         if cleanup_cidfile:
             os.remove(cidfile)

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -546,7 +546,7 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
             _logger.info(
                 "[job %s] Max memory used: %iMiB",
                 self.name,
-                round(memory_usage[0] / (2 ** 20)),
+                round(memory_usage[0] / (2**20)),
             )
         else:
             _logger.debug(
@@ -934,7 +934,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
         _logger.info(
             "[job %s] Max memory used: %iMiB",
             self.name,
-            int((max_mem_percent / 100 * max_mem) / (2 ** 20)),
+            int((max_mem_percent / 100 * max_mem) / (2**20)),
         )
         if cleanup_cidfile:
             os.remove(cidfile)

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -427,6 +427,8 @@ def init_job_order(
             namemap,
             records,
             input_required,
+            loader.fetcher.urljoin,
+            file_uri(os.getcwd()) + "/",
         )
         if args.tool_help:
             toolparser.print_help(cast(IO[str], stdout))

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -70,6 +70,37 @@ expression: $(inputs.foo.two)
 outputs: []
 """
 
+script_d = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
+  foo:
+    type:
+      - type: enum
+        symbols: [cymbal1, cymbal2]
+
+expression: $(inputs.foo)
+
+outputs: []
+"""
+
+script_e = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
+  foo: File
+
+expression: '{"bar": $(inputs.foo.location)}'
+
+outputs: []
+"""
+
 scripts_argparse_params = [
     ("help", script_a, lambda x: ["--debug", x, "--input", get_data("tests/echo.cwl")]),
     ("boolean", script_b, lambda x: [x, "--help"]),
@@ -78,6 +109,16 @@ scripts_argparse_params = [
         "foo with c",
         script_c,
         lambda x: [x, "--foo.one", get_data("tests/echo.cwl"), "--foo.two", "test"],
+    ),
+    (
+        "foo with d",
+        script_d,
+        lambda x: [x, "--foo", "cymbal2"],
+    ),
+    (
+        "foo with e",
+        script_e,
+        lambda x: [x, "--foo", "http://example.com"],
     ),
 ]
 
@@ -92,7 +133,7 @@ def test_argparse(
         with script_name.open(mode="w") as script:
             script.write(script_contents)
 
-        my_params = ["--outdir", str(tmp_path / "outdir")]
+        my_params = ["--outdir", str(tmp_path / "outdir"), "--debug"]
         my_params.extend(params(script.name))
         assert main(my_params) == 0, name
 


### PR DESCRIPTION
Uses loader's urljoin to construct relative references based on the file uri of the current working directory, which allows other types of URIs to pass through the command line unbothered.

Also handle edge case where input parameter type is wrapped in single-item list.