### PR TITLE
Changed cwlviewer.py to make node color dependent on operation class

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.step == 'unit' }}
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
 

--- a/cwltool/cwlviewer.py
+++ b/cwltool/cwlviewer.py
@@ -66,10 +66,6 @@ class CWLViewer:
                 if inner_edge_row["target_label"] is not None
                 else urlparse(inner_edge_row["target_step"]).fragment
             )
-            if inner_edge_row["target_step_class"].endswith("Workflow"):
-                target_color = "#F3CEA1"
-            else:
-                target_color = "lightgoldenrodyellow"
 
             target_color = (
                 "#F3CEA1"

--- a/cwltool/cwlviewer.py
+++ b/cwltool/cwlviewer.py
@@ -41,10 +41,21 @@ class CWLViewer:
                 if inner_edge_row["source_label"] is not None
                 else urlparse(inner_edge_row["source_step"]).fragment
             )
+            # Node color and style depend on class
+            source_color = (
+                "#F3CEA1"
+                if inner_edge_row["source_step_class"].endswith("Workflow")
+                else "lightgoldenrodyellow"
+            )
+            source_style = (
+                "dashed"
+                if inner_edge_row["source_step_class"].endswith("Operation")
+                else "filled"
+            )
             n = pydot.Node(
                 "",
-                fillcolor="lightgoldenrodyellow",
-                style="filled",
+                fillcolor=source_color,
+                style=source_style,
                 label=source_label,
                 shape="record",
             )
@@ -55,10 +66,25 @@ class CWLViewer:
                 if inner_edge_row["target_label"] is not None
                 else urlparse(inner_edge_row["target_step"]).fragment
             )
+            if inner_edge_row["target_step_class"].endswith("Workflow"):
+                target_color = "#F3CEA1"
+            else:
+                target_color = "lightgoldenrodyellow"
+
+            target_color = (
+                "#F3CEA1"
+                if inner_edge_row["target_step_class"].endswith("Workflow")
+                else "lightgoldenrodyellow"
+            )
+            target_style = (
+                "dashed"
+                if inner_edge_row["target_step_class"].endswith("Operation")
+                else "filled"
+            )
             n = pydot.Node(
                 "",
-                fillcolor="lightgoldenrodyellow",
-                style="filled",
+                fillcolor=target_color,
+                style=target_style,
                 label=target_label,
                 shape="record",
             )

--- a/cwltool/rdfqueries/get_inner_edges.sparql
+++ b/cwltool/rdfqueries/get_inner_edges.sparql
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
 # GET EDGES
-SELECT DISTINCT ?source_label ?target_label ?source_step ?target_step ?target_ref_input ?output_ref ?workflow
+SELECT DISTINCT ?source_label ?target_label ?source_step ?target_step ?target_ref_input ?output_ref ?workflow ?target_step_class ?source_step_class
 WHERE {
     ?workflow Workflow:steps ?step .
     {
@@ -43,6 +43,9 @@ WHERE {
         ?target_step cwl:run ?target_step_node .
         OPTIONAL {?source_step_node rdfs:label ?source_label} .
         OPTIONAL {?target_step_node rdfs:label ?target_label} .
+        # Added by Renske
+        ?target_step_node a ?target_step_class .
+        ?source_step_node a ?source_step_class .
     } .
     # root_graph is binded in python
     FILTER(?workflow = ?root_graph) .

--- a/cwltool/rdfqueries/get_inner_edges.sparql
+++ b/cwltool/rdfqueries/get_inner_edges.sparql
@@ -43,7 +43,6 @@ WHERE {
         ?target_step cwl:run ?target_step_node .
         OPTIONAL {?source_step_node rdfs:label ?source_label} .
         OPTIONAL {?target_step_node rdfs:label ?target_label} .
-        # Added by Renske
         ?target_step_node a ?target_step_class .
         ?source_step_node a ?source_step_class .
     } .

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1008,7 +1008,7 @@ def test_var_spool_cwl_checker3() -> None:
 
 def test_print_dot() -> None:
     # print Workflow
-    cwl_path = get_data("tests/wf/revsort.cwl")
+    cwl_path = get_data("tests/wf/three_step_color.cwl")
     expected_dot = pydot.graph_from_dot_data(
         """
     digraph {{
@@ -1022,11 +1022,8 @@ def test_print_dot() -> None:
                         rank=same,
                         style=dashed
                 ];
-                "workflow_input"      [fillcolor="#94DDF4",
-                        label=workflow_input,
-                        style=filled];
-                "reverse_sort"        [fillcolor="#94DDF4",
-                        label=reverse_sort,
+                "file_input"        [fillcolor="#94DDF4",
+                        label=file_input,
                         style=filled];
         }}
         subgraph cluster_outputs {{
@@ -1035,20 +1032,27 @@ def test_print_dot() -> None:
                         rank=same,
                         style=dashed
                 ];
-                "sorted_output"       [fillcolor="#94DDF4",
-                        label=sorted_output,
+                "file_output"       [fillcolor="#94DDF4",
+                        label=file_output,
+                        style=filled];
+                "string_output"       [fillcolor="#94DDF4",
+                        label=string_output,
                         style=filled];
         }}
-        "rev" [fillcolor=lightgoldenrodyellow,
-                label=rev,
+        "nested_workflow" [fillcolor="#F3CEA1",
+                label=nested_workflow,
                 style=filled];
-        "sorted"      [fillcolor=lightgoldenrodyellow,
-                label=sorted,
+        "operation"      [fillcolor=lightgoldenrodyellow,
+                label=operation,
+                style=dashed];
+        "command_line_tool"      [fillcolor=lightgoldenrodyellow,
+                label=command_line_tool,
                 style=filled];
-        "rev" -> "sorted";
-        "sorted" -> "sorted_output";
-        "workflow_input" -> "rev";
-        "reverse_sort" -> "sorted";
+        "file_input" -> "nested_workflow";
+        "nested_workflow" -> "operation";
+        "operation" -> "command_line_tool";
+        "operation" -> "string_output";
+        "command_line_tool" -> "file_output";
 }}
     """.format()
     )[0]

--- a/tests/wf/three_step_color.cwl
+++ b/tests/wf/three_step_color.cwl
@@ -1,0 +1,59 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.2
+class: Workflow
+
+requirements:
+  SubworkflowFeatureRequirement: {}
+
+inputs:
+  file_input: File
+
+outputs: 
+  string_output:
+    type: string
+    outputSource: operation/operation_output
+  file_output:
+    type: File
+    outputSource: command_line_tool/out_file
+
+steps:
+  nested_workflow:
+    label: "workflow"
+    run: 1st-workflow.cwl
+    in:
+      inp: file_input
+      ex:
+        default: "Hello.java"
+    out: [ classout ]
+  operation:
+    label: "Operation"
+    in: 
+      operation_input: nested_workflow/classout
+    out: 
+      [operation_output]
+    run:
+      class: Operation
+      inputs:
+        operation_input: File
+      outputs:
+        operation_output: string
+  command_line_tool:
+    in:
+      clt_input: operation/operation_output
+    out: [ out_file ]
+    run:
+      class: CommandLineTool
+      baseCommand: echo
+      arguments:
+      - $(inputs.clt_input)
+      - ">"
+      - "output.txt"
+      inputs:
+        clt_input:
+          type: string
+      outputs: 
+        out_file:
+          type: File
+          outputBinding:
+            glob: "output.txt"


### PR DESCRIPTION
Node color/style:
- CommandLineTool: "lightgoldenrodyellow", "filled"
- Workflow: "#F3CEA1", "filled"
- Operation: [no color], "dashed"

CommandLineTool & Workflow now have the same color as [cwlviewer](https://github.com/common-workflow-language/cwlviewer).