### PR TITLE
Separate requirements and hints when caching

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -881,11 +881,15 @@ class CommandLineTool(Process):
                 "ShellCommandRequirement",
                 "NetworkAccess",
             }
-            for rh in (self.original_requirements, self.original_hints):
-                for r in reversed(rh):
-                    cls = cast(str, r["class"])
-                    if cls in interesting and cls not in keydict:
-                        keydict[cls] = r
+
+            for r in self.original_requirements:
+                cls = cast(str, r["class"])
+                if cls in interesting and cls not in keydict:
+                    keydict.setdefault("requirements", {})[cls] = r
+            for h in self.original_hints:
+                cls = cast(str, h["class"])
+                if cls in interesting and cls not in keydict:
+                    keydict.setdefault("hints",{})[cls] = h
 
             keydictstr = json_dumps(keydict, separators=(",", ":"), sort_keys=True)
             cachekey = hashlib.md5(keydictstr.encode("utf-8")).hexdigest()  # nosec


### PR DESCRIPTION
Resolves an issue with some of the conformance tests with caching as mentioned on the Toil side: https://github.com/DataBiosphere/toil/pull/5187#issuecomment-2610649849

`iwd-container-entryname1.cwl` has the DockerRequirement under the requirements key: https://github.com/common-workflow-language/cwl-v1.2/blob/707ebcd2173889604459c5f4ffb55173c508abb3/tests/iwd/iwd-container-entryname1.cwl#L14

But `iwd-container-entryname3.cwl` has the DockerRequirement under the hints key: https://github.com/common-workflow-language/cwl-v1.2/blob/707ebcd2173889604459c5f4ffb55173c508abb3/tests/iwd/iwd-container-entryname3.cwl#L14

When hashing for caching, hints and requirements are considered the same, so a previous run of `iwd-container-entryname1.cwl` will result in a cache hit for `iwd-container-entryname3.cwl`, even though the two tasks should have different behaviors/results