### PR TITLE
Executor clears any saved result when execute is called.

### DIFF
--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -84,8 +84,8 @@ class JobExecutor(metaclass=ABCMeta):
     ) -> Tuple[Union[Optional[CWLObjectType]], str]:
         """Execute the process."""
 
-        self.final_output = []  # type: MutableSequence[Optional[CWLObjectType]]
-        self.final_status = []  # type: List[str]
+        self.final_output = []
+        self.final_status = []
 
         if not runtime_context.basedir:
             raise WorkflowException("Must provide 'basedir' in runtimeContext")

--- a/cwltool/executors.py
+++ b/cwltool/executors.py
@@ -83,6 +83,10 @@ class JobExecutor(metaclass=ABCMeta):
         logger: logging.Logger = _logger,
     ) -> Tuple[Union[Optional[CWLObjectType]], str]:
         """Execute the process."""
+
+        self.final_output = []  # type: MutableSequence[Optional[CWLObjectType]]
+        self.final_status = []  # type: List[str]
+
         if not runtime_context.basedir:
             raise WorkflowException("Must provide 'basedir' in runtimeContext")
 


### PR DESCRIPTION
The executor interface is instanced rather than a constructor interface, and the most recent results are saved on the object as final_output and final_status.  We should be able to invoke the executor more than once, however the current executor will not overwrite previously recorded results with new results.  This change clears final_output and final_status each time execute() is called so that new results can be recorded.