### PR TITLE
Expressiontool timer

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -226,9 +226,9 @@ def arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--eval-timeout",
         help="Time to wait for a Javascript expression to evaluate before giving "
-        "an error, default 20s.",
+        "an error, default 60s.",
         type=float,
-        default=20,
+        default=60,
     )
 
     provgroup = parser.add_argument_group(

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -164,7 +164,7 @@ class RuntimeContext(ContextBase):
         self.js_console = False  # type: bool
         self.job_script_provider = None  # type: Optional[DependenciesConfiguration]
         self.select_resources = None  # type: Optional[select_resources_callable]
-        self.eval_timeout = 20  # type: float
+        self.eval_timeout = 60  # type: float
         self.postScatterEval = (
             None
         )  # type: Optional[Callable[[CWLObjectType], Optional[CWLObjectType]]]

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -102,6 +102,7 @@ class LoadingContext(ContextBase):
         self.relax_path_checks = False  # type: bool
         self.singularity = False  # type: bool
         self.podman = False  # type: bool
+        self.eval_timeout = 60  # type: float
 
         super().__init__(kwargs)
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -731,6 +731,7 @@ class Process(HasReqsHints, metaclass=abc.ABCMeta):
                     self.doc_schema.names[avroname],
                     validate_js_options,
                     self.container_engine,
+                    loadingContext.eval_timeout,
                 )
 
         dockerReq, is_req = self.get_requirement("DockerRequirement")

--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -285,12 +285,20 @@ def exec_js_process(
                         pipes[1].write(buf)
         except OSError:
             break
-    timer.cancel()
 
     stdin_buf.close()
-    stdoutdata = stdout_buf.getvalue()[: -len(PROCESS_FINISHED_STR) - 1]
-    stderrdata = stderr_buf.getvalue()[: -len(PROCESS_FINISHED_STR) - 1]
+    
+    if not timer.is_alive():
+        _logger.info("Expression Tool stopped because time limit has been exceeded.")
+        _logger.info("Time limit is {} seconds. This can be increased using the --eval-timeout flag.\n".format(timeout))
+        stdoutdata = stdout_buf.getvalue()
+        stderrdata = stderr_buf.getvalue()
+    else:
+        stdoutdata = stdout_buf.getvalue()[: -len(PROCESS_FINISHED_STR) - 1]
+        stderrdata = stderr_buf.getvalue()[: -len(PROCESS_FINISHED_STR) - 1]
 
+    timer.cancel()
+    
     nodejs.poll()
 
     if nodejs.poll() not in (None, 0):

--- a/cwltool/sandboxjs.py
+++ b/cwltool/sandboxjs.py
@@ -287,10 +287,14 @@ def exec_js_process(
             break
 
     stdin_buf.close()
-    
+
     if not timer.is_alive():
         _logger.info("Expression Tool stopped because time limit has been exceeded.")
-        _logger.info("Time limit is {} seconds. This can be increased using the --eval-timeout flag.\n".format(timeout))
+        _logger.info(
+            "Time limit is {} seconds. This can be increased using the --eval-timeout flag.\n".format(
+                timeout
+            )
+        )
         stdoutdata = stdout_buf.getvalue()
         stderrdata = stderr_buf.getvalue()
     else:
@@ -298,7 +302,7 @@ def exec_js_process(
         stderrdata = stderr_buf.getvalue()[: -len(PROCESS_FINISHED_STR) - 1]
 
     timer.cancel()
-    
+
     nodejs.poll()
 
     if nodejs.poll() not in (None, 0):

--- a/cwltool/validate_js.py
+++ b/cwltool/validate_js.py
@@ -134,6 +134,7 @@ def jshint_js(
     globals: Optional[List[str]] = None,
     options: Optional[Dict[str, Union[List[str], str, int]]] = None,
     container_engine: str = "docker",
+    eval_timeout: float,
 ) -> JSHintJSReturn:
     if globals is None:
         globals = []
@@ -164,7 +165,7 @@ def jshint_js(
     returncode, stdout, stderr = exec_js_process(
         "validateJS(%s)"
         % json_dumps({"code": js_text, "options": options, "globals": globals}),
-        timeout=30,
+        timeout=eval_timeout,
         context=jshint_functions_text,
         container_engine=container_engine,
     )
@@ -216,6 +217,7 @@ def validate_js_expressions(
     schema: Schema,
     jshint_options: Optional[Dict[str, Union[List[str], str, int]]] = None,
     container_engine: str = "docker",
+    eval_timeout: float,
 ) -> None:
 
     if tool.get("requirements") is None:
@@ -236,7 +238,8 @@ def validate_js_expressions(
 
     for i, expression_lib_line in enumerate(expression_lib):
         expression_lib_line_errors, expression_lib_line_globals = jshint_js(
-            expression_lib_line, js_globals, jshint_options, container_engine
+            expression_lib_line, js_globals, jshint_options, container_engine,
+            eval_timeout
         )
         js_globals.extend(expression_lib_line_globals)
         print_js_hint_messages(
@@ -262,7 +265,8 @@ def validate_js_expressions(
                 code_fragment = unscanned_str[scan_slice[0] + 1 : scan_slice[1]]
                 code_fragment_js = code_fragment_to_js(code_fragment, "")
                 expression_errors, _ = jshint_js(
-                    code_fragment_js, js_globals, jshint_options, container_engine
+                    code_fragment_js, js_globals, jshint_options, container_engine,
+                    eval_timeout
                 )
                 print_js_hint_messages(expression_errors, source_line)
 

--- a/cwltool/validate_js.py
+++ b/cwltool/validate_js.py
@@ -134,7 +134,7 @@ def jshint_js(
     globals: Optional[List[str]] = None,
     options: Optional[Dict[str, Union[List[str], str, int]]] = None,
     container_engine: str = "docker",
-    eval_timeout: float,
+    eval_timeout: float = 60,
 ) -> JSHintJSReturn:
     if globals is None:
         globals = []
@@ -217,7 +217,7 @@ def validate_js_expressions(
     schema: Schema,
     jshint_options: Optional[Dict[str, Union[List[str], str, int]]] = None,
     container_engine: str = "docker",
-    eval_timeout: float,
+    eval_timeout: float = 60,
 ) -> None:
 
     if tool.get("requirements") is None:
@@ -238,8 +238,11 @@ def validate_js_expressions(
 
     for i, expression_lib_line in enumerate(expression_lib):
         expression_lib_line_errors, expression_lib_line_globals = jshint_js(
-            expression_lib_line, js_globals, jshint_options, container_engine,
-            eval_timeout
+            expression_lib_line,
+            js_globals,
+            jshint_options,
+            container_engine,
+            eval_timeout,
         )
         js_globals.extend(expression_lib_line_globals)
         print_js_hint_messages(
@@ -265,8 +268,11 @@ def validate_js_expressions(
                 code_fragment = unscanned_str[scan_slice[0] + 1 : scan_slice[1]]
                 code_fragment_js = code_fragment_to_js(code_fragment, "")
                 expression_errors, _ = jshint_js(
-                    code_fragment_js, js_globals, jshint_options, container_engine,
-                    eval_timeout
+                    code_fragment_js,
+                    js_globals,
+                    jshint_options,
+                    container_engine,
+                    eval_timeout,
                 )
                 print_js_hint_messages(expression_errors, source_line)
 

--- a/tests/test_singularity_versions.py
+++ b/tests/test_singularity_versions.py
@@ -1,15 +1,15 @@
 """Test singularity{,-ce} & apptainer versions."""
+from subprocess import check_output  # nosec
+
 import cwltool.singularity
 from cwltool.singularity import (
     get_version,
     is_apptainer_1_or_newer,
     is_version_2_6,
-    is_version_3_or_newer,
     is_version_3_1_or_newer,
     is_version_3_4_or_newer,
+    is_version_3_or_newer,
 )
-
-from subprocess import check_output  # nosec
 
 
 def reset_singularity_version_cache() -> None:


### PR DESCRIPTION
This PR is in response to [issue 1680](https://github.com/common-workflow-language/cwltool/issues/1680).

1. Increased the default time for expression tools to 60 seconds, so that `--eval-timeout` flag will be used more for optimisation purposes, rather than being needed to accomodate systems with slower response times for expression tools.
2. Added some log information for situations where the expression tool time limit is triggered.

Outstanding questions:
1. The `exec_js_process` routine seems to be used for organisational tasks at the start of the workflow. And is run with a 30 second time limit. If the tool time limit gets breached for that process then my log message will be misleading (because the `--eval-timeout` flag doesn't control that time limit).
2. Really it would be useful for the workflow to exit if a tool fails in this manner. Perhaps when this is implemented the log messages could be moved to a more appropriate location in the code (solving the issue I note above)?
