### PR TITLE
Handle spurious `ReceiveScatterOutput` callbacks

### DIFF
--- a/cwltool/workflow_job.py
+++ b/cwltool/workflow_job.py
@@ -88,11 +88,15 @@ class ReceiveScatterOutput:
     ) -> None:
         """Initialize."""
         self.dest = dest
-        self.completed = 0
+        self._completed = set()
         self.processStatus = "success"
         self.total = total
         self.output_callback = output_callback
         self.steps: List[Optional[JobsGeneratorType]] = []
+
+    @property
+    def completed(self) -> int:
+        return len(self._completed)
 
     def receive_scatter_output(self, index: int, jobout: CWLObjectType, processStatus: str) -> None:
         """Record the results of a scatter operation."""
@@ -108,10 +112,11 @@ class ReceiveScatterOutput:
             if self.processStatus != "permanentFail":
                 self.processStatus = processStatus
 
-        self.completed += 1
+        if index not in self._completed:
+            self._completed.add(index)
 
-        if self.completed == self.total:
-            self.output_callback(self.dest, self.processStatus)
+            if self.completed == self.total:
+                self.output_callback(self.dest, self.processStatus)
 
     def setTotal(
         self,


### PR DESCRIPTION
This commit fixes #2003 by handling spurious, repeated callbacks of the `receive_scatter_output` method of the `ReceiveScatterOutput` class. The reason of multiple awakenings has not been investigated deeply, though. In the future, a thorough examination of the `MultithreadedJobExecutor` logic may be necessary.