### PR TITLE
Make make_path_mapper extensible like make_fs_access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -910,6 +910,17 @@ make_fs_access
 
   Return a file system access object.
 
+path_mapper
+  ::
+
+    path_mapper(referenced_files, basedir, stagedir, separateDirs)
+      (MutableSequence[CWLObjectType], str, str, bool) -> PathMapper
+
+  The ``PathMapper`` class used to map input files and directories to the
+  locations where the tool expects them (and, during output collection, back
+  again).  Assign a subclass of ``cwltool.pathmapper.PathMapper`` to customise
+  staging without subclassing ``CommandLineTool``.
+
 In addition, when providing custom subclasses of Process objects, you can override the following methods:
 
 CommandLineTool.make_job_runner
@@ -919,6 +930,16 @@ CommandLineTool.make_job_runner
       (RuntimeContext) -> Type[JobBase]
 
   Create and return a job runner object (this implements concrete execution of a command line tool).
+
+CommandLineTool.make_path_mapper
+  ::
+
+    make_path_mapper(reffiles, stagedir, runtimeContext, separateDirs)
+      (MutableSequence[CWLObjectType], str, RuntimeContext, bool) -> PathMapper
+
+  Create and return the PathMapper for the input files and directories.  By
+  default this honours the ``path_mapper`` attribute above; override it in a
+  subclass for full control over how the PathMapper is constructed.
 
 Workflow.make_workflow_step
   ::

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -398,6 +398,26 @@ class ParameterOutputWorkflowException(WorkflowException):
         )
 
 
+def default_make_path_mapper(
+    reffiles: MutableSequence[CWLFileType | CWLDirectoryType],
+    stagedir: str,
+    runtimeContext: RuntimeContext,
+    separateDirs: bool,
+) -> PathMapper:
+    """Build a :py:class:`~cwltool.pathmapper.PathMapper` for the given inputs.
+
+    The concrete class is taken from
+    :py:attr:`~cwltool.context.RuntimeContext.path_mapper` (defaulting to
+    :py:class:`~cwltool.pathmapper.PathMapper`), so a custom ``PathMapper`` can
+    be supplied by setting that attribute on the
+    :py:class:`~cwltool.context.RuntimeContext` -- mirroring the
+    :py:attr:`~cwltool.context.RuntimeContext.make_fs_access` extension point --
+    without subclassing :py:class:`CommandLineTool`.
+    """
+    path_mapper_class: type[PathMapper] = getdefault(runtimeContext.path_mapper, PathMapper)
+    return path_mapper_class(reffiles, runtimeContext.basedir, stagedir, separateDirs)
+
+
 @mypyc_attr(allow_interpreted_subclasses=True)
 class CommandLineTool(Process):
     def __init__(self, toolpath_object: CommentedMap, loadingContext: LoadingContext) -> None:
@@ -447,14 +467,23 @@ class CommandLineTool(Process):
             )
         return CommandLineJob
 
-    @staticmethod
     def make_path_mapper(
+        self,
         reffiles: MutableSequence[CWLFileType | CWLDirectoryType],
         stagedir: str,
         runtimeContext: RuntimeContext,
         separateDirs: bool,
     ) -> PathMapper:
-        return PathMapper(reffiles, runtimeContext.basedir, stagedir, separateDirs)
+        """Create the :py:class:`~cwltool.pathmapper.PathMapper` for these inputs.
+
+        Delegates to :py:func:`default_make_path_mapper`, which selects the
+        concrete ``PathMapper`` class from
+        :py:attr:`~cwltool.context.RuntimeContext.path_mapper`.  This is an
+        instance method (not a ``@staticmethod``) so that subclasses of
+        :py:class:`CommandLineTool` may override it; being a regular method it
+        also dispatches correctly when cwltool is compiled with mypyc.
+        """
+        return default_make_path_mapper(reffiles, stagedir, runtimeContext, separateDirs)
 
     def updatePathmap(
         self, outdir: str, pathmap: PathMapper, fn: CWLFileType | CWLDirectoryType

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -6,7 +6,7 @@ from cwl_utils.types import CWLObjectType
 from schema_salad.avro import schema
 
 from cwltool.builder import Builder
-from cwltool.command_line_tool import CommandLineTool
+from cwltool.command_line_tool import default_make_path_mapper
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.cuda import cuda_version_and_device_count
 from cwltool.errors import WorkflowException
@@ -108,7 +108,7 @@ def test_cuda_job_setup_check(makedirs: MagicMock, check_output: MagicMock) -> N
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     jb._setup(runtime_context)
 
 
@@ -130,7 +130,7 @@ def test_cuda_job_setup_check_err(makedirs: MagicMock, check_output: MagicMock) 
 <cuda_version>1.0</cuda_version>
 </nvidia>
 """
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
 
@@ -156,7 +156,7 @@ def test_cuda_job_setup_check_err_empty_attached_gpus(
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
     assert (
@@ -185,7 +185,7 @@ def test_cuda_job_setup_check_err_empty_missing_attached_gpus(
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
     assert (
@@ -215,7 +215,7 @@ def test_cuda_job_setup_check_err_empty_cuda_version(
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
     assert (
@@ -244,7 +244,7 @@ def test_cuda_job_setup_check_err_missing_cuda_version(
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
     assert (
@@ -274,7 +274,7 @@ def test_cuda_job_setup_check_err_wrong_type_cuda_version(
 </nvidia>
 """
 
-    jb = CommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    jb = CommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     with pytest.raises(WorkflowException):
         jb._setup(runtime_context)
     assert (

--- a/tests/test_path_mapper_extension.py
+++ b/tests/test_path_mapper_extension.py
@@ -1,0 +1,100 @@
+"""Tests for customising the PathMapper used to stage a CommandLineTool's inputs.
+
+Two extension points are exercised:
+
+* setting :py:attr:`RuntimeContext.path_mapper` (like ``make_fs_access``), and
+* overriding :py:meth:`CommandLineTool.make_path_mapper` in a subclass.
+"""
+
+from collections.abc import MutableSequence
+from typing import cast
+
+from cwl_utils.types import CWLDirectoryType, CWLFileType
+from ruamel.yaml.comments import CommentedMap
+from schema_salad.sourceline import cmap
+
+from cwltool.command_line_tool import CommandLineTool, default_make_path_mapper
+from cwltool.context import LoadingContext, RuntimeContext
+from cwltool.job import JobBase
+from cwltool.pathmapper import PathMapper
+from cwltool.update import INTERNAL_VERSION, ORIGINAL_CWLVERSION
+
+
+class CustomPathMapper(PathMapper):
+    """A trivial PathMapper subclass used as a sentinel in these tests."""
+
+
+def _make_clt(cls: type[CommandLineTool] = CommandLineTool) -> CommandLineTool:
+    """Build a minimal no-op CommandLineTool for exercising ``.job()``."""
+    loading_context = LoadingContext(
+        {
+            "metadata": {
+                "cwlVersion": INTERNAL_VERSION,
+                ORIGINAL_CWLVERSION: INTERNAL_VERSION,
+            }
+        }
+    )
+    return cls(
+        cast(
+            CommentedMap,
+            cmap(
+                {
+                    "cwlVersion": INTERNAL_VERSION,
+                    "class": "CommandLineTool",
+                    "inputs": [],
+                    "outputs": [],
+                    "requirements": [],
+                }
+            ),
+        ),
+        loading_context,
+    )
+
+
+def _first_job(clt: CommandLineTool, runtime_context: RuntimeContext) -> JobBase:
+    """Return the first job produced by ``clt.job`` (without running it)."""
+    job = next(clt.job({}, lambda output, process_status: None, runtime_context))
+    assert isinstance(job, JobBase)
+    return job
+
+
+def test_default_make_path_mapper_returns_plain_pathmapper() -> None:
+    """Without customisation the default factory builds a plain PathMapper."""
+    mapper = default_make_path_mapper([], "", RuntimeContext(), True)
+    assert type(mapper) is PathMapper
+
+
+def test_default_make_path_mapper_honours_runtime_context() -> None:
+    """default_make_path_mapper uses RuntimeContext.path_mapper, like make_fs_access."""
+    runtime_context = RuntimeContext()
+    runtime_context.path_mapper = CustomPathMapper
+    mapper = default_make_path_mapper([], "", runtime_context, True)
+    assert isinstance(mapper, CustomPathMapper)
+
+
+def test_runtime_context_path_mapper_used_for_input_staging() -> None:
+    """A custom RuntimeContext.path_mapper is used when a job stages its inputs."""
+    runtime_context = RuntimeContext()
+    runtime_context.path_mapper = CustomPathMapper
+    job = _first_job(_make_clt(), runtime_context)
+    assert isinstance(job.builder.pathmapper, CustomPathMapper)
+
+
+def test_subclass_can_override_make_path_mapper() -> None:
+    """Overriding CommandLineTool.make_path_mapper in a subclass takes effect."""
+
+    class SubclassPathMapper(PathMapper):
+        pass
+
+    class CustomCommandLineTool(CommandLineTool):
+        def make_path_mapper(
+            self,
+            reffiles: MutableSequence[CWLFileType | CWLDirectoryType],
+            stagedir: str,
+            runtimeContext: RuntimeContext,
+            separateDirs: bool,
+        ) -> PathMapper:
+            return SubclassPathMapper(reffiles, runtimeContext.basedir, stagedir, separateDirs)
+
+    job = _first_job(_make_clt(CustomCommandLineTool), RuntimeContext())
+    assert isinstance(job.builder.pathmapper, SubclassPathMapper)

--- a/tests/test_tmpdir.py
+++ b/tests/test_tmpdir.py
@@ -17,7 +17,7 @@ from schema_salad.avro import schema
 from schema_salad.sourceline import cmap
 
 from cwltool.builder import Builder
-from cwltool.command_line_tool import CommandLineTool
+from cwltool.command_line_tool import CommandLineTool, default_make_path_mapper
 from cwltool.context import LoadingContext, RuntimeContext
 from cwltool.docker import DockerCommandLineJob
 from cwltool.errors import WorkflowException
@@ -159,9 +159,7 @@ def test_dockerfile_tmpdir_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         INTERNAL_VERSION,
         "docker",
     )
-    assert DockerCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    assert DockerCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         {
             "class": "DockerRequirement",
             "dockerFile": "FROM debian:stable-slim",
@@ -216,9 +214,7 @@ def test_dockerfile_build(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
 
     docker_image_id = sys._getframe().f_code.co_name
 
-    assert DockerCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    assert DockerCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         {
             "class": "DockerRequirement",
             "dockerFile": "FROM debian:stable-slim",
@@ -276,9 +272,7 @@ def test_dockerfile_singularity_build(monkeypatch: pytest.MonkeyPatch, tmp_path:
         "singularity",
     )
 
-    assert SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    assert SingularityCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         {
             "class": "DockerRequirement",
             "dockerFile": "FROM debian:stable-slim",
@@ -347,9 +341,7 @@ def test_singularity_get_image_from_sandbox(
         "cwltool.singularity._inspect_singularity_sandbox_image", lambda *args, **kwargs: False
     )
     req = {"class": "DockerRequirement", "dockerPull": f"{image_path}"}
-    res = SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    res = SingularityCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         req,
         pull_image=False,
         tmp_outdir_prefix=str(tmp_outdir_prefix),
@@ -363,9 +355,7 @@ def test_singularity_get_image_from_sandbox(
         "cwltool.singularity._inspect_singularity_sandbox_image", lambda *args, **kwargs: True
     )
     req = {"class": "DockerRequirement", "dockerPull": f"{image_path}"}
-    res = SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    res = SingularityCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         req,
         pull_image=False,
         tmp_outdir_prefix=str(tmp_outdir_prefix),
@@ -376,9 +366,7 @@ def test_singularity_get_image_from_sandbox(
 
     # test that dockerImageId is set and image exists:
     req = {"class": "DockerRequirement", "dockerImageId": f"{image_path}"}
-    res = SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
-    ).get_image(
+    res = SingularityCommandLineJob(builder, {}, default_make_path_mapper, [], [], "").get_image(
         req,
         pull_image=False,
         tmp_outdir_prefix=str(tmp_outdir_prefix),
@@ -441,7 +429,7 @@ def test_singularity_image_base_path(
     requirements1 = copy.deepcopy(initial_requirements)
     # get image from sandbox_base_path option
     res_get_image = SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
+        builder, {}, default_make_path_mapper, [], [], ""
     ).get_image(
         requirements1,
         pull_image=False,
@@ -454,7 +442,7 @@ def test_singularity_image_base_path(
 
     requirements2: CWLObjectType = {"class": "DockerRequirement", "dockerPull": "alpine"}
     res_get_req = SingularityCommandLineJob(
-        builder, {}, CommandLineTool.make_path_mapper, [], [], ""
+        builder, {}, default_make_path_mapper, [], [], ""
     ).get_from_requirements(
         requirements2,
         pull_image=False,
@@ -471,7 +459,7 @@ def test_singularity_image_base_path(
     # should return an error
     with pytest.raises(WorkflowException):
         res_get_req = SingularityCommandLineJob(
-            builder, {}, CommandLineTool.make_path_mapper, [], [], ""
+            builder, {}, default_make_path_mapper, [], [], ""
         ).get_from_requirements(
             requirements3,
             pull_image=False,
@@ -484,7 +472,7 @@ def test_singularity_image_base_path(
     with monkeypatch.context() as m:
         m.setenv("CWL_SINGULARITY_IMAGES", str(repo_path))
         res_get_image = SingularityCommandLineJob(
-            builder, {}, CommandLineTool.make_path_mapper, [], [], ""
+            builder, {}, default_make_path_mapper, [], [], ""
         ).get_image(
             requirements4,
             pull_image=False,
@@ -503,7 +491,7 @@ def test_singularity_image_base_path(
             "dockerImageId": str(image_path),
         }
         res_get_req = SingularityCommandLineJob(
-            builder, {}, CommandLineTool.make_path_mapper, [], [], ""
+            builder, {}, default_make_path_mapper, [], [], ""
         ).get_from_requirements(
             requirements5,
             pull_image=False,
@@ -549,7 +537,7 @@ def test_docker_tmpdir_prefix(tmp_path: Path) -> None:
         INTERNAL_VERSION,
         "docker",
     )
-    job = DockerCommandLineJob(builder, {}, CommandLineTool.make_path_mapper, [], [], "")
+    job = DockerCommandLineJob(builder, {}, default_make_path_mapper, [], [], "")
     runtime: list[str] = []
 
     volume_writable_file = MapperEnt(


### PR DESCRIPTION
- enable `make_path_mapper` to be extensible like `make_fs_access`
- make `CommandLineTool` `make_path_mapper` overridable by making it an instance method