### PR TITLE
Defer spython imports in singularity.py to where they're used

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -19,9 +19,6 @@ from mypy_extensions import mypyc_attr
 from packaging.version import Version
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
-from spython.main import Client
-from spython.main.parse.parsers.docker import DockerParser
-from spython.main.parse.writers.singularity import SingularityWriter
 
 from .builder import Builder
 from .context import RuntimeContext
@@ -281,6 +278,13 @@ class SingularityCommandLineJob(ContainerCommandLineJob):
             if os.path.exists(image_name):
                 found = True
             if found is False:
+                # Imported here rather than at module level: spython is only needed when
+                # actually building a Singularity image from a Dockerfile, not merely to
+                # import this module (e.g. during --validate, which never reaches this code).
+                from spython.main import Client
+                from spython.main.parse.parsers.docker import DockerParser
+                from spython.main.parse.writers.singularity import SingularityWriter
+
                 dockerfile_path = os.path.join(absolute_path, "Dockerfile")
                 singularityfile_path = dockerfile_path + ".def"
                 with open(dockerfile_path, "w") as dfile:


### PR DESCRIPTION
## Summary

`cwltool/singularity.py` imports `spython.main.Client`, `spython.main.parse.parsers.docker.DockerParser`, and `spython.main.parse.writers.singularity.SingularityWriter` at module level. Since `cwltool.workflow`/`cwltool.command_line_tool` import `cwltool.singularity` unconditionally, this means `spython` (MPL-2.0 licensed) must be installed just to import cwltool at all — even for use cases like `cwltool --validate` that never touch Singularity.

All three names are only actually used inside `SingularityCommandLineJob.get_image`'s Dockerfile-build branch (building a Singularity image from a `dockerFile` requirement), never at import time. This PR moves the three imports into that branch, right before first use.

No behavior change for actual Singularity usage — the imports still happen, just lazily, the first time an image actually needs to be built from a Dockerfile.

## Verification

- `flake8`, `black --check`, and `mypy` all pass on the changed file (mypy reports 3 pre-existing, unrelated errors in `cwlviewer.py` that exist identically on `main` before this change).
- `pytest tests/test_singularity.py tests/test_singularity_versions.py` and the broader `-k "singularity or docker"` slice: all pass (remaining skips are pre-existing environment gates — no Docker/Singularity/Podman binary available — unrelated to this change).
- Confirmed `import cwltool.singularity` now succeeds with `spython` completely uninstalled, and `cwltool --validate` runs successfully end-to-end without `spython` installed.

## Motivation

We ran into this while trying to depend on cwltool from an internal Apache-2.0-licensed project that only needs `--validate`-style validation. Being forced to pull in an MPL-2.0-licensed package for a feature we never use blocked our internal third-party license review. This is a minimal, behavior-preserving fix rather than a request to change cwltool's own dependency policy — happy to adjust the approach if maintainers prefer something different (e.g. a try/except ImportError guard instead of a bare deferred import).