### PR TITLE
Handle list-valued doc when rendering --tool-help

### DIFF
--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -966,7 +966,7 @@ def add_argument(
     urljoin: Callable[[str, str], str] = urllib.parse.urljoin,
     base_uri: str = "",
 ) -> None:
-    description = rich.markup.escape(doc_to_str(description))
+    description = rich.markup.escape(description)
     if len(name) == 1:
         flag = "-"
     else:
@@ -1075,7 +1075,7 @@ def generate_parser(
         name = shortname(inp["id"])
         namemap[name.replace("-", "_")] = name
         inptype = inp["type"]
-        description = inp.get("doc", inp.get("label", ""))
+        description = doc_to_str(inp.get("doc", inp.get("label", "")))
         default = inp.get("default", None)
         add_argument(
             toolparser,

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -941,6 +941,20 @@ class AppendAction(argparse.Action):
         setattr(namespace, self.dest, g)
 
 
+def doc_to_str(doc: Any) -> str:
+    """Normalize a CWL ``doc``/``label`` field to a single string.
+
+    The CWL spec allows ``doc`` to be either a single string or an array
+    of strings (one entry per line). Join list entries with newlines so
+    downstream consumers (argparse, rich) always receive a plain string.
+    """
+    if isinstance(doc, MutableSequence):
+        return "\n".join(str(entry) for entry in doc)
+    if doc is None:
+        return ""
+    return str(doc)
+
+
 def add_argument(
     toolparser: argparse.ArgumentParser,
     name: str,
@@ -952,7 +966,7 @@ def add_argument(
     urljoin: Callable[[str, str], str] = urllib.parse.urljoin,
     base_uri: str = "",
 ) -> None:
-    description = rich.markup.escape(description)
+    description = rich.markup.escape(doc_to_str(description))
     if len(name) == 1:
         flag = "-"
     else:
@@ -1052,7 +1066,8 @@ def generate_parser(
     base_uri: str = "",
 ) -> argparse.ArgumentParser:
     """Generate an ArgumentParser for the given CWL Process."""
-    toolparser.description = tool.tool.get("doc", tool.tool.get("label", None))
+    doc = tool.tool.get("doc", tool.tool.get("label", None))
+    toolparser.description = doc_to_str(doc) if doc is not None else None
     toolparser.add_argument("job_order", nargs="?", help="Job input json file")
     namemap["job_order"] = "job_order"
 

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -1066,8 +1066,7 @@ def generate_parser(
     base_uri: str = "",
 ) -> argparse.ArgumentParser:
     """Generate an ArgumentParser for the given CWL Process."""
-    doc = tool.tool.get("doc", tool.tool.get("label", None))
-    toolparser.description = doc_to_str(doc) if doc is not None else None
+    toolparser.description = doc_to_str(tool.tool.get("doc", tool.tool.get("label", None))) or None
     toolparser.add_argument("job_order", nargs="?", help="Job input json file")
     namemap["job_order"] = "job_order"
 

--- a/cwltool/argparser.py
+++ b/cwltool/argparser.py
@@ -949,7 +949,7 @@ def doc_to_str(doc: Any) -> str:
     downstream consumers (argparse, rich) always receive a plain string.
     """
     if isinstance(doc, MutableSequence):
-        return "\n".join(str(entry) for entry in doc)
+        return "\n".join(doc)
     if doc is None:
         return ""
     return str(doc)

--- a/tests/test_misc_cli.py
+++ b/tests/test_misc_cli.py
@@ -39,6 +39,22 @@ def test_tool_help(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "job_order   Job input json file" in stdout
 
 
+def test_tool_help_with_doc_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test --tool-help does not crash when `doc` is a list of strings.
+
+    Regression test for https://github.com/common-workflow-language/cwltool/issues/2100
+    """
+    return_code, stdout, stderr = get_main_output(
+        ["--tool-help", get_data("tests/with_doc_list.cwl")],
+        extra_env={"NO_COLOR": "1"},
+        monkeypatch=monkeypatch,
+    )
+    assert return_code == 0
+    assert "line one" in stdout
+    assert "line two" in stdout
+    assert "The message to print." in stdout
+
+
 def test_basic_pack() -> None:
     """Basic test of --pack. See test_pack.py for detailed testing."""
     return_code, stdout, stderr = get_main_output(["--pack", get_data("tests/wf/revsort.cwl")])

--- a/tests/test_toolargparse.py
+++ b/tests/test_toolargparse.py
@@ -279,6 +279,20 @@ def test_argparser_without_doc() -> None:
     assert parser.description is None
 
 
+def test_argparser_with_doc_as_list() -> None:
+    """The `doc`/`label` fields may be a list of strings per the CWL spec.
+
+    Regression test for https://github.com/common-workflow-language/cwltool/issues/2100
+    """
+    loadingContext = LoadingContext()
+    tool = load_tool(get_data("tests/with_doc_list.cwl"), loadingContext)
+    p = argparse.ArgumentParser()
+    parser = generate_parser(p, tool, {}, [], False)
+    assert parser.description is not None
+    assert "line one" in parser.description
+    assert "line two" in parser.description
+
+
 def test_argparser_prog_is_cwltool(monkeypatch: pytest.MonkeyPatch) -> None:
     """The program name is reported as ``cwltool`` when invoked as ``cwl-runner``.
 

--- a/tests/with_doc_list.cwl
+++ b/tests/with_doc_list.cwl
@@ -1,0 +1,16 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+inputs:
+  - id: message
+    type: string
+    doc:
+      - "The message to print."
+      - "Second line for the message input."
+    inputBinding: {}
+baseCommand: echo
+outputs: []
+
+doc:
+  - "This should be shown in help message, line one."
+  - "This should be shown in help message, line two."


### PR DESCRIPTION
## Problem

Fixes #2100.

The CWL spec allows `doc` (and `label`) to be either a single string or an array of strings, but the `--tool-help` renderer assumed `doc` was always a string. A tool whose top-level `doc:` is a YAML list crashes:

```console
$ cwltool --tool-help doclist.cwl
ERROR Unhandled error:
  Unable to get render width for ['line one', 'line two']; a str, Segment, or object with __rich_console__ method is required
```

And a list-valued `doc` on an *input* crashes earlier, with a different symptom:

```console
$ cwltool --tool-help doclist.cwl
ERROR Unhandled error, try again with --debug for more information:
  expected string or bytes-like object, got 'CommentedSeq'
```

Both come from the same root cause in `cwltool/argparser.py`:
- `generate_parser` assigns `tool.tool.get("doc", ...)` directly to `toolparser.description`, which `rich_argparse`'s `RichHelpFormatter` then tries to render — a list isn't a valid rich renderable.
- `add_argument` passes the same raw value into `rich.markup.escape(description)`, which requires a `str`.

## Fix

Added a small `doc_to_str` helper that normalizes `doc`/`label` to a string (list entries are joined with newlines), and used it at both call sites. The existing string path is unchanged; `None` (no doc/label) still produces `toolparser.description = None` as before.

## Tests

- `tests/test_toolargparse.py::test_argparser_with_doc_as_list` — `generate_parser` on a tool whose `doc` is a list produces a non-`None` description containing all list entries.
- `tests/test_misc_cli.py::test_tool_help_with_doc_list` — end-to-end `--tool-help` (the actual crash path via `print_help`) exits 0 and prints all doc lines, for both the top-level tool doc and an input's doc.
- New fixture: `tests/with_doc_list.cwl` (list-valued `doc` on the tool and on an input), alongside the existing `tests/with_doc.cwl`.

Both new tests fail against the unpatched code (`TypeError: expected string or bytes-like object, got 'CommentedSeq'` / `rich.errors.NotRenderableError: Unable to get render width for [...]`) and pass with the fix. Full run of `tests/test_toolargparse.py` and `tests/test_misc_cli.py`: 31 passed. `black`, `flake8`, `isort`, and `mypy` are clean on the changed files.

---

This change was produced with the assistance of Claude Code. The diff and tests were reviewed by a human before submission.