### PR TITLE
Use "run" with singularity/apptainer instead of "exec", when possible

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -159,6 +159,9 @@ class Singularity(CheckHolder):
                         return v.startswith(tmp_prefix) and v.endswith(":/tmp")
 
                     sing_vars["SINGULARITY_BIND"] = BIND
+        if vminor >= 10:
+            sing_vars["SINGULARITY_COMMAND"] = "run"
+            sing_vars["SINGULARITY_NO_EVAL"] = None
 
         result.update(sing_vars)
 


### PR DESCRIPTION
Context for the PR:
Currently if the user uses a `docker` image in a workflow and depending on the choice of the container engine (`docker` vs `singularity`), the execution can be different, if the `docker` image has an entrypoint. 

I understand that CWL community encourages docker images w/o entrypoints, however there are a good number of images produced by various scientific communities that comes with entrypoints. When this images are used in HPC environment, in most cases, due to security policies (not having access to `root`), `singularity` is chosen as the container engine. In these cases, `docker` images with entrypoint fails to execute. 

I also know that creating `CommandLineTools` with a `baseCommand` can bypass the entrypoint issue when running with `singularity` but that also makes those `CommandLineTools` container engine dependent, in turn making the CWL workflows themselves container engine dependent. 

With those observations, if there is no other strong reason for choosing `singularity exec` in the initial implementation, I would propose to change it to `singularity run`.

Here is also a link of relevant discussion: https://cwl.discourse.group/t/singularity-exec-vs-docker-run/956/4