### PR TITLE
Warn when a baseCommand cannot be found on PATH or in a container image

### DIFF
--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -9,7 +9,7 @@ import os
 import re
 import shlex
 import shutil
-import subprocess
+import subprocess  # nosec
 import threading
 import urllib
 import urllib.parse
@@ -422,7 +422,7 @@ def default_make_path_mapper(
 def _container_has_command(docker: str, image: str, command: str) -> Optional[bool]:
     """Return True/False if *command* is (not) present in *image*, or None if
     the image is not available locally and cannot be inspected."""
-    inspect = subprocess.run(
+    inspect = subprocess.run(  # nosec
         [docker, "image", "inspect", image],
         capture_output=True,
         text=True,
@@ -430,7 +430,7 @@ def _container_has_command(docker: str, image: str, command: str) -> Optional[bo
     )
     if inspect.returncode != 0:
         return None
-    probe = subprocess.run(
+    probe = subprocess.run(  # nosec
         [docker, "run", "--rm", "--entrypoint", "sh", image, "-c", shlex.quote(command)],
         capture_output=True,
         text=True,
@@ -440,7 +440,7 @@ def _container_has_command(docker: str, image: str, command: str) -> Optional[bo
         return True
     # The probe can also fail when the image has no shell at all (e.g.
     # distroless images); distinguish that from a missing command.
-    shell = subprocess.run(
+    shell = subprocess.run(  # nosec
         [docker, "run", "--rm", "--entrypoint", "sh", image, "true"],
         capture_output=True,
         text=True,

--- a/cwltool/command_line_tool.py
+++ b/cwltool/command_line_tool.py
@@ -9,6 +9,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import threading
 import urllib
 import urllib.parse
@@ -418,6 +419,38 @@ def default_make_path_mapper(
     return path_mapper_class(reffiles, runtimeContext.basedir, stagedir, separateDirs)
 
 
+def _container_has_command(docker: str, image: str, command: str) -> Optional[bool]:
+    """Return True/False if *command* is (not) present in *image*, or None if
+    the image is not available locally and cannot be inspected."""
+    inspect = subprocess.run(
+        [docker, "image", "inspect", image],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if inspect.returncode != 0:
+        return None
+    probe = subprocess.run(
+        [docker, "run", "--rm", "--entrypoint", "sh", image, "-c", shlex.quote(command)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        return True
+    # The probe can also fail when the image has no shell at all (e.g.
+    # distroless images); distinguish that from a missing command.
+    shell = subprocess.run(
+        [docker, "run", "--rm", "--entrypoint", "sh", image, "true"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if shell.returncode != 0:
+        return None
+    return False
+
+
 @mypyc_attr(allow_interpreted_subclasses=True)
 class CommandLineTool(Process):
     def __init__(self, toolpath_object: CommentedMap, loadingContext: LoadingContext) -> None:
@@ -434,12 +467,70 @@ class CommandLineTool(Process):
                     % (base_command, ", ".join(repr(p) for p in base_command.split()))
                 )
             )
+        self._warn_if_base_command_not_found(base_command)
         self.prov_obj = loadingContext.prov_obj
         self.path_check_mode: PathCheckingMode = (
             PathCheckingMode.RELAXED
             if loadingContext.relax_path_checks
             else PathCheckingMode.STRICT
         )
+
+    def _warn_if_base_command_not_found(
+        self, base_command: Union[str, MutableSequence[str]]
+    ) -> None:
+        """Warn about a ``baseCommand`` that cannot be found on PATH or in the
+        declared container image.
+
+        Validation only confirms that the document is well-formed; whether the
+        command will actually be available at execution time is an
+        environment-dependent question.  When we can positively determine that
+        the command is missing (no DockerRequirement and not on the PATH, or a
+        locally available image that does not contain the command), we emit a
+        warning.  Uncertain situations (e.g. the image is not present
+        locally) never fail, they are reported with a ``DEBUG`` message.
+
+        Containers are only probed when the image is already available
+        locally, so that ``--validate`` never triggers a large image pull.
+        """
+        command = base_command
+        if isinstance(command, list):
+            if not command:
+                return
+            command = command[0]
+        if not isinstance(command, str) or not command or "/" in command:
+            # Path-looking commands are resolved relative to the working
+            # directory at execution time; nothing further to check here.
+            return
+
+        docker_req, _ = self.get_requirement("DockerRequirement")
+        if docker_req:
+            docker = shutil.which("docker") or shutil.which("podman")
+            image = docker_req.get("dockerPull")
+            if docker is None or not isinstance(image, str) or not image:
+                _logger.debug("skipping container base command check: docker not found or no image")
+                return
+            has_command = _container_has_command(docker, image, command)
+            if has_command is False:
+                _logger.warning(
+                    SourceLine(self.tool, "baseCommand", str).makeError(
+                        "cannot find %r inside container image %r; the command may "
+                        "still be provided at runtime, but validation could not "
+                        "confirm it exists" % (command, image)
+                    )
+                )
+            elif has_command is None:
+                _logger.debug(
+                    "image %s not available locally; not checking for %r inside the container",
+                    image,
+                    command,
+                )
+        elif shutil.which(command) is None:
+            _logger.warning(
+                SourceLine(self.tool, "baseCommand", str).makeError(
+                    "cannot find %r on the PATH; the command may still be provided "
+                    "at runtime, but validation could not confirm it exists" % command
+                )
+            )
 
     def make_job_runner(self, runtimeContext: RuntimeContext) -> type[JobBase]:
         """Return the correct CommandLineJob class given the container settings."""

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,6 +3,7 @@
 import io
 import logging
 import re
+from pathlib import Path
 
 import pytest
 
@@ -297,7 +298,7 @@ def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
 
     calls: list[list[str]] = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd: list[str], **kwargs: object) -> object:
         calls.append(cmd)
 
         class Result:
@@ -308,11 +309,11 @@ def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
             result.returncode = 1
         return result
 
-    monkeypatch.setattr(clt.subprocess, "run", fake_run)
-    assert clt._container_has_command("docker", "missing:latest", "foo") is None
+    monkeypatch.setattr(getattr(clt, "subprocess"), "run", fake_run)
+    assert getattr(clt, "_container_has_command")("docker", "missing:latest", "foo") is None
     assert calls[-1][1] == "image"
 
-    def fake_run2(cmd, **kwargs):
+    def fake_run2(cmd: list[str], **kwargs: object) -> object:
         calls.append(cmd)
 
         class Result:
@@ -321,11 +322,11 @@ def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
         result = Result()
         return result
 
-    monkeypatch.setattr(clt.subprocess, "run", fake_run2)
-    assert clt._container_has_command("docker", "present:latest", "foo") is False
+    monkeypatch.setattr(getattr(clt, "subprocess"), "run", fake_run2)
+    assert getattr(clt, "_container_has_command")("docker", "present:latest", "foo") is False
     assert "sh" in calls[-2] and "foo" in calls[-2]
 
-    def fake_run3(cmd, **kwargs):
+    def fake_run3(cmd: list[str], **kwargs: object) -> object:
         calls.append(cmd)
 
         class Result:
@@ -336,10 +337,10 @@ def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
             result.returncode = 1
         return result
 
-    monkeypatch.setattr(clt.subprocess, "run", fake_run3)
-    assert clt._container_has_command("docker", "distroless:latest", "foo") is None
+    monkeypatch.setattr(getattr(clt, "subprocess"), "run", fake_run3)
+    assert getattr(clt, "_container_has_command")("docker", "distroless:latest", "foo") is None
 
-    def fake_run4(cmd, **kwargs):
+    def fake_run4(cmd: list[str], **kwargs: object) -> object:
         calls.append(cmd)
 
         class Result:
@@ -348,12 +349,12 @@ def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
         result = Result()
         return result
 
-    monkeypatch.setattr(clt.subprocess, "run", fake_run4)
-    assert clt._container_has_command("docker", "full:latest", "foo") is True
+    monkeypatch.setattr(getattr(clt, "subprocess"), "run", fake_run4)
+    assert getattr(clt, "_container_has_command")("docker", "full:latest", "foo") is True
 
 
 def test_validate_warns_for_missing_basecommand_in_container(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: str
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A base command missing from a locally available image warns but validates."""
     import cwltool.command_line_tool as clt
@@ -363,7 +364,7 @@ def test_validate_warns_for_missing_basecommand_in_container(
         "_container_has_command",
         lambda docker, image, command: False,
     )
-    monkeypatch.setattr(clt.shutil, "which", lambda exe: "docker")
+    monkeypatch.setattr(getattr(clt, "shutil"), "which", lambda exe: "docker")
     custom_log = io.StringIO()
     handler = logging.StreamHandler(custom_log)
     handler.setLevel(logging.DEBUG)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -245,3 +245,139 @@ def test_validate_no_basecommand_space_warning(cwl_file: str) -> None:
     )
     assert exit_code == 0
     assert "single string containing whitespace" not in custom_log.getvalue()
+
+
+def test_validate_warns_when_base_command_not_on_path() -> None:
+    """A 'baseCommand' that is not on the PATH warns but still validates."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, stdout, stderr = get_main_output(
+        ["--validate", get_data("tests/wf/2240-basecommand-unavailable.cwl")],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "is valid CWL" in stdout
+    assert "cannot find 'definitely_not_a_real_command_xyz' on the PATH" in custom_log.getvalue()
+
+
+def test_validate_warns_when_list_base_command_not_on_path() -> None:
+    """A list-form 'baseCommand' whose program is missing warns but validates."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data("tests/wf/2240-basecommand-list-missing.cwl")],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "cannot find 'definitely_not_a_real_command_xyz' on the PATH" in custom_log.getvalue()
+
+
+@pytest.mark.parametrize(
+    "cwl_file",
+    ["tests/wf/2240-basecommand-available.cwl", "tests/wf/2240-basecommand-path.cwl"],
+)
+def test_validate_no_missing_basecommand_warning(cwl_file: str) -> None:
+    """A 'baseCommand' that resolves on the PATH (or is an absolute path) does not warn."""
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    exit_code, _, _ = get_main_output(
+        ["--validate", get_data(cwl_file)],
+        logger_handler=handler,
+    )
+    assert exit_code == 0
+    assert "cannot find" not in custom_log.getvalue()
+
+
+def test_container_has_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_container_has_command probes an image only when it is present locally."""
+    import cwltool.command_line_tool as clt
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 1
+
+        result = Result()
+        if cmd[1] == "image":
+            result.returncode = 1
+        return result
+
+    monkeypatch.setattr(clt.subprocess, "run", fake_run)
+    assert clt._container_has_command("docker", "missing:latest", "foo") is None
+    assert calls[-1][1] == "image"
+
+    def fake_run2(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0 if cmd[1] == "image" or "true" in cmd else 1
+
+        result = Result()
+        return result
+
+    monkeypatch.setattr(clt.subprocess, "run", fake_run2)
+    assert clt._container_has_command("docker", "present:latest", "foo") is False
+    assert "sh" in calls[-2] and "foo" in calls[-2]
+
+    def fake_run3(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0 if cmd[1] == "image" else 1
+
+        result = Result()
+        if cmd[1] == "run" and "true" in cmd:
+            result.returncode = 1
+        return result
+
+    monkeypatch.setattr(clt.subprocess, "run", fake_run3)
+    assert clt._container_has_command("docker", "distroless:latest", "foo") is None
+
+    def fake_run4(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+
+        result = Result()
+        return result
+
+    monkeypatch.setattr(clt.subprocess, "run", fake_run4)
+    assert clt._container_has_command("docker", "full:latest", "foo") is True
+
+
+def test_validate_warns_for_missing_basecommand_in_container(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: str
+) -> None:
+    """A base command missing from a locally available image warns but validates."""
+    import cwltool.command_line_tool as clt
+
+    monkeypatch.setattr(
+        clt,
+        "_container_has_command",
+        lambda docker, image, command: False,
+    )
+    monkeypatch.setattr(clt.shutil, "which", lambda exe: "docker")
+    custom_log = io.StringIO()
+    handler = logging.StreamHandler(custom_log)
+    handler.setLevel(logging.DEBUG)
+    with open(get_data("tests/wf/2240-basecommand-unavailable.cwl"), encoding="utf-8") as f:
+        tool = f.read()
+    tool = tool.replace(
+        "inputs: []",
+        "requirements:\n  - class: DockerRequirement\n    dockerPull: ubuntu:latest\ninputs: []",
+    )
+    tool_file = tmp_path / "2240-basecommand-in-container.cwl"
+    tool_file.write_text(tool, encoding="utf-8")
+    exit_code, _, _ = get_main_output(["--validate", str(tool_file)], logger_handler=handler)
+    assert exit_code == 0
+    assert (
+        "cannot find 'definitely_not_a_real_command_xyz' inside container image 'ubuntu:latest'"
+        in custom_log.getvalue()
+    )

--- a/tests/wf/2240-basecommand-available.cwl
+++ b/tests/wf/2240-basecommand-available.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: sh
+inputs: []
+outputs: []

--- a/tests/wf/2240-basecommand-list-missing.cwl
+++ b/tests/wf/2240-basecommand-list-missing.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [definitely_not_a_real_command_xyz, --flag]
+inputs: []
+outputs: []

--- a/tests/wf/2240-basecommand-path.cwl
+++ b/tests/wf/2240-basecommand-path.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: /bin/sh
+inputs: []
+outputs: []

--- a/tests/wf/2240-basecommand-unavailable.cwl
+++ b/tests/wf/2240-basecommand-unavailable.cwl
@@ -1,0 +1,6 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: definitely_not_a_real_command_xyz
+inputs: []
+outputs: []


### PR DESCRIPTION
Closes #2240 (second checklist item).

During `--validate`, emit a warning (never an error) when a literal `baseCommand` cannot be resolved on the PATH, or cannot be found inside the declared container image when that image is already available locally.

Design points:
- Lists take the first element (the program); strings with a `/` (paths) and expressions are skipped.
- Container probing only happens when the image is already available locally (`docker image inspect`), so `--validate` never triggers a large image pull; when the image is not local the check is skipped with a DEBUG message.
- Images without a shell (e.g. distroless) are distinguished from images that genuinely lack the command, and are skipped rather than misreported.
- Supports both `docker` and `podman`.

Tests: 6 new cases in `tests/test_validate.py` (PATH missing, list-form missing, present command silent, absolute path silent, container probe unit tests, container-mode warning), new CWL fixtures under `tests/wf/2240-*`. `tests/test_validate.py` and `tests/test_examples.py` pass locally; flake8/black/isort clean.