### PR TITLE
Raise a clear error for an empty command line (#1618)

### DIFF
--- a/cwltool/job.py
+++ b/cwltool/job.py
@@ -307,6 +307,12 @@ class JobBase(HasReqsHints, metaclass=ABCMeta):
             stderr_path = stderr_stdout_log_path(self.base_path_logs, self.stderr)
             stdout_path = stderr_stdout_log_path(self.base_path_logs, self.stdout)
             commands = [str(x) for x in runtime + self.command_line]
+            if not commands:
+                raise WorkflowException(
+                    "Cannot run a CommandLineTool that produces an empty command line. "
+                    "Specify a 'baseCommand', 'arguments', and/or an input with an "
+                    "'inputBinding' so there is a program to execute."
+                )
             if runtimeContext.secret_store is not None:
                 commands = cast(
                     list[str],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -990,6 +990,15 @@ def test_glob_expr_error(tmp_path: Path) -> None:
     assert "Resolved glob patterns must be strings" in stderr
 
 
+def test_empty_command_line_error() -> None:
+    """A CommandLineTool with an empty command line fails cleanly, not with an IndexError."""
+    error_code, _, stderr = get_main_output([get_data("tests/wf/no-basecommand.cwl")])
+    assert error_code != 0
+    stderr = re.sub(r"\s\s+", " ", stderr)
+    assert "empty command line" in stderr
+    assert "IndexError" not in stderr
+
+
 def test_format_expr_error() -> None:
     """Better format expression error."""
     error_code, _, stderr = get_main_output(

--- a/tests/wf/no-basecommand.cwl
+++ b/tests/wf/no-basecommand.cwl
@@ -1,0 +1,8 @@
+#!/usr/bin/env cwl-runner
+# Regression fixture for https://github.com/common-workflow-language/cwltool/issues/1618
+# A CommandLineTool with no baseCommand/arguments/input bindings produces an empty
+# command line; running it should fail with a clear error, not a raw IndexError.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs: []
+outputs: []


### PR DESCRIPTION
## Problem

Fixes #1618.

A `CommandLineTool` with no `baseCommand`, `arguments`, or input bindings produces an empty command line. cwltool passed that empty list straight to `subprocess.Popen([])`, which crashes with a raw, confusing error:

```
IndexError: list index out of range
```

…originating deep inside `subprocess` (`executable = args[0]`), rather than a clean validation error for the malformed-but-parseable document.

### Repro

```cwl
cwlVersion: v1.2
class: CommandLineTool
inputs: []
outputs: []
```

```console
$ cwltool missing.cwl --debug
...
IndexError: list index out of range
```

## Fix

Guard the empty-command case in `JobBase._execute` (`cwltool/job.py`) right after the command list is constructed, and raise a `WorkflowException` with an actionable message:

```
Cannot run a CommandLineTool that produces an empty command line. Specify a
'baseCommand', 'arguments', and/or an input with an 'inputBinding' so there is
a program to execute.
```

The condition is `if not commands:`, so it only fires when there is genuinely nothing to execute — i.e. no container runtime wrapper (`docker run …`) **and** no command. A container job (where `runtime` supplies `docker run <image>`) is unaffected, so relying on an image's default `CMD` still works. The existing `except WorkflowException` handler turns this into a clean `permanentFail` instead of an unhandled traceback.

## Tests

Added `tests/wf/no-basecommand.cwl` fixture and `test_empty_command_line_error` in `tests/test_examples.py`, asserting a non-zero exit, the new message in stderr, and no `IndexError`.

```console
$ python -m pytest tests/test_examples.py::test_empty_command_line_error -q
1 passed
```

Verified `black`, `flake8`, and `isort` are clean on the changed files, and that a normal tool (`tests/echo.cwl`) still runs.

---

This change was produced with the assistance of **Claude Code** (model: Claude Opus). The diff, root-cause analysis, and test were reviewed by a human before submission.