### PR TITLE
allow explicit EUID/EGID=0:0 for docker rootless

### DIFF
--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -364,7 +364,8 @@ class DockerCommandLineJob(ContainerCommandLineJob):
                 runtime.append("--log-driver=none")
 
             euid, egid = docker_vm_id()
-            euid, egid = euid or os.geteuid(), egid or os.getgid()
+            euid = euid if euid is not None else os.geteuid()
+            egid = egid if egid is not None else os.getgid()
 
             if runtimeContext.no_match_user is False and (euid is not None and egid is not None):
                 runtime.append("--user=%d:%d" % (euid, egid))


### PR DESCRIPTION
When [docker rootless mode](https://docs.docker.com/engine/security/rootless/) is employed, the docker daemon can be configured to automatically map users to a "safe range" of UID/GID.

When doing so, a `--user=0:0` (typically `root`) could instead be mapped to higher-IDs automatically by the daemon, according to configured `/etc/subuid` and `/etc/subgid` mappings. Therefore, passing explicitly the resolved `os.geteuid()`/`os.getgid()` of the non-root user would confuse the mapping. The previous checks did not allow the falsy `0` values, which prevents mapping (eg: `0->10000`) with explicit `--user=0:0` to support the case where `/etc/subuid` defines `dockremap:100000:65535` and the current user(rootless) happens to be in that `100000-165535` range.

The current alternative is to use `--no-match-user`. However, that forces all or nothing UID/GID. If something else like `1000:0` was desired to employ the rootless-mapped "`0`" group to the current user's group, but still enforce another special user, it cannot be done. 

For extra context, I am trying to support this feature here: https://github.com/crim-ca/weaver/pull/886/changes/0b08a8a92607dbc89adc566f02e261a26bc4b5df..f139a29a62d3614d6d1685308e4b53d24cf46bcd
There, I override `docker_vm_id` to pass down desired UID/GID.