### PR TITLE
Changed outputSource refScope from 0 to 1

### DIFF
--- a/cwltool/schemas/v1.0/Workflow.yml
+++ b/cwltool/schemas/v1.0/Workflow.yml
@@ -169,7 +169,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.1.0-dev1/Workflow.yml
+++ b/cwltool/schemas/v1.1.0-dev1/Workflow.yml
@@ -226,7 +226,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.1/Workflow.yml
+++ b/cwltool/schemas/v1.1/Workflow.yml
@@ -235,7 +235,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2.0-dev1/Workflow.yml
+++ b/cwltool/schemas/v1.2.0-dev1/Workflow.yml
@@ -200,7 +200,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2.0-dev2/Workflow.yml
+++ b/cwltool/schemas/v1.2.0-dev2/Workflow.yml
@@ -205,7 +205,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2.0-dev3/Workflow.yml
+++ b/cwltool/schemas/v1.2.0-dev3/Workflow.yml
@@ -205,7 +205,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2.0-dev4/Workflow.yml
+++ b/cwltool/schemas/v1.2.0-dev4/Workflow.yml
@@ -223,7 +223,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2.0-dev5/Workflow.yml
+++ b/cwltool/schemas/v1.2.0-dev5/Workflow.yml
@@ -223,7 +223,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?

--- a/cwltool/schemas/v1.2/Workflow.yml
+++ b/cwltool/schemas/v1.2/Workflow.yml
@@ -223,7 +223,7 @@ $graph:
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"
-        refScope: 0
+        refScope: 1
       type:
         - string?
         - string[]?


### PR DESCRIPTION
This change allows a corret id reference in the outputSource field of `WorkflowOutputParameter` objects