### PR TITLE
Fix 2d output arrays with format tag

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1497,14 +1497,16 @@ class CommandLineTool(Process):
                 else:
 
                     def recursively_insert(j_dict: Any, key: Any, val: Any) -> Any:
-                        """Recursively inserts a value into any dictionaries"""
+                        """Recursively insert a value into any dictionary."""
                         if isinstance(j_dict, List):
                             return [recursively_insert(x, key, val) for x in j_dict]
                         if isinstance(j_dict, Dict):
                             if j_dict.get("class") == "File":
                                 j_dict[key] = val
                             else:
-                                return {x: recursively_insert(y, key, val) for x, y in j_dict.items()}
+                                return {
+                                    x: recursively_insert(y, key, val) for x, y in j_dict.items()
+                                }
                         return j_dict
 
                     result = recursively_insert(result, "format", format_field)

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1498,9 +1498,9 @@ class CommandLineTool(Process):
 
                     def recursively_insert(j_dict: Any, key: Any, val: Any) -> Any:
                         """Recursively insert a value into any dictionary."""
-                        if isinstance(j_dict, List):
+                        if isinstance(j_dict, MutableSequence):
                             return [recursively_insert(x, key, val) for x in j_dict]
-                        if isinstance(j_dict, Dict):
+                        if isinstance(j_dict, MutableMapping):
                             if j_dict.get("class") == "File":
                                 j_dict[key] = val
                             else:

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -1495,8 +1495,19 @@ class CommandLineTool(Process):
                             )
                         primary["format"] = format_eval
                 else:
-                    for primary in aslist(result):
-                        primary["format"] = format_field
+
+                    def recursively_insert(j_dict: Any, key: Any, val: Any) -> Any:
+                        """Recursively inserts a value into any dictionaries"""
+                        if isinstance(j_dict, List):
+                            return [recursively_insert(x, key, val) for x in j_dict]
+                        if isinstance(j_dict, Dict):
+                            if j_dict.get("class") == "File":
+                                j_dict[key] = val
+                            else:
+                                return {x: recursively_insert(y, key, val) for x, y in j_dict.items()}
+                        return j_dict
+
+                    result = recursively_insert(result, "format", format_field)
             # Ensure files point to local references outside of the run environment
             adjustFileObjs(result, revmap)
 

--- a/tests/output_2D_file_format.cwl
+++ b/tests/output_2D_file_format.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+baseCommand: 'true'
+
+requirements:
+  InlineJavascriptRequirement: {}
+
+inputs: {}
+
+outputs:
+  output_array:
+    type: {"type": "array", "items": {"type": "array", "items": "File"}}
+    outputBinding:
+      outputEval: |
+        ${
+          var out2d = [];
+          for (var i = 0; i < 2; i++) {
+            var out1d = [];
+            for (var j = 0; j < 2; j++) {
+              out1d.push({"class": "File", "location": "../../filename.txt"});
+            }
+            out2d.push(out1d);
+          }
+          return out2d;
+        }
+    format: some_format

--- a/tests/test_2D.py
+++ b/tests/test_2D.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+from .util import get_data
+
+
+def test_output_2D_file_format() -> None:
+    """Test format tag for 2D output arrays."""
+
+    params = [
+        sys.executable,
+        "-m",
+        "cwltool",
+        get_data("tests/output_2D_file_format.cwl"),
+    ]
+
+    assert subprocess.check_call(params) == 0

--- a/tests/test_2D.py
+++ b/tests/test_2D.py
@@ -1,16 +1,20 @@
 import subprocess
 import sys
+from pathlib import Path
 
 from .util import get_data
 
 
 def test_output_2D_file_format() -> None:
-    """Test format tag for 2D output arrays."""
+    """A simple test for format tag fix for 2D output arrays."""
 
+    Path("filename.txt").touch()
     params = [
         sys.executable,
         "-m",
         "cwltool",
+        "--cachedir",  # just so that the relative path of file works out
+        "foo",
         get_data("tests/output_2D_file_format.cwl"),
     ]
 

--- a/tests/test_2D.py
+++ b/tests/test_2D.py
@@ -1,21 +1,19 @@
-import subprocess
-import sys
 from pathlib import Path
+import pytest
+from .util import get_data, get_main_output
 
-from .util import get_data
-
-
-def test_output_2D_file_format() -> None:
+@pytest.fixture(scope="session")
+def test_output_2d_file_format(tmp_path_factory: pytest.TempPathFactory) -> None:
     """A simple test for format tag fix for 2D output arrays."""
 
-    Path("filename.txt").touch()
-    params = [
-        sys.executable,
-        "-m",
-        "cwltool",
-        "--cachedir",  # just so that the relative path of file works out
-        "foo",
-        get_data("tests/output_2D_file_format.cwl"),
-    ]
+    tmp_path: Path = tmp_path_factory.mktemp("tmp")
+    # still need to create 'filename.txt' as it is needed in output_2D_file_format.cwl
+    _ = tmp_path / "filename.txt"
+    commands = [
+        "--cachedir",
+        str(tmp_path / "foo"),  # just so that the relative path of file works out
+        get_data("tests/output_2D_file_format.cwl")]
 
-    assert subprocess.check_call(params) == 0
+    error_code, _, stderr = get_main_output(commands)
+
+    assert error_code == 0, stderr

--- a/tests/test_2D.py
+++ b/tests/test_2D.py
@@ -1,18 +1,20 @@
 from pathlib import Path
-import pytest
+
 from .util import get_data, get_main_output
 
-@pytest.fixture(scope="session")
-def test_output_2d_file_format(tmp_path_factory: pytest.TempPathFactory) -> None:
+
+def test_output_2d_file_format(tmp_path: Path) -> None:
     """A simple test for format tag fix for 2D output arrays."""
 
-    tmp_path: Path = tmp_path_factory.mktemp("tmp")
     # still need to create 'filename.txt' as it is needed in output_2D_file_format.cwl
-    _ = tmp_path / "filename.txt"
+    (tmp_path / "filename.txt").touch()
     commands = [
         "--cachedir",
         str(tmp_path / "foo"),  # just so that the relative path of file works out
-        get_data("tests/output_2D_file_format.cwl")]
+        "--outdir",
+        str(tmp_path / "out"),
+        get_data("tests/output_2D_file_format.cwl"),
+    ]
 
     error_code, _, stderr = get_main_output(commands)
 


### PR DESCRIPTION
The issue is when we print 2d_output arrays which have "format" tag

`touch filename.txt`
`cwltool --cachedir foo output_2D_file_format.cwl`
``` ERROR Workflow error, try again with --debug for more information:
("Error collecting output for parameter 'output_array': output_2D_file_format.cwl:14:3: list indices must
                                                                                        be integers or
                                                                                        slices, not str",
                                                                                        {})
```

The crux of the issue is aslist function, only promotes scalars to 1d arrays. Arbitrary JS can return an arbitrary json, format handling code needs to handle arbitrary json (not just scalars or 1d arrays which is done through aslist function).

With this fix the output should be something like this

```
jaganathv2$ touch filename.txt
jaganathv2$ cwltool --cachedir foo output_2D_file_format.cwl
INFO /Users/jaganathv2/mambaforge/envs/cwt/bin/cwltool 3.1.20220628170239.dev281+g57619ffd
INFO Resolved 'output_2D_file_format.cwl' to 'file:///Users/jaganathv2/Code/WIC/cwltool/tests/output_2D_file_format.cwl'
INFO [job output_2D_file_format.cwl] Output of job will be cached in /Users/jaganathv2/Code/WIC/cwltool/tests/foo/585a1a734523fb1e13030642dc26ad4a
INFO [job output_2D_file_format.cwl] /Users/jaganathv2/Code/WIC/cwltool/tests/foo/585a1a734523fb1e13030642dc26ad4a$ true
INFO [job output_2D_file_format.cwl] completed success
{
    "output_array": [
        [
            {
                "class": "File",
                "location": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt",
                "format": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/output_2D_file_format.cwl#some_format",
                "basename": "filename.txt",
                "size": 0,
                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
                "path": "/Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt"
            },
            {
                "class": "File",
                "location": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt",
                "format": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/output_2D_file_format.cwl#some_format",
                "basename": "filename.txt",
                "size": 0,
                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
                "path": "/Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt"
            }
        ],
        [
            {
                "class": "File",
                "location": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt",
                "format": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/output_2D_file_format.cwl#some_format",
                "basename": "filename.txt",
                "size": 0,
                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
                "path": "/Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt"
            },
            {
                "class": "File",
                "location": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt",
                "format": "file:///Users/jaganathv2/Code/WIC/cwltool/tests/output_2D_file_format.cwl#some_format",
                "basename": "filename.txt",
                "size": 0,
                "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
                "path": "/Users/jaganathv2/Code/WIC/cwltool/tests/filename.txt"
            }
        ]
    ]
}INFO Final process status is success
```