### PR TITLE
Give a meaningful error for an empty job order file

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -367,11 +367,19 @@ def load_job_order(
         input_basedir = (
             args.basedir if args.basedir else os.path.abspath(os.path.dirname(job_order_file))
         )
-        job_order_object, _ = loader.resolve_ref(
-            job_order_file,
-            checklinks=False,
-            content_types=CWL_CONTENT_TYPES,
-        )
+        try:
+            job_order_object, _ = loader.resolve_ref(
+                job_order_file,
+                checklinks=False,
+                content_types=CWL_CONTENT_TYPES,
+            )
+        except StopIteration:
+            _logger.error(
+                "CWL input object at %s is empty. It should be a JSON/YAML dictionary "
+                "of the input parameters, or '{}' if the process takes no inputs.",
+                job_order_file,
+            )
+            sys.exit(1)
 
     if (
         isinstance(job_order_object, CommentedMap)

--- a/tests/test_empty_input.py
+++ b/tests/test_empty_input.py
@@ -1,6 +1,8 @@
 from io import StringIO
 from pathlib import Path
 
+import pytest
+
 from cwltool.main import main
 
 from .util import get_data
@@ -22,3 +24,21 @@ def test_empty_input(tmp_path: Path) -> None:
         assert main(params, stdin=empty_input) == 0
     except SystemExit as err:
         assert err.code == 0
+
+
+def test_empty_input_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """An empty job order file gets a meaningful error message, not a blank one."""
+    empty_input = tmp_path / "empty.yml"
+    empty_input.write_text("")
+
+    params = [
+        "--outdir",
+        str(tmp_path),
+        get_data("tests/wf/no-parameters-echo.cwl"),
+        str(empty_input),
+    ]
+
+    with pytest.raises(SystemExit) as err:
+        main(params)
+    assert err.value.code == 1
+    assert "is empty" in caplog.text


### PR DESCRIPTION
Fixes #2043

An empty job order file makes schema-salad's `Loader.fetch()` raise a bare `StopIteration`, which `main()` catches in its generic handler and renders as "I'm sorry, I couldn't load this CWL file" followed by an empty error string. `load_job_order()` now catches it and reports that the input object file is empty, in the same style as the existing "not formatted correctly" error for malformed input objects.
