### PR TITLE
remove galaxy-tool-util from build dependency

### DIFF
--- a/cwltool.Dockerfile
+++ b/cwltool.Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git gcc python3-dev libxml2-dev libxslt-dev libc-dev linu
 
 WORKDIR /cwltool
 COPY . .
-RUN export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CWLTOOL=$(grep __version__ cwltool/_version.py  | awk -F\' '{ print $2 }') ; \
+RUN export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CWLTOOL=$(grep __version__ cwltool/_version.py  | awk -F\' '{ print $2 }' | tr -d '\\n') ; \
 	CWLTOOL_USE_MYPYC=1 MYPYPATH=mypy-stubs pip wheel --no-binary schema-salad \
 	--wheel-dir=/wheels .[deps]  # --verbose
 RUN rm /wheels/schema_salad*

--- a/cwltool/software_requirements.py
+++ b/cwltool/software_requirements.py
@@ -159,7 +159,7 @@ def get_container_from_software_requirements(
             [DOCKER_CONTAINER_TYPE], tool_info
         )
         if container_description:
-            return container_description.identifier
+            return str(container_description.identifier)
 
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires = [
     "ruamel.yaml>=0.16.0,<0.18",
     "schema-salad>=8.4.20230426093816,<9",
     "cwl-utils>=0.32",
-    "galaxy-tool-util>=22.1.2,<23.2,!=23.0.1,!=23.0.2,!=23.0.3,!=23.0.4,!=23.0.5",
     "toml",
     "argcomplete>=1.12.0",
 ]


### PR DESCRIPTION
Some of the build dependencies appear to be regular dependencies, and do not appear to be required at build time.
This may cause issues in certain specific situations. See this Dockerfile for a minimal reproducible example.
For now, this PR simply removes galaxy-tool-util from pyproject.toml (only).

```
FROM condaforge/miniforge3

# This works
# RUN conda install "python<3.10"

# Have to downgrade python to install pypy
RUN conda install "python<3.10" pypy

# Install binary system dependencies through conda (so we don't have to install compilers)
RUN conda install psutil

# This works
# RUN pip install cwltool

RUN conda install git
# Due to listing galaxy-tool-util as a build dependency,
# pip attempts to install conda-package-streaming and then zstandard from source and fails with:
# No such file or directory: 'cc'
RUN pip install cwltool@git+https://github.com/common-workflow-language/cwltool.git
```