### PR TITLE
Fix '--make-template' for union types

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -242,7 +242,9 @@ def generate_example_input(
             for field in cast(List[CWLObjectType], inptype["fields"]):
                 value, f_comment = generate_example_input(field["type"], None)
                 if f_comment:
-                    example.insert(0, shortname(cast(str, field["name"])), value, f_comment)
+                    example.insert(
+                        0, shortname(cast(str, field["name"])), value, f_comment
+                    )
                 else:
                     example.insert(0, shortname(cast(str, field["name"])), value, None)
         elif "default" in inptype:

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -241,12 +241,7 @@ def generate_example_input(
                 comment = "Anonymous record type."
             for field in cast(List[CWLObjectType], inptype["fields"]):
                 value, f_comment = generate_example_input(field["type"], None)
-                if f_comment:
-                    example.insert(
-                        0, shortname(cast(str, field["name"])), value, f_comment
-                    )
-                else:
-                    example.insert(0, shortname(cast(str, field["name"])), value, None)
+                example.insert(0, shortname(cast(str, field["name"])), value, f_comment)
         elif "default" in inptype:
             example = inptype["default"]
             comment = 'default value of type "{}".'.format(inptype["type"])
@@ -340,10 +335,7 @@ def generate_input_template(tool: Process) -> CWLObjectType:
     ):
         name = shortname(inp["id"])
         value, comment = generate_example_input(inp["type"], inp.get("default", None))
-        if comment:
-            template.insert(0, name, value, comment)
-        else:
-            template.insert(0, name, value, None)
+        template.insert(0, name, value, comment)
     return template
 
 

--- a/tests/test_make_template.py
+++ b/tests/test_make_template.py
@@ -8,3 +8,8 @@ from cwltool import main
 def test_anonymous_record() -> None:
     inputs = cmap([{"type": "record", "fields": []}])
     assert main.generate_example_input(inputs, None) == ({}, "Anonymous record type.")
+
+
+def test_union() -> None:
+    inputs = cmap(["string", "string[]"])
+    assert main.generate_example_input(inputs, None) == ("a_string", 'one of type "string", type "string[]"')

--- a/tests/test_make_template.py
+++ b/tests/test_make_template.py
@@ -17,3 +17,12 @@ def test_union() -> None:
         "a_string",
         'one of type "string", type "string[]"',
     )
+
+
+def test_optional_union() -> None:
+    """Test for --make-template for an optional union type."""
+    inputs = cmap(["null", "string", "string[]"])
+    assert main.generate_example_input(inputs, None) == (
+        "a_string",
+        'one of type "string", type "string[]" (optional)',
+    )

--- a/tests/test_make_template.py
+++ b/tests/test_make_template.py
@@ -11,5 +11,9 @@ def test_anonymous_record() -> None:
 
 
 def test_union() -> None:
+    """Test for --make-template for a union type."""
     inputs = cmap(["string", "string[]"])
-    assert main.generate_example_input(inputs, None) == ("a_string", 'one of type "string", type "string[]"')
+    assert main.generate_example_input(inputs, None) == (
+        "a_string",
+        'one of type "string", type "string[]"',
+    )


### PR DESCRIPTION
This request makes `cwltool --make-template` to support union types.

It includes the following fixes:
- `--make-template` fails with the following message: "IndexError: string index out of range"
  - It is caused by calling `CommentedSeq()#insert` with empty comment. `insert` can handle `None` comment but cannot handle empty string comment. I fixed it by checking whether the comment is an empty string or not.
- Even if the above issue is fixed, `cwltool --make-template` does not work with the union type because it try to generate examples for all possible types. This request fixes it by generating an example for the first candidate type

I checked it works with the following CWL document.
- https://zenodo.org/api/files/2422dda0-1bd9-4109-aa44-53d55fd934de/download-sra.cwl
```cwl
...
inputs:
  repo:
    type: string
    default: "ddbj"
    inputBinding:
      position: 1
      prefix: "-r"
  run_ids:
    type:
      - string
      - string[]
    inputBinding:
      position: 2
...
```


- Before merging this request:
```console
$ cwltool --debug --make-template download-sra.cwl 
INFO /home/vscode/.local/bin/cwltool 3.1.20221108103845
INFO Resolved 'download-sra.cwl' to 'file:///workspaces/cwltool/download-sra.cwl'
ERROR I'm sorry, I couldn't load this CWL file.
The error was: 
Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.10/site-packages/cwltool/main.py", line 1171, in main
    make_template(tool)
  File "/home/vscode/.local/lib/python3.10/site-packages/cwltool/main.py", line 779, in make_template
    generate_input_template(tool),
  File "/home/vscode/.local/lib/python3.10/site-packages/cwltool/main.py", line 336, in generate_input_template
    template.insert(0, name, value, comment)
  File "/home/vscode/.local/lib/python3.10/site-packages/ruamel/yaml/comments.py", line 896, in insert
    self.yaml_add_eol_comment(comment, key=key)
  File "/home/vscode/.local/lib/python3.10/site-packages/ruamel/yaml/comments.py", line 434, in yaml_add_eol_comment
    if comment[0] != '#':
IndexError: string index out of range
```

- After merging this request:
```console
$ cwltool --make-template download-sra.cwl 
INFO /home/vscode/.local/bin/cwltool 3.1.20221108103845
INFO Resolved 'download-sra.cwl' to 'file:///workspaces/cwltool/download-sra.cwl'
run_ids: a_string  # one of type "string", array of type "string"
repo: "ddbj"  # default value of type "string".
```

I guess this request can fix #1404.

