### PR TITLE
Fix fast container job hangs

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -869,7 +869,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
                         os.remove(cidfile)
                     except OSError as exc:
                         _logger.warning("Ignored error cleaning up %s cidfile: %s", docker_exe, exc)
-                    return
+                return
             try:
                 with open(cidfile) as cidhandle:
                     cid = cidhandle.readline().strip()


### PR DESCRIPTION
Starting from Podman 4.4.0, cidfile is removed along with the container.

Always return if container is terminated so we don't stuck in the loop waiting for a file which has already been removed.

Fixes: #1961