### PR TITLE
Provenance: fix bagit structure when there are no data files

### DIFF
--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -298,6 +298,7 @@ class ResearchObject:
         self.cwltool_version = "cwltool %s" % versionstring().split()[-1]
         ##
         self.relativised_input_object = {}  # type: CWLObjectType
+        self.has_manifest = False
 
         self._initialize()
         _logger.debug("[provenance] Temporary research object: %s", self.folder)
@@ -355,6 +356,8 @@ class ResearchObject:
     def _finalize(self) -> None:
         self._write_ro_manifest()
         self._write_bag_info()
+        if not self.has_manifest:
+            (Path(self.folder) / "manifest-sha1.txt").touch()
 
     def user_provenance(self, document: ProvDocument) -> None:
         """Add the user provenance."""
@@ -853,6 +856,7 @@ class ResearchObject:
         if os.path.commonprefix(["data/", rel_path]) == "data/":
             # payload file, go to manifest
             manifest = "manifest"
+            self.has_manifest = True
         else:
             # metadata file, go to tag manifest
             manifest = "tagmanifest"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -192,6 +192,15 @@ def test_directory_workflow(tmp_path: Path) -> None:
         assert p.is_file(), f"Could not find {l} as {p}"
 
 
+@needs_docker
+def test_no_data_files(tmp_path: Path) -> None:
+    folder = cwltool(
+        tmp_path,
+        get_data("tests/wf/conditional_step_no_inputs.cwl"),
+    )
+    check_bagit(folder)
+
+
 def check_output_object(base_path: Path) -> None:
     output_obj = base_path / "workflow" / "primary-output.json"
     compare_checksum = "sha1$b9214658cc453331b62c2282b772a5c063dbd284"


### PR DESCRIPTION
When the workflow has no input or output files, the RO created by `cwltool --provenance` has no files under `data/`. In this case, no bagit manifest is created, making the RO bag invalid:

```python
from bdbag.bdbagit import BDBag

bag = BDBag("ro")
bag.validate()
```

```
bagit.BagValidationError: No manifest files found
```

This PR changes `ResearchObject` so that it creates an empty manifest to fix the bagit structure in such cases.