### PR TITLE
Suppress erroneous warnings for `pickValue`

### DIFF
--- a/cwltool/checker.py
+++ b/cwltool/checker.py
@@ -24,6 +24,7 @@ def check_types(
     srctype: SinkType,
     sinktype: SinkType,
     linkMerge: str | None,
+    pickValue: str | None,
     valueFrom: str | None,
 ) -> Literal["pass"] | Literal["warning"] | Literal["exception"]:
     """
@@ -33,23 +34,49 @@ def check_types(
     """
     if valueFrom is not None:
         return "pass"
+    if pickValue is not None:
+        if (
+            isinstance((_srctype := _get_type(srctype)), MutableMapping)
+            and _srctype["type"] == "array"
+        ):
+            match pickValue:
+                case "all_non_null":
+                    _srctype = {"type": "array", "items": _srctype["items"]}
+                    if (
+                        isinstance(_srctype["items"], MutableSequence)
+                        and "null" in _srctype["items"]
+                    ):
+                        _srctype["items"].remove("null")
+                case "first_non_null" | "the_only_non_null":
+                    if (
+                        isinstance(_srctype["items"], MutableSequence)
+                        and "null" in _srctype["items"]
+                    ):
+                        _srctype = [elem for elem in _srctype["items"] if elem != "null"]
+                case _:
+                    raise WorkflowException(f"Unrecognized pickValue enum {pickValue!r}")
+        _sinktype = _get_type(sinktype)
+    else:
+        _srctype = srctype
+        _sinktype = sinktype
     match linkMerge:
         case None:
-            if can_assign_src_to_sink(srctype, sinktype, strict=True):
+            if can_assign_src_to_sink(_srctype, _sinktype, strict=True):
                 return "pass"
-            if can_assign_src_to_sink(srctype, sinktype, strict=False):
+            if can_assign_src_to_sink(_srctype, _sinktype, strict=False):
                 return "warning"
             return "exception"
         case "merge_nested":
             return check_types(
-                {"items": _get_type(srctype), "type": "array"},
+                {"items": _get_type(_srctype), "type": "array"},
                 _get_type(sinktype),
+                None,
                 None,
                 None,
             )
         case "merge_flattened":
             return check_types(
-                merge_flatten_type(_get_type(srctype)), _get_type(sinktype), None, None
+                merge_flatten_type(_get_type(_srctype)), _get_type(sinktype), None, None, None
             )
         case _:
             raise WorkflowException(f"Unrecognized linkMerge enum {linkMerge!r}")
@@ -370,7 +397,15 @@ def _check_all_types(
                 srcs_of_sink: list[CWLObjectType] = []
                 for parm_id in cast(MutableSequence[str], sink[sourceField]):
                     srcs_of_sink += [src_dict[parm_id]]
-                    if is_conditional_step(param_to_step, parm_id) and pickValue is None:
+                    sink_type = cast(
+                        Union[str, list[str], list[CWLObjectType], CWLObjectType], sink["type"]
+                    )
+                    if (
+                        is_conditional_step(param_to_step, parm_id)
+                        and "null" != sink_type
+                        and "null" not in sink_type
+                        and pickValue is None
+                    ):
                         validation["warning"].append(
                             _SrcSink(
                                 src_dict[parm_id],
@@ -432,7 +467,7 @@ def _check_all_types(
                     }
 
             for src in srcs_of_sink:
-                check_result = check_types(src, sink, linkMerge, valueFrom)
+                check_result = check_types(src, sink, linkMerge, pickValue, valueFrom)
                 if check_result == "warning":
                     validation["warning"].append(
                         _SrcSink(src, sink, linkMerge, message=extra_message)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -681,12 +681,13 @@ def test_compare_types_strict(
 
 
 typechecks = [
-    (["string", "int"], ["string", "int", "null"], None, None, "pass"),
-    (["string", "int"], ["string", "null"], None, None, "warning"),
-    (["File", "int"], ["string", "null"], None, None, "exception"),
+    (["string", "int"], ["string", "int", "null"], None, None, None, "pass"),
+    (["string", "int"], ["string", "null"], None, None, None, "warning"),
+    (["File", "int"], ["string", "null"], None, None, None, "exception"),
     (
         {"items": ["string", "int"], "type": "array"},
         {"items": ["string", "int", "null"], "type": "array"},
+        None,
         None,
         None,
         "pass",
@@ -696,6 +697,7 @@ typechecks = [
         {"items": ["string", "null"], "type": "array"},
         None,
         None,
+        None,
         "warning",
     ),
     (
@@ -703,22 +705,25 @@ typechecks = [
         {"items": ["string", "null"], "type": "array"},
         None,
         None,
+        None,
         "exception",
     ),
     # check linkMerge when sinktype is not an array
-    (["string", "int"], ["string", "int", "null"], "merge_nested", None, "exception"),
+    (["string", "int"], ["string", "int", "null"], "merge_nested", None, None, "exception"),
     # check linkMerge: merge_nested
     (
         ["string", "int"],
         {"items": ["string", "int", "null"], "type": "array"},
         "merge_nested",
         None,
+        None,
         "pass",
     ),
     (
         ["string", "int"],
         {"items": ["string", "null"], "type": "array"},
         "merge_nested",
+        None,
         None,
         "warning",
     ),
@@ -727,22 +732,25 @@ typechecks = [
         {"items": ["string", "null"], "type": "array"},
         "merge_nested",
         None,
+        None,
         "exception",
     ),
     # check linkMerge: merge_nested and sinktype is "Any"
-    (["string", "int"], "Any", "merge_nested", None, "pass"),
+    (["string", "int"], "Any", "merge_nested", None, None, "pass"),
     # check linkMerge: merge_flattened
     (
         ["string", "int"],
         {"items": ["string", "int", "null"], "type": "array"},
         "merge_flattened",
         None,
+        None,
         "pass",
     ),
     (
         ["string", "int"],
         {"items": ["string", "null"], "type": "array"},
         "merge_flattened",
+        None,
         None,
         "warning",
     ),
@@ -751,6 +759,7 @@ typechecks = [
         {"items": ["string", "null"], "type": "array"},
         "merge_flattened",
         None,
+        None,
         "exception",
     ),
     (
@@ -758,12 +767,14 @@ typechecks = [
         {"items": ["string", "int", "null"], "type": "array"},
         "merge_flattened",
         None,
+        None,
         "pass",
     ),
     (
         {"items": ["string", "int"], "type": "array"},
         {"items": ["string", "null"], "type": "array"},
         "merge_flattened",
+        None,
         None,
         "warning",
     ),
@@ -772,14 +783,16 @@ typechecks = [
         {"items": ["string", "null"], "type": "array"},
         "merge_flattened",
         None,
+        None,
         "exception",
     ),
     # check linkMerge: merge_flattened and sinktype is "Any"
-    (["string", "int"], "Any", "merge_flattened", None, "pass"),
+    (["string", "int"], "Any", "merge_flattened", None, None, "pass"),
     (
         {"items": ["string", "int"], "type": "array"},
         "Any",
         "merge_flattened",
+        None,
         None,
         "pass",
     ),
@@ -789,6 +802,82 @@ typechecks = [
         {"items": "string", "type": "array"},
         "merge_flattened",
         None,
+        None,
+        "pass",
+    ),
+    # check pickValue: all_non_null
+    (
+        {"items": ["null", "string"], "type": "array"},
+        {"items": "string", "type": "array"},
+        None,
+        "all_non_null",
+        None,
+        "pass",
+    ),
+    (
+        {"items": ["null", "string"], "type": "array"},
+        {"items": "string", "type": "array"},
+        None,
+        None,
+        None,
+        "warning",
+    ),
+    (
+        {"items": ["null", "string"], "type": "array"},
+        "string",
+        None,
+        "all_non_null",
+        None,
+        "exception",
+    ),
+    # check pickValue: first_non_null
+    (
+        {"items": ["null", "string"], "type": "array"},
+        "string",
+        None,
+        "first_non_null",
+        None,
+        "pass",
+    ),
+    (
+        {"items": ["null", "string"], "type": "array"},
+        "int",
+        None,
+        "first_non_null",
+        None,
+        "exception",
+    ),
+    # check pickValue: the_only_non_null
+    (
+        {"items": ["null", "int"], "type": "array"},
+        "int",
+        None,
+        "the_only_non_null",
+        None,
+        "pass",
+    ),
+    # check pickValue: all_non_null and linkMerge: merge_nested
+    (
+        [
+            {"items": ["null", "string"], "type": "array"},
+            {"items": ["null", "File"], "type": "array"},
+        ],
+        {"items": {"items": ["string", "File"], "type": "array"}, "type": "array"},
+        "merge_nested",
+        "all_non_null",
+        None,
+        "pass",
+    ),
+    # check pickValue: all_non_null and linkMerge: merge_flattened
+    (
+        [
+            {"items": ["null", "string"], "type": "array"},
+            {"items": ["null", "Directory"], "type": "array"},
+        ],
+        {"items": ["string", "Directory"], "type": "array"},
+        "merge_flattened",
+        "all_non_null",
+        None,
         "pass",
     ),
     # check valueFrom
@@ -796,18 +885,28 @@ typechecks = [
         {"items": ["File", "int"], "type": "array"},
         {"items": ["string", "null"], "type": "array"},
         "merge_flattened",
+        None,
         "special value",
         "pass",
     ),
 ]
 
 
-@pytest.mark.parametrize("src_type,sink_type,link_merge,value_from,expected_type", typechecks)
+@pytest.mark.parametrize(
+    "src_type,sink_type,link_merge,pick_value,value_from,expected_type", typechecks
+)
 def test_typechecking(
-    src_type: Any, sink_type: Any, link_merge: str, value_from: Any, expected_type: str
+    src_type: Any,
+    sink_type: Any,
+    link_merge: str,
+    pick_value: Any,
+    value_from: Any,
+    expected_type: str,
 ) -> None:
     assert (
-        cwltool.checker.check_types(src_type, sink_type, linkMerge=link_merge, valueFrom=value_from)
+        cwltool.checker.check_types(
+            src_type, sink_type, linkMerge=link_merge, pickValue=pick_value, valueFrom=value_from
+        )
         == expected_type
     )
 


### PR DESCRIPTION
Handle `pickValue` in `check_types` to prevent erroneous warnings messages