### PR TITLE
use device indices for docker --gpus

### DIFF
--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -399,7 +399,9 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             runtime.append("--rm")
 
         if self.builder.resources.get("cudaDeviceCount"):
-            runtime.append("--gpus=" + str(self.builder.resources["cudaDeviceCount"]))
+            count = int(self.builder.resources["cudaDeviceCount"])
+            indices = ",".join([str(x) for x in range(count)])
+            runtime.append("--gpus=" + indices)
 
         cidfile_path = None  # type: Optional[str]
         # add parameters to docker to write a container ID file

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -991,8 +991,8 @@ hints:
 
         cudaReq, _ = self.get_requirement("http://commonwl.org/cwltool#CUDARequirement")
         if cudaReq:
-            request["cudaDeviceCountMin"] = 1
-            request["cudaDeviceCountMax"] = 1
+            request["cudaDeviceCountMin"] = cudaReq.get("cudaDeviceCountMin", 1)
+            request["cudaDeviceCountMax"] = cudaReq.get("cudaDeviceCountMax", 1)
 
         for rsc, a in (
             (resourceReq, "cores"),

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -991,8 +991,12 @@ hints:
 
         cudaReq, _ = self.get_requirement("http://commonwl.org/cwltool#CUDARequirement")
         if cudaReq:
-            request["cudaDeviceCountMin"] = cudaReq.get("cudaDeviceCountMin", 1)
-            request["cudaDeviceCountMax"] = cudaReq.get("cudaDeviceCountMax", 1)
+            request["cudaDeviceCountMin"] = cast(
+                Union[int, float, str], cudaReq.get("cudaDeviceCountMin", 1)
+            )
+            request["cudaDeviceCountMax"] = cast(
+                Union[int, float, str], cudaReq.get("cudaDeviceCountMax", 1)
+            )
 
         for rsc, a in (
             (resourceReq, "cores"),


### PR DESCRIPTION
The logic for supporting cuda seems to mix up the number of devices (the 'count') and the device indices in several places. In particular, when running with docker `--gpus=1` is passed, which doesn't work on a machine with only a single gpu (i.e. device index 0). This might not be noticed when running on a machine with two or more gpus. This PR fixes the bug and otherwise leaves the API unchanged.

More generally, I think it would be better to expose the device indices directly, i.e. rename `cudaDeviceCountMin` and `cudaDeviceCountMax` to `cudaDeviceIndexMin` and `cudaDeviceIndexMax`. This would be very useful when combining scattering on a machine with multiple gpus, where it can be faster to restrict each calculation to a single gpu and cycle through them in a round robin fashion.