### PR TITLE
ci: don't fail CI when Codecov upload fails on fork PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ matrix.step == 'unit' }}
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -231,7 +231,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   release_test:
@@ -320,6 +320,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The three Codecov upload steps use fail_ci_if_error: true with a token-gated upload (CODECOV_TOKEN). GitHub Actions withholds secrets from pull requests opened from forks, so the upload step fails and turns the whole CI run red for external contributors, regardless of whether their actual changes pass.

This restores the behaviour intentionally set in #1857 ("keep running even if codecov upload fails"), which was reverted by fe1e8a9a ("Fix codecov v4 configuration"). Coverage uploads from trusted (non-fork) runs still happen; they just no longer hard-fail CI.