### PR TITLE
software dependencies: allow newer versions of galaxy-tool-util

### DIFF
--- a/cwltool/software_requirements.py
+++ b/cwltool/software_requirements.py
@@ -12,6 +12,7 @@ import os
 import string
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     List,
     MutableMapping,
@@ -109,7 +110,7 @@ class DependenciesConfiguration:
 
 def get_dependencies(builder: HasReqsHints) -> ToolRequirements:
     (software_requirement, _) = builder.get_requirement("SoftwareRequirement")
-    dependencies: List["ToolRequirement"] = []
+    dependencies: List[Union["ToolRequirement", Dict[str, Any]]] = []
     if software_requirement and software_requirement.get("packages"):
         packages = cast(
             MutableSequence[MutableMapping[str, Union[str, MutableSequence[str]]]],
@@ -158,7 +159,7 @@ def get_container_from_software_requirements(
             [DOCKER_CONTAINER_TYPE], tool_info
         )
         if container_description:
-            return cast(Optional[str], container_description.identifier)
+            return container_description.identifier
 
     return None
 

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -5,3 +5,5 @@ types-requests
 types-setuptools
 types-psutil
 types-mock
+galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5
+galaxy-util<23.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ requires = [
     "importlib_resources>=1.4",  # equivalent to Python 3.9
     "ruamel.yaml>=0.16.0,<0.18",
     "schema-salad>=8.4.20230426093816,<9",
-    "packaging<22",
     "cwl-utils>=0.19",
+    "galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5",
     "toml",
     "argcomplete>=1.12.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,10 @@ setup(
         "cwl-utils >= 0.22",
     ],
     extras_require={
-        "deps": ["galaxy-tool-util >= 22.1.2, <23", "galaxy-util <23"],
+        "deps": [
+            "galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5",
+            "galaxy-util <23.2",
+        ],
     },
     python_requires=">=3.8, <4",
     use_scm_version=True,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,5 @@ pytest-mock>=1.10.0
 pytest-cov
 arcp>=0.2.0
 -rrequirements.txt
-galaxy-tool-util>=22.1.2,<23
-galaxy-util<23
+galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5
+galaxy-util<23.2

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -17,7 +17,7 @@ from .util import get_data, get_main_output, get_tool_env, needs_docker
 
 deps: Optional[ModuleType] = None
 try:
-    from galaxy.tool_util import deps  # type: ignore[no-redef]
+    from galaxy.tool_util import deps
 except ImportError:
     pass
 


### PR DESCRIPTION
Skip the known broken versions (23.0.1 - 23.0.5)
