### PR TITLE
guard `import pwd` for windows

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -21,12 +21,13 @@ from cwl_utils import expression
 from cwl_utils.file_formats import check_format
 from mypy_extensions import mypyc_attr
 from rdflib import Graph
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.avro.schema import Names, Schema, make_avsc_object
 from schema_salad.exceptions import ValidationException
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import convert_to_dict, json_dumps
 from schema_salad.validate import validate
+
+from ruamel.yaml.comments import CommentedMap
 
 from .errors import WorkflowException
 from .loghandler import _logger

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -33,13 +33,14 @@ from typing import (
 
 import shellescape
 from mypy_extensions import mypyc_attr
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.avro.schema import Schema
 from schema_salad.exceptions import ValidationException
 from schema_salad.ref_resolver import file_uri, uri_file_path
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 from schema_salad.validate import validate_ex
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .builder import (
     INPUT_OBJ_VOCAB,

--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -18,11 +18,12 @@ from typing import (
     Union,
 )
 
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.avro.schema import Names
 from schema_salad.ref_resolver import Loader
 from schema_salad.utils import FetcherCallableType
 from typing_extensions import Literal
+
+from ruamel.yaml.comments import CommentedMap
 
 from .mpi import MpiConfig
 from .pathmapper import PathMapper

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -4,9 +4,10 @@ from typing import IO, Any, Dict, Iterator, Optional, TextIO, Union, cast
 
 from rdflib import Graph
 from rdflib.query import ResultRow
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.jsonld_context import makerdf
 from schema_salad.utils import ContextType
+
+from ruamel.yaml.comments import CommentedMap
 
 from .cwlviewer import CWLViewer
 from .process import Process

--- a/cwltool/load_tool.py
+++ b/cwltool/load_tool.py
@@ -21,7 +21,6 @@ from typing import (
 )
 
 from cwl_utils.parser import cwl_v1_2, cwl_v1_2_utils
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.exceptions import ValidationException
 from schema_salad.fetcher import Fetcher
 from schema_salad.ref_resolver import Loader, file_uri
@@ -34,6 +33,8 @@ from schema_salad.utils import (
     ResolveType,
     json_dumps,
 )
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from . import CWL_CONTENT_TYPES, process, update
 from .context import LoadingContext

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -34,9 +34,6 @@ from typing import (
 import argcomplete
 import coloredlogs
 import pkg_resources  # part of setuptools
-import ruamel.yaml
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
-from ruamel.yaml.main import YAML
 from schema_salad.exceptions import ValidationException
 from schema_salad.ref_resolver import Loader, file_uri, uri_file_path
 from schema_salad.sourceline import cmap, strip_dup_lineno
@@ -47,6 +44,10 @@ from schema_salad.utils import (
     json_dumps,
     yaml_no_ts,
 )
+
+import ruamel.yaml
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.main import YAML
 
 from . import CWL_CONTENT_TYPES, workflow
 from .argparser import arg_parser, generate_parser, get_default_args

--- a/cwltool/pack.py
+++ b/cwltool/pack.py
@@ -14,9 +14,10 @@ from typing import (
     cast,
 )
 
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.ref_resolver import Loader, SubLoader
 from schema_salad.utils import ResolveType
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .context import LoadingContext
 from .load_tool import fetch_document, resolve_and_validate_document

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -36,7 +36,6 @@ from cwl_utils import expression
 from mypy_extensions import mypyc_attr
 from pkg_resources import resource_stream
 from rdflib import Graph
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.avro.schema import (
     Names,
     Schema,
@@ -49,6 +48,8 @@ from schema_salad.schema import load_schema, make_avro_schema, make_valid_avro
 from schema_salad.sourceline import SourceLine, strip_dup_lineno
 from schema_salad.utils import convert_to_dict
 from schema_salad.validate import avro_type_name, validate_ex
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .builder import INPUT_OBJ_VOCAB, Builder
 from .context import LoadingContext, RuntimeContext, getdefault

--- a/cwltool/procgenerator.py
+++ b/cwltool/procgenerator.py
@@ -1,9 +1,10 @@
 import copy
 from typing import Dict, Optional, Tuple, cast
 
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.exceptions import ValidationException
 from schema_salad.sourceline import indent
+
+from ruamel.yaml.comments import CommentedMap
 
 from .context import LoadingContext, RuntimeContext
 from .errors import WorkflowException

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -8,6 +8,7 @@ import copy
 import datetime
 import hashlib
 import os
+
 try:
     import pwd
 except ImportError:

--- a/cwltool/provenance.py
+++ b/cwltool/provenance.py
@@ -8,7 +8,12 @@ import copy
 import datetime
 import hashlib
 import os
-import pwd
+try:
+    import pwd
+except ImportError:
+    # Guard against `from .provenance import ...` on windows.
+    # See windows_check() in main.py
+    pass
 import re
 import shutil
 import tempfile

--- a/cwltool/update.py
+++ b/cwltool/update.py
@@ -11,10 +11,11 @@ from typing import (
     cast,
 )
 
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.exceptions import ValidationException
 from schema_salad.ref_resolver import Loader
 from schema_salad.sourceline import SourceLine
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .loghandler import _logger
 from .utils import CWLObjectType, CWLOutputType, aslist, visit_class, visit_field

--- a/cwltool/validate_js.py
+++ b/cwltool/validate_js.py
@@ -19,7 +19,6 @@ from cwl_utils.errors import SubstitutionError
 from cwl_utils.expression import scanner as scan_expression
 from cwl_utils.sandboxjs import code_fragment_to_js, exec_js_process
 from pkg_resources import resource_stream
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.avro.schema import (
     ArraySchema,
     EnumSchema,
@@ -30,6 +29,8 @@ from schema_salad.avro.schema import (
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 from schema_salad.validate import validate_ex
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .errors import WorkflowException
 from .loghandler import _logger

--- a/cwltool/workflow.py
+++ b/cwltool/workflow.py
@@ -17,9 +17,10 @@ from typing import (
 )
 from uuid import UUID
 
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.exceptions import ValidationException
 from schema_salad.sourceline import SourceLine, indent
+
+from ruamel.yaml.comments import CommentedMap
 
 from . import command_line_tool, context, procgenerator
 from .checker import circular_dependency_checker, loop_checker, static_checker

--- a/tests/test_anon_types.py
+++ b/tests/test_anon_types.py
@@ -1,11 +1,11 @@
 from typing import cast
 
 import pytest
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.sourceline import cmap
 
 from cwltool.command_line_tool import CommandLineTool
 from cwltool.context import LoadingContext
+from ruamel.yaml.comments import CommentedMap
 
 snippet = cast(
     CommentedMap,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,7 +15,6 @@ import pydot
 import pytest
 from cwl_utils.errors import JavascriptException
 from cwl_utils.sandboxjs import param_re
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.exceptions import ValidationException
 
 import cwltool.checker
@@ -29,6 +28,7 @@ from cwltool.errors import WorkflowException
 from cwltool.main import main
 from cwltool.process import CWL_IANA
 from cwltool.utils import CWLObjectType, dedup
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .util import get_data, get_main_output, needs_docker, working_directory
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -8,7 +8,6 @@ from typing import Any, Generator, List, MutableMapping, Optional, Tuple
 
 import pkg_resources
 import pytest
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from schema_salad.avro.schema import Names
 from schema_salad.utils import yaml_no_ts
 
@@ -19,6 +18,7 @@ from cwltool.command_line_tool import CommandLineTool
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.main import main
 from cwltool.mpi import MpiConfig, MPIRequirementName
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from .util import get_data, working_directory
 

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import IO, Any, List, cast
 
 import pytest
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.sourceline import cmap
 
 from cwltool.command_line_tool import CommandLineTool
@@ -13,6 +12,7 @@ from cwltool.main import main
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.update import INTERNAL_VERSION
 from cwltool.utils import CWLObjectType
+from ruamel.yaml.comments import CommentedMap
 
 from .util import needs_docker
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.sourceline import cmap
 
 from cwltool.command_line_tool import CommandLineTool
@@ -13,6 +12,7 @@ from cwltool.errors import WorkflowException
 from cwltool.job import JobBase
 from cwltool.update import INTERNAL_VERSION, ORIGINAL_CWLVERSION
 from cwltool.utils import CWLObjectType
+from ruamel.yaml.comments import CommentedMap
 
 from .util import get_data
 

--- a/tests/test_subclass_mypyc.py
+++ b/tests/test_subclass_mypyc.py
@@ -7,7 +7,6 @@ Especially if those classes are (or become) compiled with mypyc.
 import pickle
 
 import pytest
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.avro import schema
 
 from cwltool.builder import Builder
@@ -15,6 +14,7 @@ from cwltool.command_line_tool import CommandLineTool, ExpressionTool
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.update import INTERNAL_VERSION
+from ruamel.yaml.comments import CommentedMap
 
 from .test_anon_types import snippet
 

--- a/tests/test_tmpdir.py
+++ b/tests/test_tmpdir.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import List, cast
 
 import pytest
-from ruamel.yaml.comments import CommentedMap
 from schema_salad.avro import schema
 from schema_salad.sourceline import cmap
 
@@ -19,6 +18,7 @@ from cwltool.pathmapper import MapperEnt
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.update import INTERNAL_VERSION, ORIGINAL_CWLVERSION
 from cwltool.utils import create_tmp_dir
+from ruamel.yaml.comments import CommentedMap
 
 from .util import get_data, needs_docker
 


### PR DESCRIPTION
Running CWL on windows currently requires Windows Subsystem for Linux, but due to this import statement, windows users who have not yet installed WSL (or cannot install WSL due to administrator privileges) cannot even import most modules.

Since pwd is only used in provenance.py on one line https://github.com/common-workflow-language/cwltool/blob/main/cwltool/provenance.py#L80, guarding the `import pwd` will allow all other use cases that don't involve running with provenance.