### PR TITLE
Welling/check tmp dir exists

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -765,6 +765,7 @@ class CommandLineTool(Process):
 
             interesting = {
                 "DockerRequirement",
+                "DockerGpuRequirement",
                 "EnvVarRequirement",
                 "InitialWorkDirRequirement",
                 "ShellCommandRequirement",
@@ -939,6 +940,9 @@ class CommandLineTool(Process):
             j.outdir = builder.outdir
             j.tmpdir = builder.tmpdir
             j.stagedir = builder.stagedir
+
+        dockerGpuReq, _ = self.get_requirement("DockerGpuRequirement")
+        j.docker_gpu_flag = (dockerGpuReq is not None)
 
         inplaceUpdateReq, _ = self.get_requirement("InplaceUpdateRequirement")
         if inplaceUpdateReq is not None:

--- a/cwltool/docker.py
+++ b/cwltool/docker.py
@@ -341,6 +341,8 @@ class DockerCommandLineJob(ContainerCommandLineJob):
                 runtime = [user_space_docker_cmd, "run"]
         else:
             runtime = ["docker", "run", "-i"]
+        if getattr(self, 'docker_gpu_flag', False):
+            runtime.append('--gpus=all')
         self.append_volume(
             runtime, os.path.realpath(self.outdir), self.builder.outdir, writable=True
         )

--- a/cwltool/extensions.yml
+++ b/cwltool/extensions.yml
@@ -186,5 +186,3 @@ $graph:
       jsonldPredicate:
         "_id": "@type"
         "_type": "@vocab"
-    dockerGPU:
-      type: boolean

--- a/cwltool/extensions.yml
+++ b/cwltool/extensions.yml
@@ -174,3 +174,17 @@ $graph:
         The number of MPI processes to start. If you give a string,
         this will be evaluated as a CWL Expression and it must
         evaluate to an integer.
+
+- name: DockerGpuRequirement
+  type: record
+  inVocab: false
+  extends: cwl:ProcessRequirement
+  fields:
+    class:
+      type: string
+      doc: "Always 'DockerGpuRequirement'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+    dockerGPU:
+      type: boolean

--- a/cwltool/process.py
+++ b/cwltool/process.py
@@ -98,6 +98,7 @@ _logger_validation_warnings.addFilter(
 
 supportedProcessRequirements = [
     "DockerRequirement",
+    "DockerGpuRequirement",
     "SchemaDefRequirement",
     "EnvVarRequirement",
     "ScatterFeatureRequirement",
@@ -1055,7 +1056,7 @@ hints:
                         strict=strict,
                         vocab=self.doc_loader.vocab,
                     )
-                elif r["class"] in ("NetworkAccess", "LoadListingRequirement"):
+                elif r["class"] in ("NetworkAccess", "LoadListingRequirement", "DockerGpuRequirement"):
                     pass
                 else:
                     _logger.info(str(sl.makeError("Unknown hint %s" % (r["class"]))))

--- a/cwltool/schemas/v1.1/CommandLineTool.yml
+++ b/cwltool/schemas/v1.1/CommandLineTool.yml
@@ -1218,6 +1218,20 @@ $graph:
     inplaceUpdate:
       type: boolean
 
+- name: DockerGpuRequirement
+  type: record
+  extends: cwl:ProcessRequirement
+  doc: |
+    If present, specifies that Docker must be invoked with the '--gpus all'
+    command-line flags.
+  fields:
+    class:
+      type: string
+      doc: "Always 'DockerGpuRequirement'"
+      jsonldPredicate:
+        "_id": "@type"
+        "_type": "@vocab"
+
 - type: record
   name: ToolTimeLimit
   extends: ProcessRequirement

--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -388,6 +388,8 @@ class SingularityCommandLineJob(ContainerCommandLineJob):
             "--ipc",
             "--cleanenv",
         ]
+        if getattr(self, 'docker_gpu_flag', False):
+            runtime.append('--nv')
         if _singularity_supports_userns():
             runtime.append("--userns")
         else:

--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -58,6 +58,9 @@ def get_version() -> str:
         )
         if _SINGULARITY_VERSION.startswith("singularity version "):
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[20:]
+        if _SINGULARITY_VERSION.startswith("singularity-ce version "):
+            _SINGULARITY_VERSION = _SINGULARITY_VERSION[23:]
+        _logger.debug(f"Singularity version: {_SINGULARITY_VERSION}.")
     return _SINGULARITY_VERSION
 
 

--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -60,6 +60,8 @@ def get_version() -> str:
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[20:]
         if _SINGULARITY_VERSION.startswith("singularity-ce version "):
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[23:]
+        if _SINGULARITY_VERSION.startswith("apptainer version "):
+            _SINGULARITY_VERSION = _SINGULARITY_VERSION[18:]
         _logger.debug(f"Singularity version: {_SINGULARITY_VERSION}.")
     return _SINGULARITY_VERSION
 

--- a/cwltool/utils.py
+++ b/cwltool/utils.py
@@ -484,4 +484,5 @@ def local_path(posix_path: str) -> str:
 def create_tmp_dir(tmpdir_prefix: str) -> str:
     """Create a temporary directory that respects the given tmpdir_prefix."""
     tmp_dir, tmp_prefix = os.path.split(tmpdir_prefix)
+    os.makedirs(tmp_dir, exist_ok=True)
     return tempfile.mkdtemp(prefix=tmp_prefix, dir=tmp_dir)


### PR DESCRIPTION
There appears to be an order-of-operations problem when using the --provenance flag which causes cwltool to attempt to create a scratch directory before the parent directory cwl-tmp has been created.  This mod verifies that the parent directory exists before a scratch directory is created.