### PR TITLE
Set last modification date of remote file as local file timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,13 +97,14 @@ remove_unused_imports: $(PYSOURCES)
 	autoflake --in-place --remove-all-unused-imports $^
 
 pep257: pydocstyle
-## pydocstyle      : check Python code style
+## pydocstyle      : check Python docstring style
 pydocstyle: $(PYSOURCES)
 	pydocstyle --add-ignore=D100,D101,D102,D103 $^ || true
 
 pydocstyle_report.txt: $(PYSOURCES)
 	pydocstyle setup.py $^ > $@ 2>&1 || true
 
+## diff_pydocstyle_report	: check Python docstring style for changed files only
 diff_pydocstyle_report: pydocstyle_report.txt
 	diff-quality --compare-branch=main --violations=pydocstyle --fail-under=100 $^
 

--- a/cwltool/pathmapper.py
+++ b/cwltool/pathmapper.py
@@ -138,7 +138,7 @@ class PathMapper:
                 ):
                     deref = ab
                     if urllib.parse.urlsplit(deref).scheme in ["http", "https"]:
-                        deref = downloadHttpFile(path)
+                        deref, _last_modified = downloadHttpFile(path)
                     else:
                         # Dereference symbolic links
                         st = os.lstat(deref)

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -345,6 +345,13 @@ def trim_listing(obj):  # type: (Dict[str, Any]) -> None
 
 
 def downloadHttpFile(httpurl: str) -> Tuple[str, Optional[datetime]]:
+    """
+    Download a remote file, possibly using a locally cached copy.
+
+    Returns a tuple:
+    - the local path for the downloaded file
+    - the Last-Modified timestamp if received from the remote server.
+    """
     cache_session = None
     if "XDG_CACHE_HOME" in os.environ:
         directory = os.environ["XDG_CACHE_HOME"]

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -365,7 +365,7 @@ def downloadHttpFile(httpurl: str) -> Tuple[str, Optional[datetime]]:
                 f.write(chunk)
     r.close()
 
-    date_raw: Optional[str] = r.headers.get('Last-Modified', None)
+    date_raw: Optional[str] = r.headers.get("Last-Modified", None)
     date: Optional[datetime] = parsedate_to_datetime(date_raw) if date_raw else None
     if date:
         date_epoch = date.timestamp()

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -1,5 +1,5 @@
 """Shared functions and other definitions."""
-
+from datetime import datetime
 import collections
 import os
 import random
@@ -33,7 +33,7 @@ from typing import (
     Union,
     cast,
 )
-
+from email.utils import parsedate_to_datetime
 import pkg_resources
 import requests
 from cachecontrol import CacheControl
@@ -344,8 +344,7 @@ def trim_listing(obj):  # type: (Dict[str, Any]) -> None
         del obj["listing"]
 
 
-def downloadHttpFile(httpurl):
-    # type: (str) -> str
+def downloadHttpFile(httpurl: str) -> Tuple[str, Optional[datetime]]:
     cache_session = None
     if "XDG_CACHE_HOME" in os.environ:
         directory = os.environ["XDG_CACHE_HOME"]
@@ -365,7 +364,14 @@ def downloadHttpFile(httpurl):
             if chunk:  # filter out keep-alive new chunks
                 f.write(chunk)
     r.close()
-    return str(f.name)
+
+    date_raw: Optional[str] = r.headers.get('Last-Modified', None)
+    date: Optional[datetime] = parsedate_to_datetime(date_raw) if date_raw else None
+    if date:
+        date_epoch = date.timestamp()
+        os.utime(f.name, (date_epoch, date_epoch))
+
+    return str(f.name), date
 
 
 def ensure_writable(path: str, include_root: bool = False) -> None:

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -1,5 +1,4 @@
 """Shared functions and other definitions."""
-from datetime import datetime
 import collections
 import os
 import random
@@ -11,6 +10,8 @@ import sys
 import tempfile
 import urllib
 import uuid
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from functools import partial
 from itertools import zip_longest
 from pathlib import Path, PurePosixPath
@@ -33,7 +34,7 @@ from typing import (
     Union,
     cast,
 )
-from email.utils import parsedate_to_datetime
+
 import pkg_resources
 import requests
 from cachecontrol import CacheControl

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ setup(
         "pytest >= 6.2, < 7.2",
         "mock >= 2.0.0",
         "pytest-mock >= 1.10.0",
+        "pytest-httpserver",
         "arcp >= 0.2.0",
         "rdflib-jsonld>=0.4.0, <= 0.6.1;python_version<='3.6'",
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 pytest >= 6.2, < 7.2
 pytest-xdist
+pytest-httpserver
 mock >= 2.0.0
 pytest-mock >= 1.10.0
 pytest-cov

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from cwltool.pathmapper import PathMapper
 from cwltool.utils import CWLObjectType
 
-from pytest_httpserver import HTTPServer
+from pytest_httpserver import HTTPServer  # type: ignore[import]
 
 
 def test_http_path_mapping(tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ def test_modification_date(tmp_path: Path) -> None:
         httpserver.expect_request(f"/{remote_file_name}").respond_with_data(
             response_data="Hello World", headers=headers
         )
-        location = httpserver.url_for(f"/{remove_file_name}")
+        location = httpserver.url_for(f"/{remote_file_name}")
 
         base_file: List[CWLObjectType] = [
             {

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -29,8 +29,9 @@ def test_http_path_mapping(tmp_path: Path) -> None:
 
     assert ">Sequence 561 BP; 135 A; 106 C; 98 G; 222 T; 0 other;" in contents
 
+
 def test_modification_date(tmp_path: Path) -> None:
-    input_file_path = "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip" # replace this with another remote file
+    input_file_path = "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip"  # replace this with another remote file
     base_file: List[CWLObjectType] = [
         {
             "class": "File",
@@ -38,15 +39,16 @@ def test_modification_date(tmp_path: Path) -> None:
             "basename": "test_ppi.zip",
         }
     ]
-    
-    date_now = datetime.now() # the current datetime
-    
+
+    date_now = datetime.now()  # the current datetime
+
     pathmap = PathMapper(base_file, os.getcwd(), str(tmp_path))._pathmap
-    
+
     assert input_file_path in pathmap
     assert os.path.exists(pathmap[input_file_path].resolved)
 
     last_modified = os.path.getmtime(pathmap[input_file_path].resolved)
 
-    assert date_now.timestamp() > last_modified # remote file should have earlier last modification date
-    
+    assert (
+        date_now.timestamp() > last_modified
+    )  # remote file should have earlier last modification date

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from cwltool.pathmapper import PathMapper
 from cwltool.utils import CWLObjectType
 
-from pytest_httpserver import HTTPServer  # type: ignore[import]
+from pytest_httpserver import HTTPServer
 
 
 def test_http_path_mapping(tmp_path: Path) -> None:

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -53,6 +53,7 @@ def test_modification_date(tmp_path: Path) -> None:
     with HTTPServer() as httpserver:
         httpserver.expect_request(f"/{basename}").respond_with_data(response_data="Hello World", headers=headers)   
         location = httpserver.url_for(f"/{basename}")
+    
     # input_file_path = "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip"  # replace this with another remote file
     base_file: List[CWLObjectType] = [
         {
@@ -64,7 +65,7 @@ def test_modification_date(tmp_path: Path) -> None:
 
     date_now = datetime.now()  # the current datetime
 
-    pathmap = PathMapper(base_file, os.getcwd(), str(tmp_path))._pathmap
+    pathmap = PathMapper(base_file, os.getcwd(), str(tmp_path))._pathmap # it fails here
 
     # assert input_file_path in pathmap
     assert location in pathmap

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -1,18 +1,21 @@
 import os
 from pathlib import Path
 from typing import List
+from datetime import datetime
 
 from cwltool.pathmapper import PathMapper
-from cwltool.utils import CWLObjectType
+from cwltool.utils import CWLObjectType, downloadHttpFile
 
 
 def test_http_path_mapping(tmp_path: Path) -> None:
 
     input_file_path = "https://raw.githubusercontent.com/common-workflow-language/cwltool/main/tests/2.fasta"
+    # input_file_path = "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip"
     base_file: List[CWLObjectType] = [
         {
             "class": "File",
             "location": "https://raw.githubusercontent.com/common-workflow-language/cwltool/main/tests/2.fasta",
+            # "location": "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip",
             "basename": "chr20.fa",
         }
     ]
@@ -25,3 +28,25 @@ def test_http_path_mapping(tmp_path: Path) -> None:
         contents = file.read()
 
     assert ">Sequence 561 BP; 135 A; 106 C; 98 G; 222 T; 0 other;" in contents
+
+def test_modification_date(tmp_path: Path) -> None:
+    input_file_path = "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip" # replace this with another remote file
+    base_file: List[CWLObjectType] = [
+        {
+            "class": "File",
+            "location": "https://ibi.vu.nl/downloads/multi-task-PPI/test_ppi.zip",
+            "basename": "test_ppi.zip",
+        }
+    ]
+    
+    date_now = datetime.now() # the current datetime
+    
+    pathmap = PathMapper(base_file, os.getcwd(), str(tmp_path))._pathmap
+    
+    assert input_file_path in pathmap
+    assert os.path.exists(pathmap[input_file_path].resolved)
+
+    last_modified = os.path.getmtime(pathmap[input_file_path].resolved)
+
+    assert date_now.timestamp() > last_modified # remote file should have earlier last modification date
+    

--- a/tests/test_http_input.py
+++ b/tests/test_http_input.py
@@ -1,12 +1,14 @@
 import os
+import sys
+from datetime import datetime
 from pathlib import Path
 from typing import List
-from datetime import datetime
+
+import pytest
+from pytest_httpserver import HTTPServer
 
 from cwltool.pathmapper import PathMapper
 from cwltool.utils import CWLObjectType
-
-from pytest_httpserver import HTTPServer
 
 
 def test_http_path_mapping(tmp_path: Path) -> None:
@@ -30,6 +32,7 @@ def test_http_path_mapping(tmp_path: Path) -> None:
     assert ">Sequence 561 BP; 135 A; 106 C; 98 G; 222 T; 0 other;" in contents
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="timesout on CI")
 def test_modification_date(tmp_path: Path) -> None:
     """Local copies of remote files should preserve last modification date."""
     # Initialize the server


### PR DESCRIPTION
Changed cwltool/utils.py::downloadHttpFile to set Last-Modified date of remote file as timestamp of downloaded file.