### PR TITLE
use nonlocal mem_tn variable

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -513,6 +513,7 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
         mem_tm: "Optional[Timer]" = None
 
         def get_tree_mem_usage(memory_usage: MutableSequence[Optional[int]]) -> None:
+            nonlocal mem_tm
             try:
                 with monitor.oneshot():
                     children = monitor.children()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/jfennick/mambaforge-pypy3/envs/wic/lib/python3.10/site-packages/cwltool/job.py", line 518, in get_tree_mem_usage
    children = monitor.children()
  File "/home/jfennick/mambaforge-pypy3/envs/wic/lib/python3.10/site-packages/psutil/__init__.py", line 277, in wrapper
    raise NoSuchProcess(self.pid, self._name, msg=msg)
psutil.NoSuchProcess: process no longer exists (pid=31753)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jfennick/mambaforge-pypy3/envs/wic/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/home/jfennick/mambaforge-pypy3/envs/wic/lib/python3.10/threading.py", line 1378, in run
    self.function(*self.args, **self.kwargs)
  File "/home/jfennick/mambaforge-pypy3/envs/wic/lib/python3.10/site-packages/cwltool/job.py", line 531, in get_tree_mem_usage
    if mem_tm is not None:
UnboundLocalError: local variable 'mem_tm' referenced before assignment
```
Using the `--parallel` flag, the mem_fn variables in the inner and outer scopes are not the same due to a missing `global mem_tm` line.