### PR TITLE
Warn when 'baseCommand' is a single string with whitespace (#2240)

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -423,6 +423,17 @@ class CommandLineTool(Process):
     def __init__(self, toolpath_object: CommentedMap, loadingContext: LoadingContext) -> None:
         """Initialize this CommandLineTool."""
         super().__init__(toolpath_object, loadingContext)
+        base_command = self.tool.get("baseCommand")
+        if isinstance(base_command, str) and len(base_command.split()) > 1:
+            _logger.warning(
+                SourceLine(self.tool, "baseCommand", str).makeError(
+                    "'baseCommand' is a single string containing whitespace: %r. "
+                    "It will be passed to the operating system as one program name, "
+                    "which is unlikely to exist. If you meant a program plus arguments, "
+                    "provide a list instead, e.g. [%s]."
+                    % (base_command, ", ".join(repr(p) for p in base_command.split()))
+                )
+            )
         self.prov_obj = loadingContext.prov_obj
         self.path_check_mode: PathCheckingMode = (
             PathCheckingMode.RELAXED

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,6 +4,8 @@ import io
 import logging
 import re
 
+import pytest
+
 from .util import get_data, get_main_output
 
 
@@ -125,3 +127,37 @@ def test_validate_custom_logger() -> None:
     assert "tests/CometAdapter.cwl#out' previously defined" not in stdout
     assert "tests/CometAdapter.cwl#out' previously defined" not in stderr
     assert "tests/CometAdapter.cwl#out' previously defined" in custom_log_text
+
+
+def test_validate_warns_on_basecommand_with_space() -> None:
+    """A 'baseCommand' string containing whitespace warns but still validates."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, stdout, stderr = get_main_output(
+        ["--validate", get_data("tests/wf/2240-basecommand-space.cwl")],
+        logger_handler=handler,
+    )
+    custom_log_text = re.sub(r"\s\s+", " ", custom_log.getvalue())
+    assert exit_code == 0
+    assert "is valid CWL" in stdout
+    assert "'baseCommand' is a single string containing whitespace" in custom_log_text
+    assert "'tar xf'" in custom_log_text
+    assert "['tar', 'xf']" in custom_log_text
+
+
+@pytest.mark.parametrize(
+    "cwl_file",
+    ["tests/wf/2240-basecommand-list.cwl", "tests/CometAdapter.cwl"],
+)
+def test_validate_no_basecommand_space_warning(cwl_file: str) -> None:
+    """A list-form (or absent) 'baseCommand' does not trigger the whitespace warning."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data(cwl_file)],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "single string containing whitespace" not in custom_log.getvalue()

--- a/tests/wf/2240-basecommand-list.cwl
+++ b/tests/wf/2240-basecommand-list.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [tar, xf]
+inputs: []
+outputs: []

--- a/tests/wf/2240-basecommand-space.cwl
+++ b/tests/wf/2240-basecommand-space.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: "tar xf"
+inputs: []
+outputs: []


### PR DESCRIPTION
## Problem

Addresses item 1 of #2240.

A `CommandLineTool` `baseCommand` written as a single string with internal whitespace — e.g.

```cwl
baseCommand: "tar xf"
```

— is interpreted by CWL as **one** program name (`argv[0] == "tar xf"`), not as `tar` plus the argument `xf`. Such an executable almost never exists, so the tool fails at run time. Today `--validate` accepts this silently:

```console
$ cwltool --validate space-basecommand.cwl
... space-basecommand.cwl is valid CWL.
```

The author almost certainly meant the list form `[tar, xf]`.

## Fix

Emit a warning at construction time (so it surfaces under `--validate`, before any execution) when `baseCommand` is a single string that splits into more than one whitespace-separated token. The warning points at the `baseCommand` source line and suggests the list form:

```console
$ cwltool --validate space-basecommand.cwl
WARNING space-basecommand.cwl:4:1: 'baseCommand' is a single string containing
whitespace: 'tar xf'. It will be passed to the operating system as one program
name, which is unlikely to exist. If you meant a program plus arguments, provide
a list instead, e.g. ['tar', 'xf'].
... space-basecommand.cwl is valid CWL.
```

It is a **warning, not an error** — the document is still structurally valid CWL, and a single-element command path that legitimately contains a space is technically allowed; this just flags the common mistake. The check lives in `CommandLineTool.__init__` and only fires for the single-string form, so:

- list-form `baseCommand: [tar, xf]` → no warning
- single-word `baseCommand: echo` → no warning
- absent `baseCommand` (e.g. ExpressionTool/Workflow) → no warning

This intentionally scopes to checkbox 1 of #2240 (warn about a space). Checkbox 2 (actually probing PATH / containers for the executable) is a larger, runtime/container-aware change and is left for a follow-up.

## Tests

`tests/test_validate.py`:
- `test_validate_warns_on_basecommand_with_space` — asserts the warning text, the offending value, and the suggested list form are logged (captured via a custom `logger_handler`, matching `test_validate_custom_logger`), and that exit code is still 0 / "valid CWL".
- `test_validate_no_basecommand_space_warning` (parametrized) — list-form and an existing no-baseCommand fixture produce **no** whitespace warning.

Fixtures: `tests/wf/2240-basecommand-space.cwl`, `tests/wf/2240-basecommand-list.cwl`.

I verified the warning test **fails** against the unpatched code (proving it guards the bug, not a no-op). All 9 tests in `tests/test_validate.py` pass; `black`, `flake8`, and `isort` are clean on the changed files.

---

This change was produced with the assistance of **Claude Code** (model: Claude Opus). The diff, root-cause analysis, and tests were reviewed by a human before submission.