### PR TITLE
Update Python version support document; drop Python 3.7 (EOL)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         py-ver-major: [3]
-        py-ver-minor: [6, 7, 8, 9, 10, 11]
+        py-ver-minor: [6, 8, 9, 10, 11]
         step: [lint, unit, bandit, mypy]
         exclude:
           - py-ver-major: 3

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ and provide comprehensive validation of CWL
 files as well as provide other tools related to working with CWL.
 
 ``cwltool`` is written and tested for
-`Python <https://www.python.org/>`_ ``3.x {x = 6, 7, 8, 9, 10, 11}``
+`Python <https://www.python.org/>`_ ``3.x {x = 6, 8, 9, 10, 11}``
 
 The reference implementation consists of two packages.  The ``cwltool`` package
 is the primary Python module containing the reference implementation in the

--- a/docs/pythonversions.rst
+++ b/docs/pythonversions.rst
@@ -22,7 +22,7 @@ and downstream users before making the decision to drop support for a
 Python version before the date outlined in this policy.  The reasoning
 for dropping support for a Python version should be outlined here.
 
-As of February 2022, here are approximate cwltool support periods for
+As of 2023-07-03, here are approximate cwltool support periods for
 across Python versions:
 
 ====== ======================
@@ -30,11 +30,12 @@ Python cwltool end of support
 ====== ======================
 2.7    ended January 2020
 3.5    ended October 2020
-3.6    June 2024 (Centos 7 EOL)
-3.7    June 2023 (upstream EOL)
-3.8    April 2025 (Ubuntu 20.04 EOL)
-3.9    October 2025 (upstream EOL)
-3.10   October 2026 (upstream EOL)
+3.6    2024-06 (Centos 7 EOL)
+3.7    2023-06-27 (upstream EOL)
+3.8    2025-04-02 (Ubuntu 20.04 LTS EOL)
+3.9    2025-11-05 (upstream EOL)
+3.10   2027-04-01 (Ubuntu 22.04 LTS EOL))
+3.11   2027-11-24 (upstream EOL)
 ====== ======================
 
 Default Python version of supported Linux distributions, for reference
@@ -43,9 +44,10 @@ Default Python version of supported Linux distributions, for reference
 ====== =============================================
 Python Linux distros where it is the default version
 ====== =============================================
-3.6    Ubuntu 18.04, Centos 7
+3.6    Ubuntu 18.04 LTS, Centos 7
 3.7    Debian 10
-3.8    Ubuntu 20.04
+3.8    Ubuntu 20.04 LTS
 3.9    Debian 11
-3.10   None
+3.10   Ubuntu 22.04 LTS
+3.11   Debian 12
 ====== =============================================

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- refresh python version support
- CI: Drop Python 3.7 from testing
