### PR TITLE
Write cached Singularity image resolution back to dockerImageId

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -234,7 +234,7 @@ class SingularityCommandLineJob(ContainerCommandLineJob):
                 d_image_id = dockerRequirement["dockerImageId"]
                 if d_image_id in _IMAGES:
                     if (resolved_image_id := _IMAGES[d_image_id]) != d_image_id:
-                        dockerRequirement["dockerImage_id"] = resolved_image_id
+                        dockerRequirement["dockerImageId"] = resolved_image_id
                     return True
                 if d_image_id.startswith("/"):
                     _logger.info(

--- a/tests/test_singularity.py
+++ b/tests/test_singularity.py
@@ -14,6 +14,7 @@ from cwltool.main import main
 from cwltool.singularity import (
     _IMAGES,
     _IMAGES_LOCK,
+    SingularityCommandLineJob,
     _inspect_singularity_sandbox_image,
 )
 
@@ -414,3 +415,21 @@ def test_inspect_image_wrong_sb_call(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("cwltool.singularity.run", mock_failed_subprocess)
     res_inspect = _inspect_singularity_sandbox_image("/tmp/container_repo/alpine")
     assert res_inspect is False
+
+
+def test_get_image_cached_resolution_updates_docker_image_id() -> None:
+    """A cached image resolution must be written back to 'dockerImageId'."""
+    with _IMAGES_LOCK:
+        _IMAGES["test-cached-image.sif"] = "/cache/test-cached-image.sif"
+    try:
+        docker_requirement: dict[str, str] = {
+            "class": "DockerRequirement",
+            "dockerImageId": "test-cached-image.sif",
+        }
+        assert SingularityCommandLineJob.get_image(
+            docker_requirement, pull_image=False, tmp_outdir_prefix="/tmp/"
+        )
+        assert docker_requirement["dockerImageId"] == "/cache/test-cached-image.sif"
+    finally:
+        with _IMAGES_LOCK:
+            _IMAGES.pop("test-cached-image.sif", None)


### PR DESCRIPTION
Closes #2283

When `get_image()` hits the `_IMAGES` cache it wrote the resolved image to `dockerRequirement["dockerImage_id"]`, but nothing ever reads that field — `get_from_requirements()` and the sandbox path both read `dockerImageId`, so the cached resolution was discarded and the unresolved id was used. Writes it back to `dockerImageId`, matching the cache update at the end of the same method.

Regression test seeds `_IMAGES` with a resolved path and asserts the requirement is updated; it fails on master and passes with the change.
