### PR TITLE
Delete "dirname" also for type Directory

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -260,7 +260,7 @@ def revmap_file(
             return f
 
     if "dirname" in f:
-        del f["dirname"]
+        del f["dirname"]  # type: ignore[typeddict-item]
 
     if "path" in f:
         path = builder.fs_access.join(builder.outdir, f["path"])

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -259,7 +259,7 @@ def revmap_file(
             f["location"] = builder.fs_access.join(outdir, f["location"])
             return f
 
-    if is_file(f) and "dirname" in f:
+    if "dirname" in f:
         del f["dirname"]
 
     if "path" in f:


### PR DESCRIPTION
Dear developers,

I have observed that suddenly under certain circumstances inputs (of type `Directory`) are mounted into the `WorkDir` without having specified it. This may cause conflicts, especially if identical file names are used.

The issue appeared the first time at version [3.2.20260413085819](https://github.com/common-workflow-language/cwltool/releases/tag/3.2.20260413085819)

I have one example (in short).
I have used the InitialWorkDirRequirement to put my inputs `msin` to:

```
hints:
   - class: InitialWorkDirRequirement
    listing:
      - entry: $(inputs.msin)
        writable: false
```

`msin` itself is correctly mounted to the workDir, but in addition also a second input:

```
{
        "position": [
            0,
            "flag_transfer_source_ms"
        ],
        "prefix": "flagtransfer.source_ms=",
        "separate": false,
        "datum": {
            "basename": "L667520_123MHz_uv.dp3concat",
            "class": "Directory",
            "dirname": "/ubcCuq",
            "location": "/home/alex/debug/tmp/7da5clhb/L667520_123MHz_uv.dp3concat",
            "nameext": ".dp3concat",
            "nameroot": "L667520_123MHz_uv",
            "writable": false,
            "path": "/ubcCuq/L667520_123MHz_uv.dp3concat"
        }
    },
```

Surprisingly, it has put the `flag_transfer_source_ms` already in the workDir right from the beginning, given by the inputs:

```
"file:///home/alex/prefactor3-cwl/workflows/linc_target/concat.cwl#concat/dp3concat/flag_transfer_source_ms": {
        "basename": "L667520_123MHz_uv.dp3concat",
        "class": "Directory",
        "dirname": "/ubcCuq",
        "location": "/home/alex/debug/tmp/7da5clhb/L667520_123MHz_uv.dp3concat",
        "nameext": ".dp3concat",
        "nameroot": "L667520_123MHz_uv",
        "writable": false
    },
```
The root cause is that `dirname` became part of the input dictionary itself and is propagated through the entire workflow.
I repeated my workflow with an older cwltool version. There I get from an output of a previous step:

```
outputs {
    "msout": [
        {
            "basename": "L667520_121MHz_uv.dp3concat",
            "class": "Directory",
            "location": "file:///home/alex/debug/tmp/sx3t5ahe/L667520_121MHz_uv.dp3concat",
            "nameext": ".dp3concat",
            "nameroot": "L667520_121MHz_uv",
            "writable": true
        }
    ],
```
And with the new version the `dirname` became part of the output.

```
outputs {
    "msout": [
        {
            "basename": "L667520_123MHz_uv.dp3concat",
            "class": "Directory",
            "dirname": "/ubcCuq",
            "location": "file:///home/alex/debug/tmp/7da5clhb/L667520_123MHz_uv.dp3concat",
            "nameext": ".dp3concat",
            "nameroot": "L667520_123MHz_uv",
            "writable": true
        }
    ],
```

Removing the `dirname` entry from the output dictionary solves this issue.

Cheers,
Alex