### PR TITLE
Move sys.exit

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1511,10 +1511,9 @@ def run(*args: Any, **kwargs: Any) -> int:
     """Run cwltool."""
     windows_check()
     signal.signal(signal.SIGTERM, _signal_handler)
+    retval = 1
     try:
         retval = main(*args, **kwargs)
-    except:
-        retval = 1
     finally:
         _terminate_processes()
     return retval

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1507,15 +1507,18 @@ def windows_check() -> None:
         )
 
 
-def run(*args: Any, **kwargs: Any) -> None:
+def run(*args: Any, **kwargs: Any) -> int:
     """Run cwltool."""
     windows_check()
     signal.signal(signal.SIGTERM, _signal_handler)
     try:
-        sys.exit(main(*args, **kwargs))
+        retval = main(*args, **kwargs)
+    except:
+        retval = 1
     finally:
         _terminate_processes()
+    return retval
 
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    sys.exit(run(sys.argv[1:]))


### PR DESCRIPTION
This PR simply moves the sys.exit() call so that users call call run() without exiting. I'm currently copy & pasting the body of run (without the sys.exit call of course), but that isn't ideal.

FYI the reason I'm interested in calling run() is because the normal way of using the cwltool [Python API](https://github.com/common-workflow-language/cwltool#import-as-a-module) does not (easily) allow using all of the CLI arguments. (In particular, --cachedir and --provenance)