### PR TITLE
docs: link cwl-docker-extract from CWL_SINGULARITY_CACHE help (#1537)

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -66,7 +66,9 @@ def arg_parser() -> argparse.ArgumentParser:
     env_table.add_env(
         "CWL_SINGULARITY_CACHE",
         f"directory path to find already downloaded Singularity images; "
-        f"[{bt}]dockerFile[/] images will also be searched for and stored here",
+        f"[{bt}]dockerFile[/] images will also be searched for and stored here. "
+        f"Images can be pre-pulled into this directory using "
+        f"[link=https://github.com/common-workflow-language/cwl-utils#pull-the-all-referenced-software-container-images]cwl-docker-extract[/] from cwl-utils",
     )
     env_table.add_env(
         "ORCID",

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -68,7 +68,8 @@ def arg_parser() -> argparse.ArgumentParser:
         f"directory path to find already downloaded Singularity images; "
         f"[{bt}]dockerFile[/] images will also be searched for and stored here. "
         f"Images can be pre-pulled into this directory using "
-        f"[link=https://github.com/common-workflow-language/cwl-utils#pull-the-all-referenced-software-container-images]cwl-docker-extract[/] from cwl-utils",
+        f"[link=https://cwl-utils.readthedocs.io/en/latest/#cwl-docker-extract]"
+        f"cwl-docker-extract[/] from cwl-utils",
     )
     env_table.add_env(
         "ORCID",


### PR DESCRIPTION
## Summary

Fixes #1537, which asked to document `CWL_SINGULARITY_CACHE` and link to the cwl-utils [*Pull the all referenced software container images*](https://github.com/common-workflow-language/cwl-utils#pull-the-all-referenced-software-container-images) reference.

The variable is now listed in the environment-variable table (introduced when the CLI groups were reorganized), so it appears in `cwltool --help` and the autogenerated Sphinx CLI docs. What was still missing is the second half of the request: pointing users at *how* to pre-populate that cache.

## Change

Extend the `CWL_SINGULARITY_CACHE` entry in `cwltool/argparser.py` to link to cwl-utils' `cwl-docker-extract`, which pre-pulls all referenced container images into a directory. It uses the existing `[link=...]` markup (same as the `ORCID` entry), so it renders correctly in both outputs:

**`cwltool --help`** (terminal hyperlink):
```
CWL_SINGULARITY_CACHE │ directory path to find already downloaded
                      │ Singularity images; dockerFile images will also be
                      │ searched for and stored here. Images can be
                      │ pre-pulled into this directory using
                      │ cwl-docker-extract from cwl-utils
```

**Sphinx CLI docs** (reStructuredText):
```rst
.. envvar:: CWL_SINGULARITY_CACHE

    directory path to find already downloaded Singularity images; ``dockerFile`` images
    will also be searched for and stored here. Images can be pre-pulled into this directory
    using `cwl-docker-extract <https://github.com/common-workflow-language/cwl-utils#pull-the-all-referenced-software-container-images>`__ from cwl-utils
```

Verified the cwl-utils anchor still resolves, the parser still builds, and `black`/`flake8` are clean. Docs-only string change. **Once this lands, #1537 can be closed.**

---

This change was produced with the assistance of **Claude Code** (model: Claude Opus). It was reviewed by a human before submission.