### PR TITLE
Add regression test for boolean input with a default (#779)

### DIFF
--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -328,3 +328,27 @@ def test_argparse_append_with_default(job_order: list[str], expected_values: lis
     cmd_line = vars(toolparser.parse_args(job_order))
     file_paths = list(cmd_line["file_paths"])
     assert expected_values == file_paths
+
+
+@pytest.mark.parametrize(
+    "cwl_file,expected_default",
+    [
+        ("tests/wf/779-boolean-default-false.cwl", False),
+        ("tests/wf/779-boolean-default-true.cwl", True),
+    ],
+)
+def test_boolean_with_default_not_required(cwl_file: str, expected_default: bool) -> None:
+    """A boolean input with a default value must not be a required CLI argument.
+
+    Regression test for https://github.com/common-workflow-language/cwltool/issues/779
+    where ``default: false`` was incorrectly treated as a required ``--a_bool`` flag.
+    """
+    loadingContext = LoadingContext()
+    tool = load_tool(get_data(cwl_file), loadingContext)
+    # input_required=True mirrors the default CLI behavior; the input must still be
+    # optional purely because it declares a default value.
+    toolparser = generate_parser(argparse.ArgumentParser(prog="test"), tool, {}, [], True)
+    # Parsing with no arguments must succeed (the flag is optional) and fall back
+    # to the declared default rather than erroring with "arguments are required".
+    cmd_line = vars(toolparser.parse_args([]))
+    assert cmd_line["a_bool"] == expected_default

--- a/tests/wf/779-boolean-default-false.cwl
+++ b/tests/wf/779-boolean-default-false.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+# Regression fixture for https://github.com/common-workflow-language/cwltool/issues/779
+# A boolean input with `default: false` must NOT become a required CLI argument.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  a_bool:
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --a_bool
+outputs: []
+baseCommand: echo

--- a/tests/wf/779-boolean-default-true.cwl
+++ b/tests/wf/779-boolean-default-true.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+# Companion fixture for https://github.com/common-workflow-language/cwltool/issues/779
+# A boolean input with `default: true` must also NOT be a required CLI argument.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  a_bool:
+    type: boolean
+    default: true
+    inputBinding:
+      prefix: --a_bool
+outputs: []
+baseCommand: echo


### PR DESCRIPTION
## Summary

Addresses #779.

Issue #779 reported that a `boolean` input with `default: false` was incorrectly treated as a **required** CLI argument:

```console
$ cwltool t.cwl
t.cwl: error: the following arguments are required: --a_false
```

…while `default: true` worked fine — an argparse-generation asymmetry.

## Status: already fixed, never locked down

This was fixed in 48e8afd1 (Aug 2019), when the `required` computation in `add_argument` became:

```python
required = default is None and input_required
```

Since a `boolean` with `default: false` has `default=False` (not `None`), it is correctly optional today. I confirmed current `main` runs the issue's repro without error. However, the behavior was never covered by a test and the issue is still open.

## Change

Adds a parametrized regression test in `tests/test_toolargparse.py` (plus two small fixtures under `tests/wf/`) covering **both** `default: false` and `default: true`. It builds the parser via `generate_parser(..., input_required=True)` — mirroring the default CLI behavior — and asserts that parsing with no arguments succeeds and falls back to the declared default, rather than erroring as required.

I verified the test genuinely guards the bug: against the pre-2019 logic it fails on the `default: false` case with the exact error from the issue, while the `default: true` case still passes — matching the original report.

```console
$ python -m pytest tests/test_toolargparse.py -q
19 passed
```

`black`, `flake8`, and `isort` are clean on the changed files. **Once this lands, #779 can be closed.**

---

This change was produced with the assistance of **Claude Code** (model: Claude Opus). The analysis and test were reviewed by a human before submission.