### PR TITLE
always print floats on the command line with decimal notation

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -2,7 +2,8 @@
 import copy
 import logging
 import math
-from typing import (  # pylint: disable=unused-import
+from decimal import Decimal
+from typing import (
     IO,
     TYPE_CHECKING,
     Any,
@@ -28,6 +29,8 @@ from schema_salad.utils import convert_to_dict, json_dumps
 from schema_salad.validate import validate
 
 from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.representer import RoundTripRepresenter
+from ruamel.yaml.scalarfloat import ScalarFloat
 
 from .errors import WorkflowException
 from .loghandler import _logger
@@ -604,6 +607,12 @@ class Builder(HasReqsHints):
                     '{} object missing "path": {}'.format(value["class"], value)
                 )
             return value["path"]
+        elif isinstance(value, ScalarFloat):
+            rep = RoundTripRepresenter()
+            dec_value = Decimal(rep.represent_scalar_float(value).value)
+            if "E" in str(dec_value):
+                return str(dec_value.quantize(1))
+            return str(dec_value)
         else:
             return str(value)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1829,3 +1829,14 @@ def test_res_req_expr_float_1_2() -> None:
     assert exit_code == 0, stderr
     assert json.loads(stdout)["result"]["outdirSize"] >= 708
     assert json.loads(stdout)["result"]["tmpdirSize"] >= 708
+
+
+def test_very_small_and_large_floats() -> None:
+    """Confirm that very small or large numbers are not transformed into scientific notation."""
+    exit_code, stdout, stderr = get_main_output(
+        [
+            get_data("tests/wf/floats_small_and_large.cwl"),
+        ]
+    )
+    assert exit_code == 0, stderr
+    assert json.loads(stdout)["result"] == "0.00001 0.0000123 123000 1230000"

--- a/tests/wf/floats_small_and_large.cwl
+++ b/tests/wf/floats_small_and_large.cwl
@@ -1,0 +1,39 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+requirements:
+  InlineJavascriptRequirement: {}
+
+inputs:
+ annotation_prokka_evalue:
+   type: float
+   default: 0.00001
+   inputBinding: {}
+
+ annotation_prokka_evalue2:
+   type: float
+   default: 1.23e-05
+   inputBinding: {}
+
+ annotation_prokka_evalue3:
+   type: float
+   default: 1.23e5
+   inputBinding: {}
+
+ annotation_prokka_evalue4:
+   type: float
+   default: 1230000
+   inputBinding: {}
+
+
+arguments: [ -n ]
+
+stdout: dump
+
+outputs:
+  result:
+    type: string
+    outputBinding:
+      glob: dump
+      loadContents: true
+      outputEval: $(self[0].contents)


### PR DESCRIPTION
Fixes #1831 

- [x] Always convert scientific notation provided floats to decimal representation as [per the spec](https://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineBinding)