### PR TITLE
release testing tweaks

### DIFF
--- a/release-test.sh
+++ b/release-test.sh
@@ -89,8 +89,9 @@ rm -f lib/python-wheels/setuptools* \
 	&& pip install --force-reinstall -U pip==${pipver} \
         && pip install setuptools==${setuptoolsver} wheel
 package_tar=$(find . -name "${package}*tar.gz")
-pip install "-r${DIR}/test-requirements.txt"
+pip install "-r${DIR}/test-requirements.txt" udocker
 pip install "${package_tar}${extras}"
+udocker install
 mkdir out
 tar --extract --directory=out -z -f ${package}*.tar.gz
 pushd out/${package}*

--- a/release-test.sh
+++ b/release-test.sh
@@ -55,8 +55,7 @@ fi
 
 python3 -m venv testenv2
 python3 -m venv testenv3
-python3 -m venv testenv4
-rm -Rf testenv[234]/local
+rm -Rf testenv[23]/local
 
 # Secondly we test via pip
 

--- a/release-test.sh
+++ b/release-test.sh
@@ -25,8 +25,8 @@ run_tests() {
 	"${test_prefix}"bin/py.test "--ignore=${mod_loc}/schemas/" \
 		--pyargs -x ${module} -n auto --dist=loadfile
 }
-pipver=20.3.3 # minimum required version of pip for Python 3.10
-setuptoolsver=50.0.1  # fix for "AttributeError: module 'importlib.util' has no attribute 'abc'"
+pipver=20.3.4 # minimum required version of pip for Python 3.10
+setuptoolsver=52.0.0
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 rm -Rf testenv? || /bin/true


### PR DESCRIPTION
- release: preinstall udocker so that test_udocker_should_display_memory_usage doesn't timeout
- release: testenv4 isn't needed
- release: bump minimum setuptools version slightly to match Debian 11 ('bullseye').
