### PR TITLE
Add application/octet-stream

### DIFF
--- a/cwltool/__init__.py
+++ b/cwltool/__init__.py
@@ -9,4 +9,5 @@ CWL_CONTENT_TYPES = [
     "text/yaml",
     "text/x-yaml",
     "application/x-yaml",
+    "application/octet-stream",
 ]


### PR DESCRIPTION
When I run the workflow uploaded on [Zenodo](https://zenodo.org), I get the following warning because Zenodo responds it as Content-Type `application/octet-stream`.

```
While fetching https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl, got content-type of 'application/octet-stream, application/octet-stream'. Expected one of ['text/plain', 'application/json', 'text/vnd.yaml', 'text/yaml', 'text/x-yaml', 'application/x-yaml'].
```

curl results:

```bash
$ curl -I https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl
HTTP/1.1 200 OK
Server: nginx
Content-Type: application/octet-stream
Content-Length: 1151
Content-MD5: 415878c78ed8265bd7367099cf2254f7
Content-Security-Policy: default-src 'none';
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
X-Frame-Options: sameorigin
X-XSS-Protection: 1; mode=block
Content-Disposition: attachment; filename=trimming_and_qc.cwl
ETag: "md5:415878c78ed8265bd7367099cf2254f7"
Last-Modified: Thu, 17 Feb 2022 05:21:19 GMT
Date: Thu, 17 Feb 2022 05:39:29 GMT
Accept-Ranges: none
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 59
X-RateLimit-Reset: 1645076430
Retry-After: 60
Strict-Transport-Security: max-age=0
Referrer-Policy: strict-origin-when-cross-origin
Set-Cookie: session=2414ff00ee599514_620ddf91.9Z1lUiYZ5LJr-Qodu_Wyz7WBG94; Expires=Sun, 20-Mar-2022 05:39:29 GMT; Secure; HttpOnly; Path=/
X-Session-ID: 2414ff00ee599514_620ddf91
X-Request-ID: b00256265a0c9b3a8f5ac3907ea7d990
```

I think uploading workflows to Zenodo is a common use case.
So, I think this warning should be deleted.

## My environment

```bash
$ python3 -V
Python 3.8.12

$ cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.6 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.6 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

Install the main branch of `cwltool` from the source.

```bash
$ git log --oneline | head -n 5
997bddaf Update ruamel-yaml requirement from <0.17.21,>=0.15 to >=0.15,<0.17.22
5f933547 scandeps should not apply mergedirs at every level (#1615)
7cef4dd9 Update pytest requirement from <6.3,>=6.2 to >=6.2,<7.1
cc9efc0a improve tests
4ef91119 feat: format test file

$ python3 -m venv cwltool-dev
$ source cwltool-dev/bin/activate.fish

(cwltool-dev) $ which pip
/home/ubuntu/git/github.com/suecharo/cwltool/cwltool-dev/bin/pip
(cwltool-dev) $ which python3
/home/ubuntu/git/github.com/suecharo/cwltool/cwltool-dev/bin/python3
(cwltool-dev) $ pip install --editable .[deps]
...
(cwltool-dev) $ python3 -m cwltool --version
/home/ubuntu/git/github.com/suecharo/cwltool/cwltool/__main__.py 3.1.20220214090456
```

## Problem

Run the workflow uploaded to Zenodo. (https://sandbox.zenodo.org/record/1016630#)

Prepare the input files:

```bash
(cwltool-dev) $ mkdir -p ~/sandbox/cwltool-dev/exe
(cwltool-dev) $ cd ~/sandbox/cwltool-dev/exe
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/ERR034597_1.small.fq.gz
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/ERR034597_2.small.fq.gz
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/fastqc.cwl
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/trimmomatic_pe.cwl
(cwltool-dev) $ curl -O https://sandbox.zenodo.org/record/1016630/files/wf_params.json
(cwltool-dev) $ ls -lh
total 6.7M
-rw-rw-r-- 1 ubuntu ubuntu 3.4M Feb 17 12:42 ERR034597_1.small.fq.gz
-rw-rw-r-- 1 ubuntu ubuntu 3.3M Feb 17 12:42 ERR034597_2.small.fq.gz
-rw-rw-r-- 1 ubuntu ubuntu  577 Feb 17 12:53 fastqc.cwl
-rw-rw-r-- 1 ubuntu ubuntu 1.2K Feb 17 12:52 trimming_and_qc.cwl
-rw-rw-r-- 1 ubuntu ubuntu 1.6K Feb 17 12:53 trimmomatic_pe.cwl
-rw-rw-r-- 1 ubuntu ubuntu  161 Feb 17 12:52 wf_params.json
(cwltool-dev) $ cd -
(cwltool-dev) $ mkdir -p ~/sandbox/cwltool-dev/output-local
(cwltool-dev) $ mkdir -p ~/sandbox/cwltool-dev/output-remote
```

Run the workflow from local workflow:

```bash
(cwltool-dev) $ python3 -m cwltool \
    --basedir ~/sandbox/cwltool-dev/exe \
    --outdir ~/sandbox/cwltool-dev/output-local \
    ~/sandbox/cwltool-dev/exe/trimming_and_qc.cwl \
    ~/sandbox/cwltool-dev/exe/wf_params.json

INFO /home/ubuntu/git/github.com/suecharo/cwltool/cwltool/__main__.py 3.1.20220214090456
INFO Resolved '/home/ubuntu/sandbox/cwltool-dev/exe/trimming_and_qc.cwl' to 'file:///home/ubuntu/sandbox/cwltool-dev/exe/trimming_and_qc.cwl'
INFO [workflow ] start
...
INFO Final process status is success
(cwltool-dev) $ ls ~/sandbox/cwltool-dev/output-local
ERR034597_1.small_fastqc.html       ERR034597_1.small.fq.trimmed.2P.fq
ERR034597_1.small.fq.trimmed.1P.fq  ERR034597_1.small.fq.trimmed.2U.fq
ERR034597_1.small.fq.trimmed.1U.fq  ERR034597_2.small_fastqc.html
```

However, run the workflow from remote workflow:

```bash
(cwltool-dev) $ python3 -m cwltool \
    --basedir ~/sandbox/cwltool-dev/exe \
    --outdir ~/sandbox/cwltool-dev/output-remote \
    https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl \
    https://sandbox.zenodo.org/record/1016630/files/wf_params.json

INFO /home/ubuntu/git/github.com/suecharo/cwltool/cwltool/__main__.py 3.1.20220214090456
While fetching https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl, got content-type of 'application/octet-stream, application/octet-stream'. Expected one of ['text/plain', 'application/json', 'text/vnd.yaml', 'text/yaml', 'text/x-yaml', 'application/x-yaml'].
While fetching https://sandbox.zenodo.org/record/1016630/files/fastqc.cwl, got content-type of 'application/octet-stream, application/octet-stream'. Expected one of ['text/plain', 'application/json', 'text/vnd.yaml', 'text/yaml', 'text/x-yaml', 'application/x-yaml'].
While fetching https://sandbox.zenodo.org/record/1016630/files/trimmomatic_pe.cwl, got content-type of 'application/octet-stream, application/octet-stream'. Expected one of ['text/plain', 'application/json', 'text/vnd.yaml', 'text/yaml', 'text/x-yaml', 'application/x-yaml'].
INFO [workflow ] start
...
INFO Final process status is success
```

A warning is displayed.

## After modifying the file

Modified https://github.com/common-workflow-language/cwltool/blob/main/cwltool/__init__.py as adding `application/octet-stream`, then:

```bash
(cwltool-dev) $ python3 -m cwltool \
    --basedir ~/sandbox/cwltool-dev/exe \
    --outdir ~/sandbox/cwltool-dev/output-remote \
    https://sandbox.zenodo.org/record/1016630/files/trimming_and_qc.cwl \
    https://sandbox.zenodo.org/record/1016630/files/wf_params.json

INFO /home/ubuntu/git/github.com/suecharo/cwltool/cwltool/__main__.py 3.1.20220214090456
INFO [workflow ] start
...
INFO Final process status is success
```
