### PR TITLE
pass through QEMU_LD_PREFIX by default

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -582,8 +582,9 @@ class CommandLineJob(JobBase):
         env["HOME"] = self.outdir
         env["TMPDIR"] = self.tmpdir
         env["PATH"] = os.environ["PATH"]
-        if "SYSTEMROOT" in os.environ:
-            env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+        for extra in ("SYSTEMROOT", "QEMU_LD_PREFIX"):
+            if extra in os.environ:
+                env[extra] = os.environ[extra]
         return env
 
 


### PR DESCRIPTION
For systems using qemu-user-static to run foreign binaries outside of containers

Description of `QEMU_LD_PREFIX` https://lists.gnu.org/archive/html/qemu-devel/2011-07/msg02389.html