### PR TITLE
Fix codespell issues

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ Reporting
 If you are being harassed by a member of the CWL Project, notice that someone
 else is being harassed, or have any other concerns, please contact the CWL
 Leadership Team at leadership@commonwl.org. If person who is harassing
-you is on the team, they will recuse themselves from handling your incident. We
+you is on the team, they will recurse themselves from handling your incident. We
 will respond as promptly as we can.
 
 This code of conduct applies to CWL Project spaces, but if you are being

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ Reporting
 If you are being harassed by a member of the CWL Project, notice that someone
 else is being harassed, or have any other concerns, please contact the CWL
 Leadership Team at leadership@commonwl.org. If person who is harassing
-you is on the team, they will recurse themselves from handling your incident. We
+you is on the team, they will recuse themselves from handling your incident. We
 will respond as promptly as we can.
 
 This code of conduct applies to CWL Project spaces, but if you are being

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ pydocstyle_report.txt: $(PYSOURCES)
 diff_pydocstyle_report: pydocstyle_report.txt
 	diff-quality --compare-branch=main --violations=pydocstyle --fail-under=100 $^
 
-## codespell              : check for common mispellings
+## codespell              : check for common misspellings
 codespell:
 	codespell -w $(shell git ls-files | grep -v cwltool/schemas | grep -v cwltool/jshint/ | grep -v mypy-stubs)
 

--- a/cwltool/run_job.py
+++ b/cwltool/run_job.py
@@ -42,7 +42,7 @@ def main(argv: List[str]) -> int:
       "stdout_path": a string (or a null) giving the path that should receive the STDOUT
       "stderr_path": a string (or a null) giving the path that should receive the STDERR
 
-    The second argument is optional, it specifes a shell script to execute prior,
+    The second argument is optional, it specifies a shell script to execute prior,
       and the environment variables it sets will be combined with the environment
       variables from the "env" key in the JSON dictionary from the first argument.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+
+[codespell]
+ignore-words-list=ORE,ore,RO,ro


### PR DESCRIPTION
I think `codespell` is failing in other PR's:

- https://github.com/common-workflow-language/cwltool/pull/1703
- https://github.com/common-workflow-language/cwltool/pull/1714
- https://github.com/common-workflow-language/cwltool/pull/1709

I tested it locally, and it reformatted a few files. I excluded the word ORE as that's from an ontology's name. After the changes in this PR, `make cleanup` passes with exit code `0` for me :tada: 

```bash
(venv) kinow@ranma:~/Development/python/workspace/cwltool$ make cleanup
isort cwltool/argparser.py cwltool/builder.py cwltool/checker.py cwltool/command_line_tool.py cwltool/context.py cwltool/cuda.py cwltool/cwlrdf.py cwltool/cwlviewer.py cwltool/docker_id.py cwltool/docker.py cwltool/env_to_stdout.py cwltool/errors.py cwltool/executors.py cwltool/factory.py cwltool/flatten.py cwltool/__init__.py cwltool/job.py cwltool/load_tool.py cwltool/loghandler.py cwltool/__main__.py cwltool/main.py cwltool/mpi.py cwltool/mutation.py cwltool/pack.py cwltool/pathmapper.py cwltool/process.py cwltool/procgenerator.py cwltool/provenance_constants.py cwltool/provenance_profile.py cwltool/provenance.py cwltool/resolver.py cwltool/run_job.py cwltool/secrets.py cwltool/singularity.py cwltool/singularity_utils.py cwltool/software_requirements.py cwltool/stdfsaccess.py cwltool/subgraph.py cwltool/task_queue.py cwltool/udocker.py cwltool/update.py cwltool/utils.py cwltool/validate_js.py cwltool/workflow_job.py cwltool/workflow.py tests/__init__.py tests/test_anon_types.py tests/test_check.py tests/test_conditionals.py tests/test_content_type.py tests/test_context.py tests/test_cuda.py tests/test_cwl_version.py tests/test_default_path.py tests/test_dependencies.py tests/test_docker_info.py tests/test_docker_paths_with_colons.py tests/test_docker.py tests/test_empty_input.py tests/test_environment.py tests/test_examples.py tests/test_ext.py tests/test_fetch.py tests/test_http_input.py tests/test_input_deps.py tests/test_iwdr.py tests/test_js_sandbox.py tests/test_load_tool.py tests/test_make_template.py tests/test_misc_cli.py tests/test_mpi.py tests/test_override.py tests/test_pack.py tests/test_parallel.py tests/test_path_checks.py tests/test_pathmapper.py tests/test_procgenerator.py tests/test_provenance.py tests/test_rdfprint.py tests/test_recursive_validation.py tests/test_relocate.py tests/test_schemadef.py tests/test_secrets.py tests/test_singularity.py tests/test_singularity_versions.py tests/test_stdout_stderr_log_dir.py tests/test_streaming.py tests/test_subgraph.py tests/test_target.py tests/test_tmpdir.py tests/test_toolargparse.py tests/test_trs.py tests/test_udocker.py tests/test_validate_js.py tests/test_validate.py tests/test_windows_warning.py tests/util.py setup.py mypy-stubs
Fixing /home/kinow/Development/python/workspace/cwltool/mypy-stubs/prov/model.pyi
black --exclude cwltool/schemas setup.py cwltool.py cwltool tests mypy-stubs
reformatted mypy-stubs/prov/model.pyi

All done! ✨ 🍰 ✨
1 file reformatted, 412 files left unchanged.
flake8 cwltool/argparser.py cwltool/builder.py cwltool/checker.py cwltool/command_line_tool.py cwltool/context.py cwltool/cuda.py cwltool/cwlrdf.py cwltool/cwlviewer.py cwltool/docker_id.py cwltool/docker.py cwltool/env_to_stdout.py cwltool/errors.py cwltool/executors.py cwltool/factory.py cwltool/flatten.py cwltool/__init__.py cwltool/job.py cwltool/load_tool.py cwltool/loghandler.py cwltool/__main__.py cwltool/main.py cwltool/mpi.py cwltool/mutation.py cwltool/pack.py cwltool/pathmapper.py cwltool/process.py cwltool/procgenerator.py cwltool/provenance_constants.py cwltool/provenance_profile.py cwltool/provenance.py cwltool/resolver.py cwltool/run_job.py cwltool/secrets.py cwltool/singularity.py cwltool/singularity_utils.py cwltool/software_requirements.py cwltool/stdfsaccess.py cwltool/subgraph.py cwltool/task_queue.py cwltool/udocker.py cwltool/update.py cwltool/utils.py cwltool/validate_js.py cwltool/workflow_job.py cwltool/workflow.py tests/__init__.py tests/test_anon_types.py tests/test_check.py tests/test_conditionals.py tests/test_content_type.py tests/test_context.py tests/test_cuda.py tests/test_cwl_version.py tests/test_default_path.py tests/test_dependencies.py tests/test_docker_info.py tests/test_docker_paths_with_colons.py tests/test_docker.py tests/test_empty_input.py tests/test_environment.py tests/test_examples.py tests/test_ext.py tests/test_fetch.py tests/test_http_input.py tests/test_input_deps.py tests/test_iwdr.py tests/test_js_sandbox.py tests/test_load_tool.py tests/test_make_template.py tests/test_misc_cli.py tests/test_mpi.py tests/test_override.py tests/test_pack.py tests/test_parallel.py tests/test_path_checks.py tests/test_pathmapper.py tests/test_procgenerator.py tests/test_provenance.py tests/test_rdfprint.py tests/test_recursive_validation.py tests/test_relocate.py tests/test_schemadef.py tests/test_secrets.py tests/test_singularity.py tests/test_singularity_versions.py tests/test_stdout_stderr_log_dir.py tests/test_streaming.py tests/test_subgraph.py tests/test_target.py tests/test_tmpdir.py tests/test_toolargparse.py tests/test_trs.py tests/test_udocker.py tests/test_validate_js.py tests/test_validate.py tests/test_windows_warning.py tests/util.py setup.py
diff-quality --compare-branch=main --violations=pydocstyle --fail-under=100 pydocstyle_report.txt
-------------
Diff Quality
Quality Report: pydocstyle
Diff: main...HEAD, staged and unstaged changes
-------------
cwltool/run_job.py (100%)
-------------
Total:   1 line
Violations: 0 lines
% Quality: 100%
-------------
(venv) kinow@ranma:~/Development/python/workspace/cwltool$ echo $?
0
```
