### PR TITLE
skip cwl-utils 0.30

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,6 +1,6 @@
 mypy==1.6.1  # also update pyproject.toml
 ruamel.yaml>=0.16.0,<0.19
-cwl-utils>=0.22
+cwl-utils>=0.22,!=0.30
 types-requests
 types-setuptools
 types-psutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "importlib_resources>=1.4",  # equivalent to Python 3.9
     "ruamel.yaml>=0.16.0,<0.18",
     "schema-salad>=8.4.20230426093816,<9",
-    "cwl-utils>=0.19",
+    "cwl-utils>=0.22,!=0.30",
     "galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5",
     "toml",
     "argcomplete>=1.12.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ coloredlogs
 pydot>=1.4.1
 argcomplete>=1.12.0
 pyparsing!=3.0.2  # breaks --print-dot (pydot) https://github.com/pyparsing/pyparsing/issues/319
-cwl-utils>=0.22
+cwl-utils>=0.22,!=0.30

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         "pydot >= 1.4.1",
         "argcomplete",
         "pyparsing != 3.0.2",  # breaks --print-dot (pydot) https://github.com/pyparsing/pyparsing/issues/319
-        "cwl-utils >= 0.22",
+        "cwl-utils >= 0.22, != 0.30",
     ],
     extras_require={
         "deps": [


### PR DESCRIPTION
cwl-utils 0.30 breaks the `--fast-parser` with the following CWL v1.2.1 conformance tests
- `format_checking_equivalentclass`
- `filesarray_secondaryfiles`
- `input_records_file_entry_with_format`
- `record_output_file_entry_format`

https://github.com/common-workflow-language/cwltool/actions/runs/6849823212/job/18622793216?pr=1678#step:7:335