### PR TITLE
fix compute_checksums during cache check for input File with literal default

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -866,7 +866,7 @@ class CommandLineTool(Process):
                         and "checksum" in e
                         and e["checksum"] != "sha1$hash"
                     ):
-                        return cast(Optional[str], e["checksum"])
+                        return cast(str, e["checksum"])
                 return None
 
             def remove_prefix(s: str, prefix: str) -> str:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1325,6 +1325,28 @@ def test_cache_relative_paths(tmp_path: Path, factor: str) -> None:
     assert (tmp_path / "cwltool_cache" / "27903451fc1ee10c148a0bdeb845b2cf").exists()
 
 
+@pytest.mark.parametrize("factor", test_factors)
+def test_cache_default_literal_file(tmp_path: Path, factor: str) -> None:
+    """Confirm that running a CLT with a default literal file with caching succeeds."""
+    test_file = "tests/wf/extract_region_specs.cwl"
+    cache_dir = str(tmp_path / "cwltool_cache")
+    commands = factor.split()
+    commands.extend(
+        [
+            "--out",
+            str(tmp_path / "out"),
+            "--cachedir",
+            cache_dir,
+            get_data(test_file),
+        ]
+    )
+    error_code, _, stderr = get_main_output(commands)
+
+    stderr = re.sub(r"\s\s+", " ", stderr)
+    assert "completed success" in stderr
+    assert error_code == 0
+
+
 def test_write_summary(tmp_path: Path) -> None:
     """Test --write-summary."""
     commands = [

--- a/tests/wf/extract_region_specs.cwl
+++ b/tests/wf/extract_region_specs.cwl
@@ -1,0 +1,21 @@
+{
+"cwlVersion": "v1.0",
+"class": "CommandLineTool",
+"inputs": [
+    {
+        "type": "File",
+        "default": {
+            "class": "File",
+            "basename": "extract_regions.py",
+            "contents": "#!/usr/bin/env python3\n\nfrom __future__ import print_function, division\nimport sys\n\ninput_filename = sys.argv[1]\nif len(sys.argv) == 3:\n    fuzz = int(sys.argv[2])\nelse:\n    fuzz = 0\ninput_file = open(input_filename)\n\ncount = 0\nfor line in input_file:\n    if not line.startswith(\">\"):\n        continue\n    count += 1\n    contig_regions_file = open(\"contig_regions{}.txt\".format(count), \"w\")\n    proteins_list_file = open(\"proteins{}.txt\".format(count), \"w\")\n    fields = line.split(\"|\")\n    protein_id = fields[0][1:]\n    contig_id = fields[1]\n    r_start = int(fields[6])\n    if r_start > fuzz:\n        r_start = r_start - fuzz\n    r_end = int(fields[7]) + fuzz\n    print(\"{}:{}-{}\".format(contig_id, r_start, r_end), file=contig_regions_file)\n    print(protein_id, file=proteins_list_file)\n    contig_regions_file.close()\n    proteins_list_file.close()\n"
+        },
+        "inputBinding": {
+            "position": 1
+        },
+        "id": "scripts"
+    }
+],
+"outputs": [
+],
+"baseCommand": "cat"
+}


### PR DESCRIPTION
Seems to have popped up due to a literal `default` `class: File` inside a CommandLineTool.

- [x] add quick, minimal test case from https://matrix.to/#/!RQMxrGNGkeDmWHOaEs:gitter.im/$bSBAQD3g8YvsFupIQdp_0p6KCaqx_pGM-kdRilVWGlU