### PR TITLE
downgrade galaxy-tool-util to workaround issue with newer conda

### DIFF
--- a/cwltool/software_requirements.py
+++ b/cwltool/software_requirements.py
@@ -158,7 +158,7 @@ def get_container_from_software_requirements(
             [DOCKER_CONTAINER_TYPE], tool_info
         )
         if container_description:
-            return container_description.identifier
+            return cast(Optional[str], container_description.identifier)
 
     return None
 

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -5,5 +5,3 @@ types-requests
 types-setuptools
 types-psutil
 types-mock
-galaxy-tool-util>=22.1.2,<24
-galaxy-util<24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ requires = [
     "importlib_resources>=1.4",  # equivalent to Python 3.9
     "ruamel.yaml>=0.16.0,<0.18",
     "schema-salad>=8.4.20230426093816,<9",
+    "packaging<22",
     "cwl-utils>=0.19",
-    "galaxy-tool-util >= 22.1.2, < 24",
     "toml",
     "argcomplete>=1.12.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         "cwl-utils >= 0.22",
     ],
     extras_require={
-        "deps": ["galaxy-tool-util >= 22.1.2, <24", "galaxy-util <24"],
+        "deps": ["galaxy-tool-util >= 22.1.2, <23", "galaxy-util <23"],
     },
     python_requires=">=3.8, <4",
     use_scm_version=True,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,5 @@ pytest-mock>=1.10.0
 pytest-cov
 arcp>=0.2.0
 -rrequirements.txt
-galaxy-tool-util>=22.1.2,<24
-galaxy-util<24
+galaxy-tool-util>=22.1.2,<23
+galaxy-util<23

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -17,7 +17,7 @@ from .util import get_data, get_main_output, get_tool_env, needs_docker
 
 deps: Optional[ModuleType] = None
 try:
-    from galaxy.tool_util import deps
+    from galaxy.tool_util import deps  # type: ignore[no-redef]
 except ImportError:
     pass
 


### PR DESCRIPTION
This reverts commit 9144a780cc5fd62e28b11c059c99e12608135d22.

While we are waiting for https://github.com/galaxyproject/galaxy/pull/16831 to be released