### PR TITLE
Warn when 'format' is used on a non-File parameter (#1616, #607)

### DIFF
--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -467,6 +467,26 @@ def avroize_type(
     return field_type
 
 
+def _type_contains_file(
+    field_type: CWLObjectType | MutableSequence[Any] | CWLOutputType | None,
+) -> bool:
+    """Return True if a (possibly compound/nullable) parameter type includes a ``File``."""
+    if isinstance(field_type, str):
+        # handle plain ("File"), namespaced ("...#File") and avro ("...cwl.File") forms
+        return field_type.replace("#", ".").split(".")[-1] == "File"
+    if isinstance(field_type, MutableSequence):
+        return any(_type_contains_file(entry) for entry in field_type)
+    if isinstance(field_type, MutableMapping):
+        if field_type.get("type") == "array":
+            return _type_contains_file(cast(CWLOutputType, field_type.get("items")))
+        if field_type.get("type") == "record":
+            return any(
+                _type_contains_file(cast(CWLObjectType, fld).get("type"))
+                for fld in cast(MutableSequence[Any], field_type.get("fields", []))
+            )
+    return False
+
+
 def get_overrides(overrides: MutableSequence[CWLObjectType], toolid: str) -> CWLObjectType:
     """Combine overrides for the target tool ID."""
     req: CWLObjectType = {}
@@ -654,6 +674,14 @@ class Process(HasReqsHints, metaclass=abc.ABCMeta):
                     c["type"] = nullable
                 else:
                     c["type"] = c["type"]
+
+                if "format" in c and not _type_contains_file(c["type"]):
+                    _logger.warning(
+                        SourceLine(i, "format", str).makeError(
+                            "'format' is only valid for 'File' type parameters, but "
+                            "'%s' is not a File; the 'format' field will be ignored." % c["name"]
+                        )
+                    )
 
                 c["type"] = avroize_type(c["type"], c["name"])
                 if key == "inputs":

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -471,19 +471,16 @@ def _type_contains_file(
     field_type: CWLObjectType | MutableSequence[Any] | CWLOutputType | None,
 ) -> bool:
     """Return True if a (possibly compound/nullable) parameter type includes a ``File``."""
-    if isinstance(field_type, str):
-        # handle plain ("File"), namespaced ("...#File") and avro ("...cwl.File") forms
-        return field_type.replace("#", ".").split(".")[-1] == "File"
-    if isinstance(field_type, MutableSequence):
-        return any(_type_contains_file(entry) for entry in field_type)
-    if isinstance(field_type, MutableMapping):
-        if field_type.get("type") == "array":
-            return _type_contains_file(cast(CWLOutputType, field_type.get("items")))
-        if field_type.get("type") == "record":
-            return any(
-                _type_contains_file(cast(CWLObjectType, fld).get("type"))
-                for fld in cast(MutableSequence[Any], field_type.get("fields", []))
-            )
+    match field_type:
+        case str() as type_str:
+            # handle plain ("File"), namespaced ("...#File") and avro ("...cwl.File") forms
+            return type_str.replace("#", ".").split(".")[-1] == "File"
+        case MutableSequence() as field_seq:
+            return any(_type_contains_file(entry) for entry in field_seq)
+        case {"type": "array", "items": list() as items}:
+            return _type_contains_file(cast(CWLOutputType, items))
+        case {"type": "record", "fields": list() as fields}:
+            return any(_type_contains_file(cast(CWLObjectType, fld).get("type")) for fld in fields)
     return False
 
 

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -477,7 +477,8 @@ def _type_contains_file(
             return type_str.replace("#", ".").split(".")[-1] == "File"
         case MutableSequence() as field_seq:
             return any(_type_contains_file(entry) for entry in field_seq)
-        case {"type": "array", "items": list() as items}:
+        case {"type": "array", "items": items}:
+            # items may be a single type ("File") or a union list (["File", "Directory"])
             return _type_contains_file(cast(CWLOutputType, items))
         case {"type": "record", "fields": list() as fields}:
             return any(_type_contains_file(cast(CWLObjectType, fld).get("type")) for fld in fields)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -85,6 +85,62 @@ def test_validate_no_format_warning_for_file() -> None:
     assert "'format' is only valid" not in custom_log.getvalue()
 
 
+def test_validate_no_format_warning_for_file_array() -> None:
+    """`format` on File[] is valid; covers array type with string items."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-file-array.cwl")],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "'format' is only valid" not in custom_log.getvalue()
+
+
+def test_validate_warns_on_format_for_directory_array() -> None:
+    """`format` on Directory[] warns; covers array type recursion."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-directory-array.cwl")],
+        logger_handler=handler,
+    )
+    log_text = re.sub(r"\s\s+", " ", custom_log.getvalue())
+    assert exit_code == 0
+    assert "'format' is only valid for 'File' type parameters" in log_text
+    assert "'dirs' is not a File" in log_text
+
+
+def test_validate_no_format_warning_for_record_with_file() -> None:
+    """`format` on a record containing a File field must not warn."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-record-file.cwl")],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "'format' is only valid" not in custom_log.getvalue()
+
+
+def test_validate_warns_on_format_for_record_without_file() -> None:
+    """`format` on a record with no File field warns; covers record type recursion."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-record-string.cwl")],
+        logger_handler=handler,
+    )
+    log_text = re.sub(r"\s\s+", " ", custom_log.getvalue())
+    assert exit_code == 0
+    assert "'format' is only valid for 'File' type parameters" in log_text
+    assert "'rec' is not a File" in log_text
+
+
 def test_validate_quiet() -> None:
     """Ensure that --validate --quiet prints the correct amount of information."""
     exit_code, stdout, stderr = get_main_output(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -57,6 +57,34 @@ def test_validate_with_invalid_input_object() -> None:
     )
 
 
+def test_validate_warns_on_format_for_non_file() -> None:
+    """`format` on a non-File parameter (e.g. Directory) warns but still validates (#1616, #607)."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-directory.cwl")],
+        logger_handler=handler,
+    )
+    log_text = re.sub(r"\s\s+", " ", custom_log.getvalue())
+    assert exit_code == 0
+    assert "'format' is only valid for 'File' type parameters" in log_text
+    assert "'indir' is not a File" in log_text
+
+
+def test_validate_no_format_warning_for_file() -> None:
+    """`format` on a File parameter is valid and must not warn (#1616, #607)."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/format-on-file.cwl")],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "'format' is only valid" not in custom_log.getvalue()
+
+
 def test_validate_quiet() -> None:
     """Ensure that --validate --quiet prints the correct amount of information."""
     exit_code, stdout, stderr = get_main_output(

--- a/tests/wf/format-on-directory-array.cwl
+++ b/tests/wf/format-on-directory-array.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+# `format` on Directory[] should warn: array items are not File.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  dirs:
+    type: Directory[]
+    format: http://edamontology.org/format_1915
+    inputBinding: {}
+outputs: []
+baseCommand: echo

--- a/tests/wf/format-on-directory.cwl
+++ b/tests/wf/format-on-directory.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+# Regression fixture for https://github.com/common-workflow-language/cwltool/issues/1616
+# (and #607): `format` is only meaningful for File parameters. Specifying it on a
+# Directory input should produce a validation warning, not pass silently.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  indir:
+    type: Directory
+    format: http://edamontology.org/format_1915
+    inputBinding: {}
+outputs: []
+baseCommand: echo

--- a/tests/wf/format-on-file-array.cwl
+++ b/tests/wf/format-on-file-array.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+# `format` on File[] is valid (items is a string after load, not a list).
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  files:
+    type: File[]
+    format: http://edamontology.org/format_1915
+    inputBinding: {}
+outputs: []
+baseCommand: echo

--- a/tests/wf/format-on-file.cwl
+++ b/tests/wf/format-on-file.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+# Companion fixture: `format` on a File input is valid and must NOT warn.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  inf:
+    type: File
+    format: http://edamontology.org/format_1915
+    inputBinding: {}
+outputs: []
+baseCommand: echo

--- a/tests/wf/format-on-record-file.cwl
+++ b/tests/wf/format-on-record-file.cwl
@@ -1,0 +1,14 @@
+#!/usr/bin/env cwl-runner
+# `format` on a record that contains a File field is valid.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  rec:
+    type:
+      type: record
+      fields:
+        - name: f
+          type: File
+    format: http://edamontology.org/format_1915
+outputs: []
+baseCommand: echo

--- a/tests/wf/format-on-record-string.cwl
+++ b/tests/wf/format-on-record-string.cwl
@@ -1,0 +1,14 @@
+#!/usr/bin/env cwl-runner
+# `format` on a record with no File field should warn.
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  rec:
+    type:
+      type: record
+      fields:
+        - name: s
+          type: string
+    format: http://edamontology.org/format_1915
+outputs: []
+baseCommand: echo


### PR DESCRIPTION
## Summary

Fixes #1616 and #607.

`format` is only meaningful for `File` parameters. cwltool silently accepted it on `Directory` (and other) inputs/outputs, so `--validate` passed with no indication that the field would be ignored — exactly the "validation passes with no warnings/errors" behavior reported in #1616, and the "complains far too late" symptom in #607.

```console
$ cwltool --validate format-on-directory.cwl
format-on-directory.cwl is valid CWL.    # before — no hint that `format` is bogus
```

## Change

In `Process.__init__` (`cwltool/process.py`), while iterating the tool's `inputs`/`outputs`, emit a warning when a parameter declares `format` but its type does not contain a `File`. A small recursive helper `_type_contains_file` handles plain (`File`), namespaced, array (`File[]`), nullable (`File?`) and record forms.

```console
$ cwltool --validate format-on-directory.cwl
format-on-directory.cwl:10:5: 'format' is only valid for 'File' type parameters, but 'indir' is not a File; the 'format' field will be ignored.
format-on-directory.cwl is valid CWL.    # after
```

A **warning** (not a hard error as #607 literally suggested) was chosen so existing documents carrying a harmless stray `format` keep validating; this also matches the direction in the newer #1616. The warning respects `--no-warnings`/`--quiet` like other validation warnings.

## Tests

Added `tests/wf/format-on-directory.cwl` and `tests/wf/format-on-file.cwl` fixtures, plus two tests in `tests/test_validate.py`:
- `test_validate_warns_on_format_for_non_file` — asserts the warning is emitted (captured via a custom log handler, as `test_validate_custom_logger` does).
- `test_validate_no_format_warning_for_file` — asserts `format` on a `File` does **not** warn.

I verified the warn-test fails against the pre-fix code and passes after, and that the File case never warns. Full `test_validate.py` passes (8); `black`/`flake8`/`isort` clean.

---

This change was produced with the assistance of **Claude Code** (model: Claude Opus). The diff, analysis, and tests were reviewed by a human before submission.