### PR TITLE
Ensure that files with identical basenames get staged to unique paths

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -264,7 +264,8 @@ def stage_files(
                     "File staging conflict, trying to stage both %s and %s to the same target %s"
                     % (targets[entry.target].resolved, entry.resolved, entry.target)
                 )
-
+    # refresh the items, since we may have updated the pathmapper due to file name clashes
+    items = pathmapper.items() if not symlink else pathmapper.items_exclude_children()
     for key, entry in items:
         if not entry.staged:
             continue

--- a/tests/test_relocate.py
+++ b/tests/test_relocate.py
@@ -33,6 +33,26 @@ def test_for_conflict_file_names(tmp_path: Path) -> None:
     out = json.loads(stream.getvalue())
     assert out["b1"]["basename"] == out["b2"]["basename"]
     assert out["b1"]["location"] != out["b2"]["location"]
+    assert Path(out["b1"]["path"]).exists()
+    assert Path(out["b2"]["path"]).exists()
+
+
+def test_for_conflict_file_names_nodocker(tmp_path: Path) -> None:
+    stream = StringIO()
+
+    assert (
+        main(
+            ["--debug", "--outdir", str(tmp_path), get_data("tests/wf/conflict.cwl")],
+            stdout=stream,
+        )
+        == 0
+    )
+
+    out = json.loads(stream.getvalue())
+    assert out["b1"]["basename"] == out["b2"]["basename"]
+    assert out["b1"]["location"] != out["b2"]["location"]
+    assert Path(out["b1"]["path"]).exists()
+    assert Path(out["b2"]["path"]).exists()
 
 
 def test_relocate_symlinks(tmp_path: Path) -> None:

--- a/tests/wf/conflict.cwl
+++ b/tests/wf/conflict.cwl
@@ -4,14 +4,13 @@ $graph:
   - class: CommandLineTool
     id: makebzz
     inputs: []
+    baseCommand: touch
     outputs:
       bzz:
         type: File
         outputBinding:
           glob: bzz
-    requirements:
-      ShellCommandRequirement: {}
-    arguments: [{shellQuote: false, valueFrom: "touch bzz"}]
+    arguments: [ bzz ]
   - class: Workflow
     id: main
     inputs: []


### PR DESCRIPTION
This error was found via [@tom-tan 's contribution to cwltest](https://github.com/common-workflow-language/cwltest/commit/4c57396b9063988a296dc99fac5ecf03b2c44302), that actually tested the existence and hashsums of all reported outputs. Thank you @tom-tan !