### PR TITLE
Fix normalization of image id for singularity pre-pulled images

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -157,13 +157,13 @@ def is_version_3_10_or_newer() -> bool:
 def _normalize_image_id(string: str) -> str:
     if ":" not in string:
         string += "_latest"
-    return string.replace("/", "_") + ".img"
+    return string.replace(":", "_") + ".img"
 
 
 def _normalize_sif_id(string: str) -> str:
     if ":" not in string:
         string += "_latest"
-    return string.replace("/", "_") + ".sif"
+    return string.replace(":", "_") + ".sif"
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)


### PR DESCRIPTION
Apptainer will replace the ':' character with an '_' when the image is pulled during pre-pull, not a '/'.

In fact, '_latest' is correctly added if a ':' is not present. I am not sure what is the reason for the '/' replacement, as '/' is not allowed at all in the docker image name+tag.

This pull fixes the replacement of the ':' character.