### PR TITLE
fix the pickling error for IO objects

### DIFF
--- a/cwltool/context.py
+++ b/cwltool/context.py
@@ -2,7 +2,6 @@
 import copy
 import os
 import shutil
-import sys
 import tempfile
 import threading
 from typing import (
@@ -199,7 +198,7 @@ class RuntimeContext(ContextBase):
         self.default_stdout: Optional[Union[IO[bytes], TextIO]] = None
         self.default_stderr: Optional[Union[IO[bytes], TextIO]] = None
         self.validate_only: bool = False
-        self.validate_stdout: Union[IO[bytes], TextIO, IO[str]] = sys.stdout
+        self.validate_stdout: Optional[Union[IO[bytes], TextIO, IO[str]]] = None
         super().__init__(kwargs)
         if self.tmp_outdir_prefix == "":
             self.tmp_outdir_prefix = self.tmpdir_prefix

--- a/tests/test_subclass_mypyc.py
+++ b/tests/test_subclass_mypyc.py
@@ -81,3 +81,12 @@ def test_serialize_builder() -> None:
         "docker",
     )
     assert pickle.dumps(builder)
+
+
+def test_pickle_unpickle_runtime_context() -> None:
+    """We can pickle & unpickle RuntimeContext"""
+
+    runtime_context = RuntimeContext()
+    stream = pickle.dumps(runtime_context)
+    assert stream
+    assert pickle.loads(stream)


### PR DESCRIPTION
Hello, I'm trying to run a CWL workflow using Toil which involves the serialization/pickling of jobs. However the recent updates to CWL throws this stack trace below
``` 
 File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/bin/toil-cwl-runner", line 8, in <module>
    sys.exit(main())
  File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/lib/python3.10/site-packages/toil/cwl/cwltoil.py", line 3903, in main
    outobj = toil.start(wf1)
  File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/lib/python3.10/site-packages/toil/common.py", line 1406, in start
    rootJobDescription = rootJob.saveAsRootJob(self._jobStore)
  File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/lib/python3.10/site-packages/toil/job.py", line 2670, in saveAsRootJob
    self._saveJobGraph(jobStore, saveSelf=True)
  File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/lib/python3.10/site-packages/toil/job.py", line 2643, in _saveJobGraph
    job.saveBody(jobStore)
  File "/home/donyapourn2/mambaforge-pypy3/envs/toil_test/lib/python3.10/site-packages/toil/job.py", line 2532, in saveBody
    pickle.dump(self, fileHandle, pickle.HIGHEST_PROTOCOL)
TypeError: cannot pickle '_io.TextIOWrapper' object
Failure! Please scroll up and find the FIRST error message.
```
I figured out this [line](https://github.com/common-workflow-language/cwltool/pull/1915/files#diff-009429634a47cfb8122167e1c0389144eea3bea7d9d1e241ff09e3b76565e7f8R202) breaks the serialization/pickling and this PR fixes this error. 
