### PR TITLE
CWLProv: add directory basename to the provenance metadata

### DIFF
--- a/cwltool/provenance_profile.py
+++ b/cwltool/provenance_profile.py
@@ -386,6 +386,10 @@ class ProvenanceProfile:
                 (PROV_TYPE, RO["Folder"]),
             ],
         )
+
+        if "basename" in value:
+            coll.add_attributes({CWLPROV["basename"]: cast(str, value["basename"])})
+
         # ORE description of ro:Folder, saved separately
         coll_b = dir_bundle.entity(
             dir_id,

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -539,6 +539,7 @@ def check_prov(
             assert (d, RDF.type, PROV.Dictionary) in g
             assert (d, RDF.type, PROV.Collection) in g
             assert (d, RDF.type, PROV.Entity) in g
+            assert len(list(g.objects(d, CWLPROV.basename))) == 1
 
             files = set()
             for entry in g.objects(d, PROV.hadDictionaryMember):


### PR DESCRIPTION
Changes the code to add a "cwlprov:basename" entry for directories (currently it is only added for files).

This is needed to support reproducibility when directories need to follow a naming pattern (e.g., from `secondaryFiles`).