### PR TITLE
Message about using --parallel, and how other CWL runners are available.

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -191,7 +191,7 @@ class JobExecutor(metaclass=ABCMeta):
             return (self.final_output[0], self.final_status[0])
         return (None, "permanentFail")
 
-    def message_about_other_runners(self):
+    def message_about_other_runners(self) -> None:
         _logger.info(
             "Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?"
         )

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -192,8 +192,12 @@ class JobExecutor(metaclass=ABCMeta):
         return (None, "permanentFail")
 
     def message_about_other_runners(self):
-        _logger.info("Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?")
-        _logger.info("Many commercial and open source platforms support CWL.  Run your same workflows without having to rewrite anything.")
+        _logger.info(
+            "Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?"
+        )
+        _logger.info(
+            "Many commercial and open source platforms support CWL.  Run your same workflows without having to rewrite anything."
+        )
         _logger.info("Visit https://www.commonwl.org/implementations/ to learn more.")
 
 
@@ -208,7 +212,9 @@ class SingleJobExecutor(JobExecutor):
         runtime_context: RuntimeContext,
     ) -> None:
 
-        _logger.info("Using default serial job executor.  Use `cwltool --parallel` to run multiple steps at a time.")
+        _logger.info(
+            "Using default serial job executor.  Use `cwltool --parallel` to run multiple steps at a time."
+        )
 
         process_run_id = None  # type: Optional[str]
 
@@ -424,7 +430,9 @@ class MultithreadedJobExecutor(JobExecutor):
         runtime_context: RuntimeContext,
     ) -> None:
 
-        _logger.info("Using parallel job executor.  Multiple steps will run at once as hardware resources permit.")
+        _logger.info(
+            "Using parallel job executor.  Multiple steps will run at once as hardware resources permit."
+        )
 
         self.taskqueue = TaskQueue(
             threading.Lock(), psutil.cpu_count()

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -193,10 +193,10 @@ class JobExecutor(metaclass=ABCMeta):
 
     def message_about_other_runners(self) -> None:
         _logger.info(
-            "Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?"
+            "Need to grow beyond `cwltool` and scale up your workflows to run on a multi-node cluster, or in the cloud?"
         )
         _logger.info(
-            "Many commercial and open source platforms support CWL.  Run your same workflows without having to rewrite anything."
+            "CWL workflows are portable and run on many commercial and open source platforms."
         )
         _logger.info("Visit https://www.commonwl.org/implementations/ to learn more.")
 

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -191,6 +191,11 @@ class JobExecutor(metaclass=ABCMeta):
             return (self.final_output[0], self.final_status[0])
         return (None, "permanentFail")
 
+    def message_about_other_runners(self):
+        _logger.info("Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?")
+        _logger.info("Many commercial and open source platforms support CWL.  Run your same workflows without having to rewrite anything.")
+        _logger.info("Visit https://www.commonwl.org/implementations/ to learn more.")
+
 
 class SingleJobExecutor(JobExecutor):
     """Default single-threaded CWL reference executor."""
@@ -202,6 +207,8 @@ class SingleJobExecutor(JobExecutor):
         logger: logging.Logger,
         runtime_context: RuntimeContext,
     ) -> None:
+
+        _logger.info("Using default serial job executor.  Use `cwltool --parallel` to run multiple steps at a time.")
 
         process_run_id = None  # type: Optional[str]
 
@@ -252,6 +259,7 @@ class SingleJobExecutor(JobExecutor):
                 else:
                     logger.error("Workflow cannot make any more progress.")
                     break
+            self.message_about_other_runners()
         except (
             ValidationException,
             WorkflowException,
@@ -416,6 +424,8 @@ class MultithreadedJobExecutor(JobExecutor):
         runtime_context: RuntimeContext,
     ) -> None:
 
+        _logger.info("Using parallel job executor.  Multiple steps will run at once as hardware resources permit.")
+
         self.taskqueue = TaskQueue(
             threading.Lock(), psutil.cpu_count()
         )  # type: TaskQueue
@@ -456,6 +466,7 @@ class MultithreadedJobExecutor(JobExecutor):
         finally:
             self.taskqueue.drain()
             self.taskqueue.join()
+        self.message_about_other_runners()
 
 
 class NoopJobExecutor(JobExecutor):


### PR DESCRIPTION
Was having a discussion about how some people have trouble distinguishing between the capabilities of `cwltool` and the broader CWL ecosystem.  It occurred to me that we could just tell people, clearly, to look elsewhere (and where to look).

Also added a message about the existence of the `--parallel` option.


```
INFO /home/peter/work/cwltool/venv3/bin/cwltool 3.1.20220519125739
INFO Resolved 'revsort.cwl' to 'file:///home/peter/work/cwl-v1.2/tests/revsort.cwl'
INFO Using default serial job executor.  Use `cwltool --parallel` to run multiple steps at a time.
INFO [workflow ] start
INFO [workflow ] starting step rev
...
INFO [job sorted] Max memory used: 0MiB
INFO [job sorted] completed success
INFO [step sorted] completed success
INFO [workflow ] completed success
INFO Need to grow beyond `cwltool` and scale up your workflows on a HPC cluster, or in the cloud?
INFO CWL workflows are portable and run on many commercial and open source platforms.
INFO Visit https://www.commonwl.org/implementations/ to learn more.
{
    "output": {
        "location": "file:///home/peter/work/cwl-v1.2/tests/output.txt",
        "basename": "output.txt",
        "class": "File",
        "checksum": "sha1$b9214658cc453331b62c2282b772a5c063dbd284",
        "size": 1111,
        "path": "/home/peter/work/cwl-v1.2/tests/output.txt"
    }
}
INFO Final process status is success
```
