### PR TITLE
Support array of integers and floats as command argument parameters

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -903,6 +903,11 @@ def add_argument(
             action = DirectoryAppendAction
         else:
             action = AppendAction
+            items = inptype["items"]
+            if items == "int" or items == "long":
+                atype = int
+            elif items == "double" or items == "fload":
+                atype = float
     elif isinstance(inptype, MutableMapping) and inptype["type"] == "enum":
         atype = str
     elif isinstance(inptype, MutableMapping) and inptype["type"] == "record":

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -906,7 +906,7 @@ def add_argument(
             items = inptype["items"]
             if items == "int" or items == "long":
                 atype = int
-            elif items == "double" or items == "fload":
+            elif items == "double" or items == "float":
                 atype = float
     elif isinstance(inptype, MutableMapping) and inptype["type"] == "enum":
         atype = str

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -156,12 +156,12 @@ scripts_argparse_params = [
     (
         "foo with f for long value (large number)",
         script_f,
-        lambda x: [x, "--foo", str(2**31+10)],
+        lambda x: [x, "--foo", str(2**31 + 10)],
     ),
     (
         "foo with f for long value (small number)",
         script_f,
-        lambda x: [x, "--foo", str(-1*(2**31)-10)],
+        lambda x: [x, "--foo", str(-1 * (2**31) - 10)],
     ),
     (
         "foo with g",

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -101,7 +101,7 @@ expression: '{"bar": $(inputs.foo.location)}'
 outputs: []
 """
 
-script_f = """
+script_int = """
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -183,22 +183,22 @@ scripts_argparse_params = [
     ),
     (
         "foo with g for long value (large number)",
-        script_f,
+        script_g,
         lambda x: [x, "--foo", str(2**31 + 10)],
     ),
     (
         "foo with g for long value (small number)",
-        script_f,
+        script_g,
         lambda x: [x, "--foo", str(-1 * (2**31) - 10)],
     ),
     (
         "foo with h",
-        script_g,
+        script_h,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),
     (
         "foo with i",
-        script_g,
+        script_i,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),
 ]

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -154,6 +154,16 @@ scripts_argparse_params = [
         lambda x: [x, "--foo", "1", "--foo", "2"],
     ),
     (
+        "foo with f for long value (large number)",
+        script_f,
+        lambda x: [x, "--foo", str(2**31+10)],
+    ),
+    (
+        "foo with f for long value (small number)",
+        script_f,
+        lambda x: [x, "--foo", str(-1*(2**31)-10)],
+    ),
+    (
         "foo with g",
         script_g,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -115,7 +115,7 @@ expression: '{"bar": $(inputs.foo)}'
 outputs: []
 """
 
-script_g = """
+script_long = """
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
@@ -129,7 +129,7 @@ expression: '{"bar": $(inputs.foo)}'
 outputs: []
 """
 
-script_h = """
+script_float = """
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
@@ -143,7 +143,7 @@ expression: '{"bar": $(inputs.foo)}'
 outputs: []
 """
 
-script_i = """
+script_double = """
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
@@ -177,28 +177,28 @@ scripts_argparse_params = [
         lambda x: [x, "--foo", "http://example.com"],
     ),
     (
-        "foo with f",
-        script_f,
+        "foo with int",
+        script_int,
         lambda x: [x, "--foo", "1", "--foo", "2"],
     ),
     (
-        "foo with g for long value (large number)",
-        script_g,
+        "foo with long for large value",
+        script_long,
         lambda x: [x, "--foo", str(2**31 + 10)],
     ),
     (
-        "foo with g for long value (small number)",
-        script_g,
+        "foo with long for small value",
+        script_long,
         lambda x: [x, "--foo", str(-1 * (2**31) - 10)],
     ),
     (
-        "foo with h",
-        script_h,
+        "foo with float",
+        script_float,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),
     (
-        "foo with i",
-        script_i,
+        "foo with double",
+        script_double,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),
 ]

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -122,6 +122,34 @@ cwlVersion: v1.0
 class: ExpressionTool
 
 inputs:
+  foo: long[]
+
+expression: '{"bar": $(inputs.foo)}'
+
+outputs: []
+"""
+
+script_h = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
+  foo: float[]
+
+expression: '{"bar": $(inputs.foo)}'
+
+outputs: []
+"""
+
+script_i = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
   foo: double[]
 
 expression: '{"bar": $(inputs.foo)}'
@@ -154,17 +182,22 @@ scripts_argparse_params = [
         lambda x: [x, "--foo", "1", "--foo", "2"],
     ),
     (
-        "foo with f for long value (large number)",
+        "foo with g for long value (large number)",
         script_f,
         lambda x: [x, "--foo", str(2**31 + 10)],
     ),
     (
-        "foo with f for long value (small number)",
+        "foo with g for long value (small number)",
         script_f,
         lambda x: [x, "--foo", str(-1 * (2**31) - 10)],
     ),
     (
-        "foo with g",
+        "foo with h",
+        script_g,
+        lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
+    ),
+    (
+        "foo with i",
         script_g,
         lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -101,6 +101,34 @@ expression: '{"bar": $(inputs.foo.location)}'
 outputs: []
 """
 
+script_f = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
+  foo: int[]
+
+expression: '{"bar": $(inputs.foo)}'
+
+outputs: []
+"""
+
+script_g = """
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+
+inputs:
+  foo: double[]
+
+expression: '{"bar": $(inputs.foo)}'
+
+outputs: []
+"""
+
 scripts_argparse_params = [
     ("help", script_a, lambda x: ["--debug", x, "--input", get_data("tests/echo.cwl")]),
     ("boolean", script_b, lambda x: [x, "--help"]),
@@ -119,6 +147,16 @@ scripts_argparse_params = [
         "foo with e",
         script_e,
         lambda x: [x, "--foo", "http://example.com"],
+    ),
+    (
+        "foo with f",
+        script_f,
+        lambda x: [x, "--foo", "1", "--foo", "2"],
+    ),
+    (
+        "foo with g",
+        script_g,
+        lambda x: [x, "--foo", "1.2", "--foo", "3.4"],
     ),
 ]
 


### PR DESCRIPTION
It fixes #2034 by considering the case of arrays of integers and floating point numbers.