### PR TITLE
Support Podman version 5.x which autodeletes the cidfiles

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -913,7 +913,7 @@ class ContainerCommandLineJob(JobBase, metaclass=ABCMeta):
             self.name,
             int((max_mem_percent / 100 * max_mem) / (2**20)),
         )
-        if cleanup_cidfile:
+        if cleanup_cidfile and os.path.exists(cidfile):
             os.remove(cidfile)
 
 


### PR DESCRIPTION
Fixes: #2001 