### PR TITLE
CWLProv snapshots: capture the workflow even if the cwl:tool trick in the input object is used

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -1389,7 +1389,9 @@ def main(
         ):
             research_obj = runtimeContext.research_obj
             if loadingContext.loader is not None:
-                research_obj.generate_snapshot(prov_deps(workflowobj, loadingContext.loader, uri))
+                research_obj.generate_snapshot(
+                    prov_deps(cast(CWLObjectType, processobj), loadingContext.loader, uri)
+                )
             else:
                 _logger.warning(
                     "Unable to generate provenance snapshot "

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -84,6 +84,19 @@ def test_revsort_workflow(tmp_path: Path) -> None:
 
 
 @needs_docker
+def test_revsort_workflow_shortcut(tmp_path: Path) -> None:
+    """Confirm that using 'cwl:tool' shortcut still snapshots the CWL files."""
+    folder = cwltool(
+        tmp_path,
+        get_data("tests/wf/revsort-job-shortcut.json"),
+    )
+    check_output_object(folder)
+    check_provenance(folder)
+    assert not (folder / "snapshot" / "revsort-job-shortcut.json").exists()
+    assert len(list((folder / "snapshot").iterdir())) == 4
+
+
+@needs_docker
 def test_nested_workflow(tmp_path: Path) -> None:
     check_provenance(cwltool(tmp_path, get_data("tests/wf/nested.cwl")), nested=True)
 

--- a/tests/wf/revsort-job-shortcut.json
+++ b/tests/wf/revsort-job-shortcut.json
@@ -1,0 +1,8 @@
+{
+  "cwl:tool": "revsort.cwl",
+  "workflow_input": {
+    "class": "File",
+    "location": "whale.txt",
+    "format": "https://www.iana.org/assignments/media-types/text/plain"
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/ResearchObject/runcrate/issues/36