### PR TITLE
Allow records with defaults to be accepted, also type longs

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -869,11 +869,23 @@ def add_argument(
             fieldname = name + "." + shortname(field["name"])
             fieldtype = field["type"]
             fielddescription = field.get("doc", "")
-            add_argument(toolparser, fieldname, fieldtype, records, fielddescription)
+            add_argument(
+                toolparser,
+                fieldname,
+                fieldtype,
+                records,
+                fielddescription,
+                default=default.get(shortname(field["name"]), None)
+                if default
+                else None,
+                input_required=required,
+            )
         return
     elif inptype == "string":
         atype = str
     elif inptype == "int":
+        atype = int
+    elif inptype == "long":
         atype = int
     elif inptype == "double":
         atype = float

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1303,7 +1303,6 @@ def main(
                 tool, job_order_object = tool.result(tfjob_order, tfout, runtimeContext)
                 if not job_order_object:
                     job_order_object = None
-
             try:
                 initialized_job_order_object = init_job_order(
                     job_order_object,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1685,3 +1685,22 @@ def test_command_line_tool_class() -> None:
     tool_path = get_data("tests/echo.cwl")
     expression_tool = factory.make(tool_path).t
     assert str(expression_tool) == f"CommandLineTool: file://{tool_path}"
+
+
+def test_record_default_with_long() -> None:
+    """Confirm that record defaults are respected."""
+    tool_path = get_data("tests/wf/paramref_arguments_roundtrip.cwl")
+    err_code, stdout, stderr = get_main_output([tool_path])
+    assert err_code == 0
+    result = json.loads(stdout)["same_record"]
+    assert result["first"] == "y"
+    assert result["second"] == 23
+    assert result["third"] == 2.3
+    assert result["fourth"] == 4242424242
+    assert result["fifth"] == 4200000000000000000000000000000000000000000
+    assert result["sixth"]["class"] == "File"
+    assert result["sixth"]["basename"] == "whale.txt"
+    assert result["sixth"]["size"] == 1111
+    assert (
+        result["sixth"]["checksum"] == "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+    )

--- a/tests/wf/paramref_arguments_roundtrip.cwl
+++ b/tests/wf/paramref_arguments_roundtrip.cwl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+inputs:
+  a_record:
+    type:
+      - "null"
+      - type: record
+        fields:
+          first: string
+          second: int
+          third: float
+          fourth: long
+          fifth: double
+          sixth: File
+    default:
+      first: y
+      second: 23
+      third: 2.3
+      fourth: 4242424242
+      fifth: 4200000000000000000000000000000000000000000
+      sixth:
+        class: File
+        path: whale.txt
+arguments:
+ - '{'
+ - '"same_record": $(inputs.a_record)'
+ - '}'
+outputs:
+  same_record:
+    type:
+      type: record
+      fields:
+        first: string
+        second: int
+        third: float
+        fourth: long
+        fifth: double
+        sixth: File
+baseCommand: echo
+stdout: cwl.output.json


### PR DESCRIPTION
Fixes #780 

-  [ ] propose `tests/wf/paramref_arguments_roundtrip.cwl` as a conformance test for CWL v1.2.1