### PR TITLE
add cudaDeviceCount flag to the request requirements

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -980,7 +980,8 @@ hints:
         ):
             if rsc is None:
                 continue
-            mn = mx = None  # type: Optional[Union[int, float]]
+            mn: Optional[Union[int, float]] = None
+            mx: Optional[Union[int, float]] = None
             if rsc.get(a + "Min"):
                 with SourceLine(rsc, f"{a}Min", WorkflowException, runtimeContext.debug):
                     mn = cast(


### PR DESCRIPTION
Hello, 

I have been attempting to execute a CUDA-based workflow using the `--parallel` flag. However, I encountered the following error message:
``` 
ERROR Got workflow error: 'cudaDeviceCount'
Traceback (most recent call last):
  File "/home/donyapourn2/actions-runner/_work/workflow-inference-compiler/workflow-inference-compiler/3/envs/globalwic/lib/pypy3.9/site-packages/cwltool/executors.py", line 314, in _runner
    job.run(runtime_context, TMPDIR_LOCK)
  File "/home/donyapourn2/actions-runner/_work/workflow-inference-compiler/workflow-inference-compiler/3/envs/globalwic/lib/pypy3.9/site-packages/cwltool/job.py", line 823, in run
    self._setup(runtimeContext)
  File "/home/donyapourn2/actions-runner/_work/workflow-inference-compiler/workflow-inference-compiler/3/envs/globalwic/lib/pypy3.9/site-packages/cwltool/job.py", line 181, in _setup
    count = cuda_check(cuda_req, math.ceil(self.builder.resources["cudaDeviceCount"]))
KeyError: 'cudaDeviceCount'
```
Upon investigating the code, it appears that the [`evalResources`](https://github.com/common-workflow-language/cwltool/blob/509ffb9d6802c837ec2a818b799ef4c332c34d04/cwltool/process.py#L946) function fails to include `cudaDeviceCount` in the request. I have made necessary changes to fix the error.