### PR TITLE
logging.warn is deprecated, use warning

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -900,7 +900,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
                     try:
                         os.remove(cidfile)
                     except OSError as exc:
-                        _logger.warn(
+                        _logger.warning(
                             "Ignored error cleaning up Docker cidfile: %s", exc
                         )
                     return
@@ -923,7 +923,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
                 process.wait()
                 stats_proc.kill()
         except OSError as exc:
-            _logger.warn("Ignored error with docker stats: %s", exc)
+            _logger.warning("Ignored error with docker stats: %s", exc)
             return
         max_mem_percent = 0  # type: float
         mem_percent = 0  # type: float

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1153,7 +1153,7 @@ def main(
                 tool = make_tool(uri, loadingContext)
             except GraphTargetMissingException as main_missing_exc:
                 if args.validate:
-                    logging.warn(
+                    logging.warning(
                         "File contains $graph of multiple objects and no default "
                         "process (#main). Validating all objects:"
                     )


### PR DESCRIPTION
`logging.warn` is deprecated since Py 3.3. Noticed the warnings (about logging.warn) in GH Actions logs for another PR.

To review, we can wait CI and just look at a `pytest` and/or `mypy` test to confirm there's no warning about warn.

-Bruno