### PR TITLE
Add QEMU step and platforms field to the publish action for Arm Docker image

### DIFF
--- a/.github/workflows/quay-publish.yml
+++ b/.github/workflows/quay-publish.yml
@@ -13,6 +13,8 @@ jobs:
         id: image_tags
         run: |
           echo -n ::set-output name=IMAGE_TAGS::${GITHUB_REF#refs/*/}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Quay.io
@@ -27,6 +29,7 @@ jobs:
           file: cwltool.Dockerfile
           tags: quay.io/commonwl/cwltool_module:${{ steps.image_tags.outputs.IMAGE_TAGS }}
           target: module
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -35,6 +38,7 @@ jobs:
         with:
           file: cwltool.Dockerfile
           tags: quay.io/commonwl/cwltool:${{ steps.image_tags.outputs.IMAGE_TAGS }}
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
It seems that there is no Docker image for Arm, so I added options to the publish action.

Please refer https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md

I would be happy to discuss, including whether or not to provide Arm image itself.