### PR TITLE
Fixed race condition which happens when a job runs "too fast",

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -857,6 +857,10 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
         cid: Optional[str] = None
         while cid is None:
             time.sleep(1)
+            # This is needed to avoid a race condition where the job
+            # was so fast that it already finished when it arrives here
+            if process.returncode is None:
+                process.poll()
             if process.returncode is not None:
                 if cleanup_cidfile:
                     try:


### PR DESCRIPTION
When a podman process finishes even before reaching the monitoring method, a deadlock happens, as no one is updating `process.returncode` and spawned process is in zombie state (so, no signal is sent).

This fix adds a `process.poll()` call, so it gives the chance to fill in `process.returncode`.

Fixes: #1883