### PR TITLE
Change caching pathmapper to respect the pathmapper factory

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -807,10 +807,10 @@ class CommandLineTool(Process):
             cachecontext.tmpdir = "/tmp"  # nosec
             cachecontext.stagedir = "/stage"
             cachebuilder = self._init_job(job_order, cachecontext)
-            cachebuilder.pathmapper = PathMapper(
+            cachebuilder.pathmapper = self.make_path_mapper(
                 cachebuilder.files,
-                runtimeContext.basedir,
                 cachebuilder.stagedir,
+                runtimeContext,
                 separateDirs=False,
             )
             _check_adjust = partial(check_adjust, self.path_check_mode.value, cachebuilder)


### PR DESCRIPTION
This changes the PathMapper construction in caching to support the pathmapper factory by calling `self.make_path_mapper` instead of directly constructing `PathMapper`. This should allow Toil to hook its own pathmapper in when caching is enabled and allow https://github.com/DataBiosphere/toil/pull/5187 to work.