### PR TITLE
--write-summary to redirect final JSON output

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -391,12 +391,12 @@ def arg_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--output-write",
-        "-o",
+        "--write-summary",
+        "-w",
         type=str,
-        help="Determines whether the final output object should be saved to a file instead of printed to stdout.",
+        help="Path to write the final output JSON object to. Default is stdout.",
         default="",
-        dest="output_write",
+        dest="write_summary",
     )
 
     parser.add_argument(

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -391,6 +391,14 @@ def arg_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--no-print-final-output",
+        action="store_true",
+        help="Determines whether the final output object should not be printed to stdout.",
+        default=False,
+        dest="no_print_final_output",
+    )
+
+    parser.add_argument(
         "--strict-memory-limit",
         action="store_true",
         help="When running with "

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -391,11 +391,12 @@ def arg_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--no-print-final-output",
-        action="store_true",
-        help="Determines whether the final output object should not be printed to stdout.",
-        default=False,
-        dest="no_print_final_output",
+        "--output-write",
+        "-o",
+        type=str,
+        help="Determines whether the final output object should be saved to a file instead of printed to stdout.",
+        default="",
+        dest="output_write",
     )
 
     parser.add_argument(

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -1,6 +1,6 @@
 import urllib
 from codecs import StreamWriter
-from typing import Any, Dict, Iterator, Optional, TextIO, Union, cast
+from typing import IO, Any, Dict, Iterator, Optional, TextIO, Union, cast
 
 from rdflib import Graph
 from rdflib.query import ResultRow
@@ -217,7 +217,7 @@ def dot_without_parameters(g: Graph, stdout: Union[TextIO, StreamWriter]) -> Non
 def printdot(
     wf: Process,
     ctx: ContextType,
-    stdout: Union[TextIO, StreamWriter],
+    stdout: IO[str],
 ) -> None:
     cwl_viewer = CWLViewer(printrdf(wf, ctx, "n3"))  # type: CWLViewer
     stdout.write(cwl_viewer.dot().replace(f"{wf.metadata['id']}#", ""))

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1398,7 +1398,13 @@ def main(
                 # Unsetting the Generation from final output object
                 visit_class(out, ("File",), MutationManager().unset_generation)
 
-                if not args.no_print_final_output:
+                if args.output_write:
+                    with open(args.output_write, "w") as file:
+                        print(
+                            json_dumps(out, indent=4, ensure_ascii=False, default=str),
+                            file=file,
+                        )
+                else:
                     print(
                         json_dumps(out, indent=4, ensure_ascii=False, default=str),
                         file=stdout,

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -39,7 +39,13 @@ import pkg_resources  # part of setuptools
 from schema_salad.exceptions import ValidationException
 from schema_salad.ref_resolver import Loader, file_uri, uri_file_path
 from schema_salad.sourceline import cmap, strip_dup_lineno
-from schema_salad.utils import ContextType, FetcherCallableType, json_dumps, yaml_no_ts
+from schema_salad.utils import (
+    ContextType,
+    FetcherCallableType,
+    json_dump,
+    json_dumps,
+    yaml_no_ts,
+)
 
 import ruamel.yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
@@ -415,7 +421,7 @@ def init_job_order(
     args: argparse.Namespace,
     process: Process,
     loader: Loader,
-    stdout: Union[TextIO, StreamWriter],
+    stdout: IO[str],
     print_input_deps: bool = False,
     relative_deps: str = "primary",
     make_fs_access: Callable[[str], StdFsAccess] = StdFsAccess,
@@ -438,7 +444,7 @@ def init_job_order(
             file_uri(os.getcwd()) + "/",
         )
         if args.tool_help:
-            toolparser.print_help(cast(IO[str], stdout))
+            toolparser.print_help(stdout)
             exit(0)
         cmd_line = vars(toolparser.parse_args(args.job_order))
         for record_name in records:
@@ -564,7 +570,7 @@ def make_relative(base: str, obj: CWLObjectType) -> None:
 def printdeps(
     obj: CWLObjectType,
     document_loader: Loader,
-    stdout: Union[TextIO, StreamWriter],
+    stdout: IO[str],
     relative_deps: str,
     uri: str,
     basedir: Optional[str] = None,
@@ -577,7 +583,7 @@ def printdeps(
     elif relative_deps == "cwd":
         base = os.getcwd()
     visit_class(deps, ("File", "Directory"), functools.partial(make_relative, base))
-    print(json_dumps(deps, indent=4, default=str), file=stdout)
+    json_dump(deps, stdout, indent=4, default=str)
 
 
 def prov_deps(
@@ -641,10 +647,10 @@ def print_pack(
     """Return a CWL serialization of the CWL document in JSON."""
     packed = pack(loadingContext, uri)
     if len(cast(Sized, packed["$graph"])) > 1:
-        return json_dumps(packed, indent=4, default=str)
-    return json_dumps(
-        cast(MutableSequence[CWLObjectType], packed["$graph"])[0], indent=4, default=str
-    )
+        target = packed
+    else:
+        target = cast(MutableSequence[CWLObjectType], packed["$graph"])[0]
+    return json_dumps(target, indent=4, default=str)
 
 
 def supported_cwl_versions(enable_dev: bool) -> List[str]:
@@ -763,9 +769,7 @@ def setup_loadingContext(
     return loadingContext
 
 
-def make_template(
-    tool: Process,
-) -> None:
+def make_template(tool: Process, target: IO[str]) -> None:
     """Make a template CWL input object for the give Process."""
 
     def my_represent_none(
@@ -783,7 +787,7 @@ def make_template(
     yaml.block_seq_indent = 2
     yaml.dump(
         generate_input_template(tool),
-        sys.stdout,
+        target,
     )
 
 
@@ -945,7 +949,7 @@ def check_working_directories(
 
 def print_targets(
     tool: Process,
-    stdout: Union[TextIO, StreamWriter],
+    stdout: IO[str],
     loading_context: LoadingContext,
     prefix: str = "",
 ) -> None:
@@ -982,7 +986,7 @@ def main(
     args: Optional[argparse.Namespace] = None,
     job_order_object: Optional[CWLObjectType] = None,
     stdin: IO[Any] = sys.stdin,
-    stdout: Optional[Union[TextIO, StreamWriter]] = None,
+    stdout: Optional[IO[str]] = None,
     stderr: IO[Any] = sys.stderr,
     versionfunc: Callable[[], str] = versionstring,
     logger_handler: Optional[logging.Handler] = None,
@@ -992,7 +996,7 @@ def main(
     runtimeContext: Optional[RuntimeContext] = None,
     input_required: bool = True,
 ) -> int:
-    if not stdout:  # force UTF-8 even if the console is configured differently
+    if stdout is None:  # force UTF-8 even if the console is configured differently
         if hasattr(sys.stdout, "encoding") and sys.stdout.encoding.upper() not in (
             "UTF-8",
             "UTF8",
@@ -1000,9 +1004,10 @@ def main(
             if hasattr(sys.stdout, "detach"):
                 stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
             else:
-                stdout = getwriter("utf-8")(sys.stdout)  # type: ignore
+                stdout = getwriter("utf-8")(sys.stdout)  # type: ignore[assignment,arg-type]
         else:
             stdout = sys.stdout
+        stdout = cast(IO[str], stdout)
 
     _logger.removeHandler(defaultStreamHandler)
     stderr_handler = logger_handler
@@ -1151,15 +1156,13 @@ def main(
                 )
 
             if args.print_pre:
-                print(
-                    json_dumps(
-                        processobj,
-                        indent=4,
-                        sort_keys=True,
-                        separators=(",", ": "),
-                        default=str,
-                    ),
-                    file=stdout,
+                json_dump(
+                    processobj,
+                    stdout,
+                    indent=4,
+                    sort_keys=True,
+                    separators=(",", ": "),
+                    default=str,
                 )
                 return 0
 
@@ -1179,7 +1182,7 @@ def main(
                     raise main_missing_exc
 
             if args.make_template:
-                make_template(tool)
+                make_template(tool, stdout)
                 return 0
 
             if args.validate:
@@ -1225,15 +1228,13 @@ def main(
             if args.print_subgraph:
                 if "name" in tool.tool:
                     del tool.tool["name"]
-                print(
-                    json_dumps(
-                        tool.tool,
-                        indent=4,
-                        sort_keys=True,
-                        separators=(",", ": "),
-                        default=str,
-                    ),
-                    file=stdout,
+                json_dump(
+                    tool.tool,
+                    stdout,
+                    indent=4,
+                    sort_keys=True,
+                    separators=(",", ": "),
+                    default=str,
                 )
                 return 0
 
@@ -1398,19 +1399,15 @@ def main(
                 # Unsetting the Generation from final output object
                 visit_class(out, ("File",), MutationManager().unset_generation)
 
-                if args.output_write:
-                    with open(args.output_write, "w") as file:
-                        print(
-                            json_dumps(out, indent=4, ensure_ascii=False, default=str),
-                            file=file,
+                if args.write_summary:
+                    with open(args.write_summary, "w") as output_file:
+                        json_dump(
+                            out, output_file, indent=4, ensure_ascii=False, default=str
                         )
                 else:
-                    print(
-                        json_dumps(out, indent=4, ensure_ascii=False, default=str),
-                        file=stdout,
-                    )
-                if hasattr(stdout, "flush"):
-                    stdout.flush()
+                    json_dump(out, stdout, indent=4, ensure_ascii=False, default=str)
+                    if hasattr(stdout, "flush"):
+                        stdout.flush()
 
             if status != "success":
                 _logger.warning("Final process status is %s", status)

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1398,10 +1398,11 @@ def main(
                 # Unsetting the Generation from final output object
                 visit_class(out, ("File",), MutationManager().unset_generation)
 
-                print(
-                    json_dumps(out, indent=4, ensure_ascii=False, default=str),
-                    file=stdout,
-                )
+                if not args.no_print_final_output:
+                    print(
+                        json_dumps(out, indent=4, ensure_ascii=False, default=str),
+                        file=stdout,
+                    )
                 if hasattr(stdout, "flush"):
                     stdout.flush()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1348,6 +1348,26 @@ def test_cache_relative_paths(tmp_path: Path, factor: str) -> None:
     assert (tmp_path / "cwltool_cache" / "27903451fc1ee10c148a0bdeb845b2cf").exists()
 
 
+def test_no_print_final_output() -> None:
+    """Test --no-print-final-output option works."""
+    commands = [
+        get_data("tests/wf/no-parameters-echo.cwl"),
+    ]
+    error_code, stdout, stderr = get_main_output(commands)
+    stderr = re.sub(r"\s\s+", " ", stderr)
+    assert error_code == 0, stderr
+
+    commands_no = [
+        "--no-print-final-output",
+        get_data("tests/wf/no-parameters-echo.cwl"),
+    ]
+    error_code, stdout_no, stderr = get_main_output(commands_no)
+    stderr = re.sub(r"\s\s+", " ", stderr)
+    assert error_code == 0, stderr
+
+    assert len(stdout_no) < len(stdout)
+
+
 @needs_docker
 def test_compute_checksum() -> None:
     runtime_context = RuntimeContext()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1348,8 +1348,8 @@ def test_cache_relative_paths(tmp_path: Path, factor: str) -> None:
     assert (tmp_path / "cwltool_cache" / "27903451fc1ee10c148a0bdeb845b2cf").exists()
 
 
-def test_no_print_final_output() -> None:
-    """Test --no-print-final-output option works."""
+def test_output_write() -> None:
+    """Test --output-write option works."""
     commands = [
         get_data("tests/wf/no-parameters-echo.cwl"),
     ]
@@ -1358,14 +1358,18 @@ def test_no_print_final_output() -> None:
     assert error_code == 0, stderr
 
     commands_no = [
-        "--no-print-final-output",
+        "--output-write",
+        "final-output.json",
         get_data("tests/wf/no-parameters-echo.cwl"),
     ]
     error_code, stdout_no, stderr = get_main_output(commands_no)
     stderr = re.sub(r"\s\s+", " ", stderr)
     assert error_code == 0, stderr
 
-    assert len(stdout_no) < len(stdout)
+    with open("final-output.json") as f:
+        final_output_str = f.read()
+
+    assert len(stdout_no) + len(final_output_str) == len(stdout)
 
 
 @needs_docker

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1348,8 +1348,8 @@ def test_cache_relative_paths(tmp_path: Path, factor: str) -> None:
     assert (tmp_path / "cwltool_cache" / "27903451fc1ee10c148a0bdeb845b2cf").exists()
 
 
-def test_output_write() -> None:
-    """Test --output-write option works."""
+def test_write_summary(tmp_path: Path) -> None:
+    """Test --write-summary."""
     commands = [
         get_data("tests/wf/no-parameters-echo.cwl"),
     ]
@@ -1357,16 +1357,17 @@ def test_output_write() -> None:
     stderr = re.sub(r"\s\s+", " ", stderr)
     assert error_code == 0, stderr
 
+    final_output_path = str(tmp_path / "final-output.json")
     commands_no = [
-        "--output-write",
-        "final-output.json",
+        "--write-summary",
+        final_output_path,
         get_data("tests/wf/no-parameters-echo.cwl"),
     ]
     error_code, stdout_no, stderr = get_main_output(commands_no)
     stderr = re.sub(r"\s\s+", " ", stderr)
     assert error_code == 0, stderr
 
-    with open("final-output.json") as f:
+    with open(final_output_path) as f:
         final_output_str = f.read()
 
     assert len(stdout_no) + len(final_output_str) == len(stdout)

--- a/tests/test_iwdr.py
+++ b/tests/test_iwdr.py
@@ -49,7 +49,7 @@ def test_directory_literal_with_real_inputs_inside(tmp_path: Path) -> None:
     """Cope with unmoveable files in the output directory created by Docker+IWDR."""
     err_code, _, _ = get_main_output(
         [
-            "--out",
+            "--outdir",
             str(tmp_path),
             get_data("tests/iwdr_dir_literal_real_file.cwl"),
             "--example={}".format(get_data("tests/__init__.py")),
@@ -62,7 +62,7 @@ def test_bad_listing_expression(tmp_path: Path) -> None:
     """Confirm better error message for bad listing expression."""
     err_code, _, stderr = get_main_output(
         [
-            "--out",
+            "--outdir",
             str(tmp_path),
             get_data("tests/iwdr_bad_expr.cwl"),
             "--example={}".format(get_data("tests/__init__.py")),

--- a/tests/test_iwdr.py
+++ b/tests/test_iwdr.py
@@ -49,7 +49,7 @@ def test_directory_literal_with_real_inputs_inside(tmp_path: Path) -> None:
     """Cope with unmoveable files in the output directory created by Docker+IWDR."""
     err_code, _, _ = get_main_output(
         [
-            "--outdir",
+            "--out",
             str(tmp_path),
             get_data("tests/iwdr_dir_literal_real_file.cwl"),
             "--example={}".format(get_data("tests/__init__.py")),
@@ -62,7 +62,7 @@ def test_bad_listing_expression(tmp_path: Path) -> None:
     """Confirm better error message for bad listing expression."""
     err_code, _, stderr = get_main_output(
         [
-            "--outdir",
+            "--out",
             str(tmp_path),
             get_data("tests/iwdr_bad_expr.cwl"),
             "--example={}".format(get_data("tests/__init__.py")),


### PR DESCRIPTION
The goal of this PR is to allow users to hide the final output json. For large workflows (particularly workflows with scattering) this can be absolutely massive. If the workflow completes successfully this isn't necessarily a problem. However, if the workflow fails, users will need to scroll up past the final output so they can see the error message(s).

The problem I'm finding is that (despite my urging) users are apparently unable or unwilling to scroll up...

The solution I've chosen here simply adds a CLI flag --no-print-final-output which hides the final output. Note that using --provenance, this information is still available at provenance/workflow/final-output.json

Another solution is instead of using print, the code could use the python logging API. Then developers using the python API could use a logging filter to hide the final output. However, this would not help CLI users.

Another solution is to neither print nor log the final output, but instead to write it directly to a file. However, as noted above, this basically already exists at provenance/workflow/final-output.json