### PR TITLE
Permit calling cwltool.main with preparsed args only even with provenance

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -682,8 +682,8 @@ ProvOut = Union[io.TextIOWrapper, WritableBagFile]
 
 def setup_provenance(
     args: argparse.Namespace,
-    argsl: List[str],
     runtimeContext: RuntimeContext,
+    argsl: Optional[List[str]] = None,
 ) -> Tuple[ProvOut, "logging.StreamHandler[ProvOut]"]:
     if not args.compute_checksum:
         _logger.error("--provenance incompatible with --no-compute-checksum")
@@ -1049,10 +1049,8 @@ def main(
 
         prov_log_stream: Optional[Union[io.TextIOWrapper, WritableBagFile]] = None
         if args.provenance:
-            if argsl is None:
-                raise Exception("argsl cannot be None")
             try:
-                prov_log_stream, prov_log_handler = setup_provenance(args, argsl, runtimeContext)
+                prov_log_stream, prov_log_handler = setup_provenance(args, runtimeContext, argsl)
             except ArgumentException:
                 return 1
 

--- a/tests/test_main_parsed_args.py
+++ b/tests/test_main_parsed_args.py
@@ -1,0 +1,40 @@
+import io
+from pathlib import Path
+
+from cwltool.argparser import arg_parser
+from cwltool.main import main
+
+from .util import get_data
+
+
+def test_main_parsed_args(tmp_path: Path) -> None:
+    """Affirm that main can be called with parsed args only."""
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    unparsed_args = [get_data("tests/echo.cwl"), "--inp", "Hello"]
+    parsed_args = arg_parser().parse_args(unparsed_args)
+
+    try:
+        assert main(args=parsed_args, stdout=stdout, stderr=stderr) == 0
+    except SystemExit as err:
+        assert err.code == 0
+
+
+def test_main_parsed_args_provenance(tmp_path: Path) -> None:
+    """Affirm that main can be called with parsed args only, requesting provenance."""
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    prov_folder = tmp_path / "provenance"  # will be created if necessary
+
+    unparsed_args = ["--provenance", str(prov_folder), get_data("tests/echo.cwl"), "--inp", "Hello"]
+    parsed_args = arg_parser().parse_args(unparsed_args)
+
+    try:
+        assert main(args=parsed_args, stdout=stdout, stderr=stderr) == 0
+    except SystemExit as err:
+        assert err.code == 0
+
+    manifest_file = prov_folder / "metadata" / "manifest.json"
+    assert manifest_file.is_file(), f"Can't find RO-Crate manifest {manifest_file}"


### PR DESCRIPTION
Permit calling `cwltool.main` with preparsed args only, even when requesting provenance.

- Parameter `argsl`, the unparsed arguments, is now optional in `cwltool.setup_provenance`. Since it has a default value it must be moved to the end of the parameter list.
- Unit tests [`test_main_parsed_args`](https://github.com/davidjsherman/cwltool/blob/08e5b9c21e05beb252f9dee2c52ea42550a24063/tests/test_main_parsed_args.py#L10-L21)  and [`test_main_parsed_args_provenance`](https://github.com/davidjsherman/cwltool/blob/08e5b9c21e05beb252f9dee2c52ea42550a24063/tests/test_main_parsed_args.py#L24-L40) verify that `cwltool.main` can be called with parsed arguments only, respectively with and without a request for provenance.

Closes #1963 