### PR TITLE
[doc] Add autolabels so intersphinx can link to anchors like index#install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ value
 
 # Folder created when using make
 cwltool_deps
+docs/_build/
+docs/autoapi/
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ author = "Peter Amstutz and Common Workflow Language Project contributors"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.inheritance_diagram",
     "autoapi.extension",
@@ -45,6 +46,8 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinxcontrib.autoprogram",
 ]
+
+autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
Related to https://github.com/common-workflow-language/user_guide/issues/334

The HTML build of Sphinx creates an inverted list of links (like a hashmap? or a dict), which can be used by extensions like `intersphinx` for linking between Sphinx sites.

In the issue linked, it is not possible to link to the cwltool installation anchor section, as it's not included in the inverted objects list (test with `python -m sphinx.ext.intersphinx https://cwltool.readthedocs.io/en/latest/objects.inv`).

With this change, the anchor items must be unique (I believe they are all unique at the moment, no errors after this change), and they are included in the `.inv` file during the HTML build, and the linked PR can successfully use it as a link.

Cheers
Bruno