### PR TITLE
scandeps should not apply mergedirs at every level

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -73,6 +73,7 @@ from .process import (
     CWL_IANA,
     Process,
     add_sizes,
+    mergedirs,
     scandeps,
     shortname,
     use_custom_schema,
@@ -620,7 +621,7 @@ def find_deps(
         nestdirs=nestdirs,
     )
     if sfs is not None:
-        deps["secondaryFiles"] = cast(MutableSequence[CWLOutputAtomType], sfs)
+        deps["secondaryFiles"] = cast(MutableSequence[CWLOutputAtomType], mergedirs(sfs))
 
     return deps
 

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -621,7 +621,9 @@ def find_deps(
         nestdirs=nestdirs,
     )
     if sfs is not None:
-        deps["secondaryFiles"] = cast(MutableSequence[CWLOutputAtomType], mergedirs(sfs))
+        deps["secondaryFiles"] = cast(
+            MutableSequence[CWLOutputAtomType], mergedirs(sfs)
+        )
 
     return deps
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -1148,6 +1148,30 @@ def scandeps(
     urljoin: Callable[[str, str], str] = urllib.parse.urljoin,
     nestdirs: bool = True,
 ) -> MutableSequence[CWLObjectType]:
+
+    """Given a CWL document or input object, search for dependencies
+    (references to external files) of 'doc' and return them as a list
+    of File or Directory objects.
+
+    The 'base' is the base URL for relative references.
+
+    Looks for objects with 'class: File' or 'class: Directory' and
+    adds them to the list of dependencies.
+
+    Anything in 'urlfields' is also added as a File dependency.
+
+    Anything in 'reffields' (such as workflow step 'run') will be
+    added as a dependency and also loaded (using the 'loadref'
+    function) and recursively scanned for dependencies.  Those
+    dependencies will be added as secondary files to the primary file.
+
+    If "nestdirs" is true, create intermediate directory objects when
+    a file is located in a subdirectory under the starting directory.
+    This is so that if the dependencies are materialized, they will
+    produce the same relative file system locations.
+
+    """
+
     r: MutableSequence[CWLObjectType] = []
     if isinstance(doc, MutableMapping):
         if "id" in doc:

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -1126,7 +1126,8 @@ def mergedirs(
             ents[basename] = e
         elif e["location"] != ents[basename]["location"]:
             raise ValidationException(
-                "Conflicting basename in listing or secondaryFiles, '%s' used by both '%s' and '%s'" % (basename, e["location"], ents[basename]["location"])
+                "Conflicting basename in listing or secondaryFiles, '%s' used by both '%s' and '%s'"
+                % (basename, e["location"], ents[basename]["location"])
             )
         elif e["class"] == "Directory":
             if e.get("listing"):

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -1104,13 +1104,20 @@ def nestdir(base: str, deps: CWLObjectType) -> CWLObjectType:
         sp = s2.split("/")
         sp.pop()
         while sp:
-            loc = dirname+"/".join(sp)
+            loc = dirname + "/".join(sp)
             nx = sp.pop()
-            deps = {"class": "Directory", "basename": nx, "listing": [deps], "location": loc}
+            deps = {
+                "class": "Directory",
+                "basename": nx,
+                "listing": [deps],
+                "location": loc,
+            }
     return deps
 
 
-def mergedirs(listing: List[CWLObjectType]) -> List[CWLObjectType]:
+def mergedirs(
+    listing: MutableSequence[CWLObjectType],
+) -> MutableSequence[CWLObjectType]:
     r = []  # type: List[CWLObjectType]
     ents = {}  # type: Dict[str, CWLObjectType]
     for e in listing:
@@ -1118,7 +1125,9 @@ def mergedirs(listing: List[CWLObjectType]) -> List[CWLObjectType]:
         if basename not in ents:
             ents[basename] = e
         elif e["location"] != ents[basename]["location"]:
-            raise Exception("Conflict between %s and %s", e["location"], ents[basename]["location"])
+            raise Exception(
+                "Conflict between %s and %s", e["location"], ents[basename]["location"]
+            )
         elif e["class"] == "Directory":
             if e.get("listing"):
                 # name already in entries
@@ -1278,7 +1287,8 @@ def scandeps(
                         )
                         if sf:
                             deps2["secondaryFiles"] = cast(
-                                MutableSequence[CWLOutputAtomType], mergedirs(sf))
+                                MutableSequence[CWLOutputAtomType], mergedirs(sf)
+                            )
                         if nestdirs:
                             deps2 = nestdir(base, deps2)
                         r.append(deps2)

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -1125,8 +1125,8 @@ def mergedirs(
         if basename not in ents:
             ents[basename] = e
         elif e["location"] != ents[basename]["location"]:
-            raise Exception(
-                "Conflict between %s and %s", e["location"], ents[basename]["location"]
+            raise ValidationException(
+                "Conflicting basename in listing or secondaryFiles, '%s' used by both '%s' and '%s'" % (basename, e["location"], ents[basename]["location"])
             )
         elif e["class"] == "Directory":
             if e.get("listing"):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -546,13 +546,17 @@ def test_scandeps_samedirname() -> None:
 
     assert scanned_deps == expected_deps
 
+
 def test_scandeps_collision() -> None:
     stream = StringIO()
 
-    assert main(
-        ["--print-deps", "--debug", get_data("tests/wf/dir_deps.json")],
-        stdout=stream,
-    ) == 1
+    assert (
+        main(
+            ["--print-deps", "--debug", get_data("tests/wf/dir_deps.json")],
+            stdout=stream,
+        )
+        == 1
+    )
 
 
 def test_trick_scandeps() -> None:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -512,6 +512,41 @@ def test_scandeps() -> None:
     assert scanned_deps2 == expected_deps
 
 
+def test_scandeps_samedirname() -> None:
+    obj: CWLObjectType = {
+        "dir1": {"class": "Directory", "location": "tests/wf/dir1/foo"},
+        "dir2": {"class": "Directory", "location": "tests/wf/dir2/foo"},
+    }
+
+    def loadref(
+        base: str, p: Union[CommentedMap, CommentedSeq, str, None]
+    ) -> Union[CommentedMap, CommentedSeq, str, None]:
+        if isinstance(p, dict):
+            return p
+        raise Exception("test case can't load things")
+
+    scanned_deps = cast(
+        List[Dict[str, Any]],
+        cwltool.process.scandeps(
+            "",
+            obj,
+            {"$import", "run"},
+            {"$include", "$schemas", "location"},
+            loadref,
+            nestdirs=False,
+        ),
+    )
+
+    scanned_deps.sort(key=lambda k: cast(str, k["basename"]))
+
+    expected_deps = [
+        {"basename": "foo", "class": "Directory", "location": "tests/wf/dir1/foo"},
+        {"basename": "foo", "class": "Directory", "location": "tests/wf/dir2/foo"},
+    ]
+
+    assert scanned_deps == expected_deps
+
+
 def test_trick_scandeps() -> None:
     stream = StringIO()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -546,6 +546,14 @@ def test_scandeps_samedirname() -> None:
 
     assert scanned_deps == expected_deps
 
+def test_scandeps_collision() -> None:
+    stream = StringIO()
+
+    assert main(
+        ["--print-deps", "--debug", get_data("tests/wf/dir_deps.json")],
+        stdout=stream,
+    ) == 1
+
 
 def test_trick_scandeps() -> None:
     stream = StringIO()

--- a/tests/wf/dir_deps.json
+++ b/tests/wf/dir_deps.json
@@ -1,0 +1,7 @@
+"dir1": {
+    "class": "Directory",
+    "listing": [
+        {"class": "File", "basename": "foo", "location": "tests/wf/foo1"},
+        {"class": "File", "basename": "foo", "location": "tests/wf/foo2"}
+    ]
+}


### PR DESCRIPTION
When getting back a list of dependencies, and using "nestdirs", in the
specific case it there are references to both a directory and files
within that directory, it may report multiple dependencies for the
same directory.  The mergedir method merges those references into one.