### PR TITLE
print-dot: Removed primary path prefix from graph labels

### DIFF
--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -194,4 +194,4 @@ def printdot(
     stdout: Union[TextIO, StreamWriter],
 ) -> None:
     cwl_viewer = CWLViewer(printrdf(wf, ctx, "n3"))  # type: CWLViewer
-    stdout.write(cwl_viewer.dot())
+    stdout.write(cwl_viewer.dot().replace(f"{wf.metadata['id']}#", ""))

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -195,3 +195,4 @@ def printdot(
 ) -> None:
     cwl_viewer = CWLViewer(printrdf(wf, ctx, "n3"))  # type: CWLViewer
     stdout.write(cwl_viewer.dot().replace(f"{wf.metadata['id']}#", ""))
+    #stdout.write(cwl_viewer.dot())

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -195,4 +195,3 @@ def printdot(
 ) -> None:
     cwl_viewer = CWLViewer(printrdf(wf, ctx, "n3"))  # type: CWLViewer
     stdout.write(cwl_viewer.dot().replace(f"{wf.metadata['id']}#", ""))
-    #stdout.write(cwl_viewer.dot())

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.940
+mypy==0.941
 types-requests
 types-setuptools
 types-psutil

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1056,15 +1056,12 @@ def test_print_dot() -> None:
     assert main(["--debug", "--print-dot", cwl_path], stdout=stdout) == 0
     computed_dot = pydot.graph_from_dot_data(stdout.getvalue())[0]
     computed_edges = sorted(
-        (source, target)
-        for source, target in computed_dot.obj_dict["edges"]
+        (source, target) for source, target in computed_dot.obj_dict["edges"]
     )
     expected_edges = sorted(
-        (source, target) 
-        for source, target in expected_dot.obj_dict["edges"]
+        (source, target) for source, target in expected_dot.obj_dict["edges"]
     )
     assert computed_edges == expected_edges
-
 
     # print CommandLineTool
     cwl_path = get_data("tests/wf/echo.cwl")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1009,7 +1009,6 @@ def test_var_spool_cwl_checker3() -> None:
 def test_print_dot() -> None:
     # print Workflow
     cwl_path = get_data("tests/wf/revsort.cwl")
-    cwl_posix_path = Path(cwl_path).as_posix()
     expected_dot = pydot.graph_from_dot_data(
         """
     digraph {{
@@ -1023,10 +1022,10 @@ def test_print_dot() -> None:
                         rank=same,
                         style=dashed
                 ];
-                "file://{cwl_posix_path}#workflow_input"      [fillcolor="#94DDF4",
+                "workflow_input"      [fillcolor="#94DDF4",
                         label=workflow_input,
                         style=filled];
-                "file://{cwl_posix_path}#reverse_sort"        [fillcolor="#94DDF4",
+                "reverse_sort"        [fillcolor="#94DDF4",
                         label=reverse_sort,
                         style=filled];
         }}
@@ -1036,24 +1035,22 @@ def test_print_dot() -> None:
                         rank=same,
                         style=dashed
                 ];
-                "file://{cwl_posix_path}#sorted_output"       [fillcolor="#94DDF4",
+                "sorted_output"       [fillcolor="#94DDF4",
                         label=sorted_output,
                         style=filled];
         }}
-        "file://{cwl_posix_path}#rev" [fillcolor=lightgoldenrodyellow,
+        "rev" [fillcolor=lightgoldenrodyellow,
                 label=rev,
                 style=filled];
-        "file://{cwl_posix_path}#sorted"      [fillcolor=lightgoldenrodyellow,
+        "sorted"      [fillcolor=lightgoldenrodyellow,
                 label=sorted,
                 style=filled];
-        "file://{cwl_posix_path}#rev" -> "file://{cwl_posix_path}#sorted";
-        "file://{cwl_posix_path}#sorted" -> "file://{cwl_posix_path}#sorted_output";
-        "file://{cwl_posix_path}#workflow_input" -> "file://{cwl_posix_path}#rev";
-        "file://{cwl_posix_path}#reverse_sort" -> "file://{cwl_posix_path}#sorted";
+        "rev" -> "sorted";
+        "sorted" -> "sorted_output";
+        "workflow_input" -> "rev";
+        "reverse_sort" -> "sorted";
 }}
-    """.format(
-            cwl_posix_path=cwl_posix_path
-        )
+    """
     )[0]
     stdout = StringIO()
     assert main(["--debug", "--print-dot", cwl_path], stdout=stdout) == 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1055,18 +1055,10 @@ def test_print_dot() -> None:
     stdout = StringIO()
     assert main(["--debug", "--print-dot", cwl_path], stdout=stdout) == 0
     computed_dot = pydot.graph_from_dot_data(stdout.getvalue())[0]
-    # computed_edges = sorted(
-    #     (urlparse(source).fragment, urlparse(target).fragment)
-    #     for source, target in computed_dot.obj_dict["edges"]
-    # )
     computed_edges = sorted(
         (source, target)
         for source, target in computed_dot.obj_dict["edges"]
     )
-    # expected_edges = sorted(
-    #     (urlparse(source).fragment, urlparse(target).fragment)
-    #     for source, target in expected_dot.obj_dict["edges"]
-    # )
     expected_edges = sorted(
         (source, target) 
         for source, target in expected_dot.obj_dict["edges"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1050,20 +1050,29 @@ def test_print_dot() -> None:
         "workflow_input" -> "rev";
         "reverse_sort" -> "sorted";
 }}
-    """
+    """.format()
     )[0]
     stdout = StringIO()
     assert main(["--debug", "--print-dot", cwl_path], stdout=stdout) == 0
     computed_dot = pydot.graph_from_dot_data(stdout.getvalue())[0]
+    # computed_edges = sorted(
+    #     (urlparse(source).fragment, urlparse(target).fragment)
+    #     for source, target in computed_dot.obj_dict["edges"]
+    # )
     computed_edges = sorted(
-        (urlparse(source).fragment, urlparse(target).fragment)
+        (source, target)
         for source, target in computed_dot.obj_dict["edges"]
     )
+    # expected_edges = sorted(
+    #     (urlparse(source).fragment, urlparse(target).fragment)
+    #     for source, target in expected_dot.obj_dict["edges"]
+    # )
     expected_edges = sorted(
-        (urlparse(source).fragment, urlparse(target).fragment)
+        (source, target) 
         for source, target in expected_dot.obj_dict["edges"]
     )
     assert computed_edges == expected_edges
+
 
     # print CommandLineTool
     cwl_path = get_data("tests/wf/echo.cwl")


### PR DESCRIPTION
Removed primary file path prefix from graph labels