### PR TITLE
Fix `cwltool:Loop` extension definition

### DIFF
--- a/cwltool/extensions-v1.2.yml
+++ b/cwltool/extensions-v1.2.yml
@@ -236,7 +236,7 @@ $graph:
         name: LoopOutputModes
         symbols: [ last, all ]
       default: last
-      doc:
+      doc: |
         - Specify the desired method of dealing with loop outputs
         - Default. Propagates only the last computed element to the subsequent steps when the loop terminates.
         - Propagates a single array with all output values to the subsequent steps when the loop terminates.


### PR DESCRIPTION
This commit fixes two small errors in the `cwltool:Loop` definition that were breaking the Schema SALAD codegen procedure.