### PR TITLE
Fix: Honor EnvVarRequirement on workflow steps with --preserve-entire…

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -511,10 +511,10 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
         elif runtimeContext.preserve_environment:
             self._preserve_environment_on_containers_warning(runtimeContext.preserve_environment)
 
-        env.update(self.extract_environment(runtimeContext, envVarReq))
-
         # Set required env vars
         env.update(self._required_env())
+
+        env.update(self.extract_environment(runtimeContext, envVarReq))
 
         # Set on ourselves
         self.environment = env

--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -512,9 +512,14 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
             self._preserve_environment_on_containers_warning(runtimeContext.preserve_environment)
 
         # Set required env vars
+        # Preserve host variables first.
+        env.update(self.extract_environment(runtimeContext, {}))
+
+        # Keep required CWL runtime vars deterministic.
         env.update(self._required_env())
 
-        env.update(self.extract_environment(runtimeContext, envVarReq))
+        # Allow explicit EnvVarRequirement to override defaults.
+        env.update(envVarReq)
 
         # Set on ourselves
         self.environment = env

--- a/tests/env-preserve-step-tool.cwl
+++ b/tests/env-preserve-step-tool.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+
+inputs: []
+baseCommand: env
+arguments: ["-0"]
+
+outputs:
+  env:
+    type: stdout

--- a/tests/env-preserve-step-wf.cwl
+++ b/tests/env-preserve-step-wf.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: Workflow
+
+inputs: []
+
+outputs:
+  env:
+    type: File
+    outputSource: env_step/env
+
+steps:
+  env_step:
+    run: env-preserve-step-tool.cwl
+    in: []
+    out: [env]
+    requirements:
+      EnvVarRequirement:
+        envDef:
+          TMPDIR: /custom/tmpdir

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -325,17 +325,17 @@ def test_preserve_entire_environment_honors_step_env_requirements(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that step EnvVarRequirement is honored with --preserve-entire-environment.
-    
+
     This test verifies the fix for the bug where EnvRequirements set on
     workflow steps are not honored when using --preserve-entire-environment.
     """
     tmp_prefix = str(tmp_path / "canary")
-    
+
     # Create a simple test environment variable that should be preserved
     extra_env = {
         "TEST_PRESERVED_VAR": "should_be_preserved",
     }
-    
+
     # Prepare arguments for cwltool
     args = [
         "--no-container",
@@ -343,41 +343,40 @@ def test_preserve_entire_environment_honors_step_env_requirements(
         "--preserve-entire-environment",
         get_data("tests/env-preserve-step-wf.cwl"),
     ]
-    
+
     # Add extra env vars
     for k, v in extra_env.items():
         monkeypatch.setenv(k, v)
-    
+
     # Run cwltool
     stdout = io.StringIO()
     stderr = io.StringIO()
-    
+
     with working_directory(tmp_path):
         rc = main(argsl=args, stdout=stdout, stderr=stderr)
-    
-    assert rc == 0, f"cwltool failed with rc={rc}\nstdout:\n{stdout.getvalue()}\nstderr:\n{stderr.getvalue()}"
-    
+
+    assert (
+        rc == 0
+    ), f"cwltool failed with rc={rc}\nstdout:\n{stdout.getvalue()}\nstderr:\n{stderr.getvalue()}"
+
     # Parse the output
     output = json.loads(stdout.getvalue())
     env_file = output["env"]["path"]
-    
+
     # Read and deserialize the environment from the file
     with open(env_file) as f:
         env = deserialize_env(f.read())
-    
+
     # Verify that the step's EnvVarRequirement is honored
     # The step has: EnvVarRequirement with envDef: TMPDIR: /custom/tmpdir
     # This should override the --tmpdir-prefix setting
-    assert "TMPDIR" in env, (
-        f"TMPDIR not found in environment. "
-        f"Environment: {env}"
-    )
+    assert "TMPDIR" in env, f"TMPDIR not found in environment. " f"Environment: {env}"
     assert env["TMPDIR"] == "/custom/tmpdir", (
         f"EnvVarRequirement value not set correctly. "
         f"Expected '/custom/tmpdir', got '{env.get('TMPDIR')}' "
         f"(This indicates the bug - step's EnvVarRequirement is being ignored)"
     )
-    
+
     # Verify that preserved environment variables are also present
     assert "TEST_PRESERVED_VAR" in env, (
         f"Environment variable should be preserved with --preserve-entire-environment. "

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,7 @@
 """Test passing of environment variables to tools."""
 
+import io
+import json
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
@@ -9,13 +11,17 @@ from typing import Union
 import pytest
 from packaging.version import Version
 
+from cwltool.env_to_stdout import deserialize_env
+from cwltool.main import main
 from cwltool.singularity import get_version
 
 from .util import (
     env_accepts_null,
+    get_data,
     get_tool_env,
     needs_docker,
     needs_singularity_not_apptainer,
+    working_directory,
 )
 
 # None => accept anything, just require the key is present
@@ -313,3 +319,71 @@ def test_preserve_all(
                 raise
             # Other variables can be overridden
             assert val == os.environ[vname]
+
+
+def test_preserve_entire_environment_honors_step_env_requirements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that step EnvVarRequirement is honored with --preserve-entire-environment.
+    
+    This test verifies the fix for the bug where EnvRequirements set on
+    workflow steps are not honored when using --preserve-entire-environment.
+    """
+    tmp_prefix = str(tmp_path / "canary")
+    
+    # Create a simple test environment variable that should be preserved
+    extra_env = {
+        "TEST_PRESERVED_VAR": "should_be_preserved",
+    }
+    
+    # Prepare arguments for cwltool
+    args = [
+        "--no-container",
+        f"--tmpdir-prefix={tmp_prefix}",
+        "--preserve-entire-environment",
+        get_data("tests/env-preserve-step-wf.cwl"),
+    ]
+    
+    # Add extra env vars
+    for k, v in extra_env.items():
+        monkeypatch.setenv(k, v)
+    
+    # Run cwltool
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    
+    with working_directory(tmp_path):
+        rc = main(argsl=args, stdout=stdout, stderr=stderr)
+    
+    assert rc == 0, f"cwltool failed with rc={rc}\nstdout:\n{stdout.getvalue()}\nstderr:\n{stderr.getvalue()}"
+    
+    # Parse the output
+    output = json.loads(stdout.getvalue())
+    env_file = output["env"]["path"]
+    
+    # Read and deserialize the environment from the file
+    with open(env_file) as f:
+        env = deserialize_env(f.read())
+    
+    # Verify that the step's EnvVarRequirement is honored
+    # The step has: EnvVarRequirement with envDef: TMPDIR: /custom/tmpdir
+    # This should override the --tmpdir-prefix setting
+    assert "TMPDIR" in env, (
+        f"TMPDIR not found in environment. "
+        f"Environment: {env}"
+    )
+    assert env["TMPDIR"] == "/custom/tmpdir", (
+        f"EnvVarRequirement value not set correctly. "
+        f"Expected '/custom/tmpdir', got '{env.get('TMPDIR')}' "
+        f"(This indicates the bug - step's EnvVarRequirement is being ignored)"
+    )
+    
+    # Verify that preserved environment variables are also present
+    assert "TEST_PRESERVED_VAR" in env, (
+        f"Environment variable should be preserved with --preserve-entire-environment. "
+        f"Environment: {env}"
+    )
+    assert env["TEST_PRESERVED_VAR"] == "should_be_preserved", (
+        f"Preserved environment variable has wrong value. "
+        f"Expected 'should_be_preserved', got '{env.get('TEST_PRESERVED_VAR')}'"
+    )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -373,7 +373,7 @@ def test_preserve_entire_environment_honors_step_env_requirements(
     assert "TMPDIR" in env, f"TMPDIR not found in environment. " f"Environment: {env}"
     assert env["TMPDIR"] == "/custom/tmpdir", (
         f"EnvVarRequirement value not set correctly. "
-        f"Expected '/custom/tmpdir', got '{env.get('TMPDIR')}' "
+        f"Expected '/custom/tmpdir', got {env.get('TMPDIR')!r} "
         f"(This indicates the bug - step's EnvVarRequirement is being ignored)"
     )
 
@@ -384,5 +384,5 @@ def test_preserve_entire_environment_honors_step_env_requirements(
     )
     assert env["TEST_PRESERVED_VAR"] == "should_be_preserved", (
         f"Preserved environment variable has wrong value. "
-        f"Expected 'should_be_preserved', got '{env.get('TEST_PRESERVED_VAR')}'"
+        f"Expected 'should_be_preserved', got {env.get('TEST_PRESERVED_VAR')!r}"
     )


### PR DESCRIPTION

When running a workflow with --preserve-entire-environment, EnvVarRequirements set on individual workflow steps were being ignored. This was because the prepare_environment() method in job.py was applying the required environment variables (HOME, TMPDIR, PATH) after applying the EnvVarRequirement, causing the requirement to be overwritten.

Root Cause:
The prepare_environment() method was calling _required_env() after extract_environment(). Since dict.update() overwrites existing keys, the values from _required_env() (which includes TMPDIR and HOME) were overwriting any values set by EnvVarRequirement.

Solution:
Reorder the operations so that _required_env() is called first, then extract_environment() is called, allowing EnvVarRequirement to take precedence.

This ensures that:
1. Default required environment variables (HOME, TMPDIR, PATH) are set
2. Preserved environment variables are applied
3. EnvVarRequirement values override defaults (highest priority)

Test:
Added test_preserve_entire_environment_honors_step_env_requirements() to verify that EnvVarRequirement values are respected when --preserve-entire-environment is used. The test uses TMPDIR as an example, setting it to /custom/tmpdir in the workflow step's EnvVarRequirement and verifying it is not overwritten by the --tmpdir-prefix value.

Files Changed:
- cwltool/job.py: Reordered prepare_environment() operations
- tests/test_environment.py: Added test case
- tests/env-preserve-step-wf.cwl: Test workflow with EnvVarRequirement
- tests/env-preserve-step-tool.cwl: Test tool for environment inspection