### PR TITLE
Replace .decode method with str(bytes, "utf-8")

### DIFF
--- a/cwltool/builder.py
+++ b/cwltool/builder.py
@@ -86,7 +86,7 @@ def content_limit_respected_read(f: IO[bytes]) -> str:
     :returns: the file contents
     :raises WorkflowException: if the file is too large
     """
-    return content_limit_respected_read_bytes(f).decode("utf-8")
+    return str(content_limit_respected_read_bytes(f), "utf-8")
 
 
 def substitute(value: str, replace: str) -> str:

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1369,8 +1369,8 @@ class CommandLineTool(Process):
                     else:
                         if binding.get("loadContents"):
                             with fs_access.open(cast(str, rfile["location"]), "rb") as f:
-                                files["contents"] = content_limit_respected_read_bytes(f).decode(
-                                    "utf-8"
+                                files["contents"] = str(
+                                    content_limit_respected_read_bytes(f), "utf-8"
                                 )
                         if compute_checksum:
                             with fs_access.open(cast(str, rfile["location"]), "rb") as f:

--- a/cwltool/cwlrdf.py
+++ b/cwltool/cwlrdf.py
@@ -27,7 +27,7 @@ def printrdf(wflow: Process, ctx: ContextType, style: str) -> str:
     rdf = gather(wflow, ctx).serialize(format=style, encoding="utf-8")
     if not rdf:
         return ""
-    return rdf.decode("utf-8")
+    return str(rdf, "utf-8")
 
 
 def lastpart(uri: Any) -> str:

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -117,7 +117,7 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             try:
                 manifest = json.loads(
                     str(
-                        subprocess.check_output([self.docker_exec, "inspect", docker_image_id]),
+                        subprocess.check_output([self.docker_exec, "inspect", docker_image_id]), # nosec
                         "utf-8",
                     )
                 )

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -117,7 +117,9 @@ class DockerCommandLineJob(ContainerCommandLineJob):
             try:
                 manifest = json.loads(
                     str(
-                        subprocess.check_output([self.docker_exec, "inspect", docker_image_id]), # nosec
+                        subprocess.check_output(
+                            [self.docker_exec, "inspect", docker_image_id]
+                        ),  # nosec
                         "utf-8",
                     )
                 )

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -116,10 +116,9 @@ class DockerCommandLineJob(ContainerCommandLineJob):
         if (docker_image_id := docker_requirement.get("dockerImageId")) is not None:
             try:
                 manifest = json.loads(
-                    subprocess.check_output(
-                        [self.docker_exec, "inspect", docker_image_id]
-                    ).decode(  # nosec
-                        "utf-8"
+                    str(
+                        subprocess.check_output([self.docker_exec, "inspect", docker_image_id]),
+                        "utf-8",
                     )
                 )
                 found = manifest is not None

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -200,7 +200,7 @@ def bytes2str_in_dicts(
 
     # if value is bytes, return decoded string,
     elif isinstance(inp, bytes):
-        return inp.decode("utf-8")
+        return str(inp, "utf-8")
 
     # simply return elements itself
     return inp

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -234,8 +234,8 @@ def test_content_limit_respected_read() -> None:
 
 
 def test_bytes2str_in_dicts() -> None:
-    d1 = {"foo": b"bar"}
+    assert bytes2str_in_dicts({"foo": b"bar"}) == {"foo": "bar"}
 
-    d2 = bytes2str_in_dicts(d1)
+    assert bytes2str_in_dicts({"foo": [b"bar"]}) == {"foo": ["bar"]}
 
-    assert d2 == {"foo": "bar"}
+    assert bytes2str_in_dicts({"foo": {"foo2": b"bar"}}) == {"foo": {"foo2": "bar"}}

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -12,7 +12,9 @@ from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.main import main
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.update import INTERNAL_VERSION
-from cwltool.utils import CWLObjectType
+from cwltool.utils import CWLObjectType, CONTENT_LIMIT, bytes2str_in_dicts
+from cwltool.builder import content_limit_respected_read
+from cwltool.errors import WorkflowException
 
 from .util import needs_docker
 
@@ -214,3 +216,25 @@ def test_clt_returns_specialchar_names(tmp_path: Path) -> None:
         result["location"]
         == "keep:ae755cd1b3cff63152ff4200f4dea7e9+52/%3A%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
     )
+
+
+def test_content_limit_respected_read() -> None:
+    b1 = b"abcd" * 100
+    b1io = BytesIO(b1)
+
+    assert(len(b1) < CONTENT_LIMIT)
+    assert(content_limit_respected_read(b1io) == str("abcd" * 100))
+
+    b2 = b"abcd" * 20000
+    b2io = BytesIO(b2)
+
+    assert(len(b2) > CONTENT_LIMIT)
+    with pytest.raises(WorkflowException):
+        content_limit_respected_read(b2io)
+
+def test_bytes2str_in_dicts() -> None:
+    d1 = {"foo": b"bar"}
+
+    d2 = bytes2str_in_dicts(d1)
+
+    assert(d2 == {"foo": "bar"})

--- a/tests/test_path_checks.py
+++ b/tests/test_path_checks.py
@@ -222,19 +222,20 @@ def test_content_limit_respected_read() -> None:
     b1 = b"abcd" * 100
     b1io = BytesIO(b1)
 
-    assert(len(b1) < CONTENT_LIMIT)
-    assert(content_limit_respected_read(b1io) == str("abcd" * 100))
+    assert len(b1) < CONTENT_LIMIT
+    assert content_limit_respected_read(b1io) == str("abcd" * 100)
 
     b2 = b"abcd" * 20000
     b2io = BytesIO(b2)
 
-    assert(len(b2) > CONTENT_LIMIT)
+    assert len(b2) > CONTENT_LIMIT
     with pytest.raises(WorkflowException):
         content_limit_respected_read(b2io)
+
 
 def test_bytes2str_in_dicts() -> None:
     d1 = {"foo": b"bar"}
 
     d2 = bytes2str_in_dicts(d1)
 
-    assert(d2 == {"foo": "bar"})
+    assert d2 == {"foo": "bar"}


### PR DESCRIPTION
This is because some bytes-like objects (such as memoryview) don't have a "decode()" method.  It appears that the preferred way to get a decoded string is to simply call the constructor with the bytes-like object and the desired encoding.
