### PR TITLE
Update namespace in urn

### DIFF
--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -517,7 +517,7 @@ class ResearchObject:
             # TODO: Change to nih:sha-256; hashes
             #  https://tools.ietf.org/html/rfc6920#section-7
             aggregate_dict = {
-                "uri": "urn:hash::sha1:" + filename,
+                "uri": "urn:hash:sha1:" + filename,
                 "bundledAs": {
                     # The arcp URI is suitable ORE proxy; local to this Research Object.
                     # (as long as we don't also aggregate it by relative path!)


### PR DESCRIPTION
Related to #1806, the URN-double colon is updated to a single colon in order to be fully compliant to the [urn-scheme](https://www.rfc-editor.org/rfc/rfc2141)