### PR TITLE
Raise error is socket is **not** available

### DIFF
--- a/cwltool-in-docker.sh
+++ b/cwltool-in-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ -S /var/run/docker.sock ] && [ -z "$DOCKER_HOST" ]; then
+if ! [ -S /var/run/docker.sock ] && [ -z "$DOCKER_HOST" ]; then
   >&2 echo 'ERROR: cwltool cannot work inside a container without access to docker'
   >&2 echo 'Launch the container with the option -v /var/run/docker.sock:/var/run/docker.sock'
   # shellcheck disable=SC2016


### PR DESCRIPTION
I was working with the `cwltool` container image, and I was wondering if the intent with the `cwltool-in-docker.sh` entrypoint was to raise an error if both the Docker socket is unavailable and `DOCKER_HOST` is unset. I could be completely wrong, but I wanted to check just in case. 