### PR TITLE
Proper PROV JSON-LD structure

### DIFF
--- a/cwltool/cwlprov/prov-jsonld-context.json
+++ b/cwltool/cwlprov/prov-jsonld-context.json
@@ -264,8 +264,7 @@
       "@type": "@id"
     },
     "type": {
-      "@id": "rdf:type",
-      "@type": "@id"
+      "@id": "prov:type"
     },
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   }

--- a/cwltool/cwlprov/prov-jsonld-context.json
+++ b/cwltool/cwlprov/prov-jsonld-context.json
@@ -1,0 +1,272 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Activity": {
+      "@context": {
+        "endTime": {
+          "@id": "prov:endedAtTime",
+          "@type": "xsd:dateTime"
+        },
+        "startTime": {
+          "@id": "prov:startedAtTime",
+          "@type": "xsd:dateTime"
+        }
+      },
+      "@id": "prov:Activity"
+    },
+    "Agent": {
+      "@context": {},
+      "@id": "prov:Agent"
+    },
+    "Alternate": {
+      "@context": {
+        "alternate1": {
+          "@reverse": "provext:qualifiedAlternate",
+          "@type": "@id"
+        },
+        "alternate2": {
+          "@id": "provext:alternate",
+          "@type": "@id"
+        }
+      },
+      "@id": "provext:Alternate"
+    },
+    "Association": {
+      "@context": {
+        "activity": {
+          "@reverse": "prov:qualifiedAssociation",
+          "@type": "@id"
+        },
+        "plan": {
+          "@id": "prov:hadPlan",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Association"
+    },
+    "Attribution": {
+      "@context": {
+        "entity": {
+          "@reverse": "prov:qualifiedAttribution",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Attribution"
+    },
+    "Communication": {
+      "@context": {
+        "informant": {
+          "@id": "prov:activity",
+          "@type": "@id"
+        },
+        "informed": {
+          "@reverse": "prov:qualifiedCommunication",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Communication"
+    },
+    "Delegation": {
+      "@context": {
+        "activity": {
+          "@id": "prov:hadActivity",
+          "@type": "@id"
+        },
+        "delegate": {
+          "@reverse": "prov:qualifiedDelegation",
+          "@type": "@id"
+        },
+        "responsible": {
+          "@id": "prov:agent",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Delegation"
+    },
+    "Derivation": {
+      "@context": {
+        "activity": {
+          "@id": "prov:hadActivity",
+          "@type": "@id"
+        },
+        "generatedEntity": {
+          "@reverse": "prov:qualifiedDerivation",
+          "@type": "@id"
+        },
+        "generation": {
+          "@id": "prov:hadGeneration",
+          "@type": "@id"
+        },
+        "usage": {
+          "@id": "prov:hadUsage",
+          "@type": "@id"
+        },
+        "usedEntity": {
+          "@id": "prov:entity",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Derivation"
+    },
+    "End": {
+      "@context": {
+        "activity": {
+          "@reverse": "prov:qualifiedEnd",
+          "@type": "@id"
+        },
+        "ender": {
+          "@id": "prov:hadActivity",
+          "@type": "@id"
+        },
+        "time": {
+          "@id": "prov:atTime",
+          "@type": "xsd:dateTime"
+        },
+        "trigger": {
+          "@id": "prov:entity",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:End"
+    },
+    "Entity": {
+      "@context": {
+        "value": {
+          "@id": "prov:value"
+        }
+      },
+      "@id": "prov:Entity"
+    },
+    "Generation": {
+      "@context": {
+        "entity": {
+          "@reverse": "prov:qualifiedGeneration",
+          "@type": "@id"
+        },
+        "time": {
+          "@id": "prov:atTime",
+          "@type": "xsd:dateTime"
+        }
+      },
+      "@id": "prov:Generation"
+    },
+    "Influence": {
+      "@context": {
+        "influencee": {
+          "@reverse": "prov:qualifiedInfluence",
+          "@type": "@id"
+        },
+        "influencer": {
+          "@id": "prov:influencer",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Influence"
+    },
+    "Invalidation": {
+      "@context": {
+        "entity": {
+          "@reverse": "prov:qualifiedInvalidation",
+          "@type": "@id"
+        },
+        "time": {
+          "@id": "prov:atTime",
+          "@type": "xsd:dateTime"
+        }
+      },
+      "@id": "prov:Invalidation"
+    },
+    "Membership": {
+      "@context": {
+        "collection": {
+          "@reverse": "provext:qualifiedMembership",
+          "@type": "@id"
+        },
+        "entity": {
+          "@id": "provext:member",
+          "@type": "@id"
+        }
+      },
+      "@id": "provext:Membership"
+    },
+    "Specialization": {
+      "@context": {
+        "generalEntity": {
+          "@id": "provext:generalEntity",
+          "@type": "@id"
+        },
+        "specificEntity": {
+          "@reverse": "provext:qualifiedSpecialization",
+          "@type": "@id"
+        }
+      },
+      "@id": "provext:Specialization"
+    },
+    "Start": {
+      "@context": {
+        "activity": {
+          "@reverse": "prov:qualifiedStart",
+          "@type": "@id"
+        },
+        "starter": {
+          "@id": "prov:hadActivity",
+          "@type": "@id"
+        },
+        "time": {
+          "@id": "prov:atTime",
+          "@type": "xsd:dateTime"
+        },
+        "trigger": {
+          "@id": "prov:entity",
+          "@type": "@id"
+        }
+      },
+      "@id": "prov:Start"
+    },
+    "Usage": {
+      "@context": {
+        "activity": {
+          "@reverse": "prov:qualifiedUsage",
+          "@type": "@id"
+        },
+        "time": {
+          "@id": "prov:atTime",
+          "@type": "xsd:dateTime"
+        }
+      },
+      "@id": "prov:Usage"
+    },
+    "activity": {
+      "@id": "prov:activity",
+      "@type": "@id"
+    },
+    "agent": {
+      "@id": "prov:agent",
+      "@type": "@id"
+    },
+    "entity": {
+      "@id": "prov:entity",
+      "@type": "@id"
+    },
+    "label": {
+      "@id": "rdfs:label"
+    },
+    "location": {
+      "@id": "prov:atLocation",
+      "@type": "@id"
+    },
+    "prov": "http://www.w3.org/ns/prov#",
+    "provext": "https://openprovenance.org/ns/provext#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "role": {
+      "@id": "prov:hadRole",
+      "@type": "@id"
+    },
+    "type": {
+      "@id": "rdf:type",
+      "@type": "@id"
+    },
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/cwltool/cwlprov/provenance_constants.py
+++ b/cwltool/cwlprov/provenance_constants.py
@@ -16,17 +16,12 @@ __citation__ = "https://doi.org/10.5281/zenodo.1208477"
 # 2. Bump minor number if adding resources or PROV statements
 # 3. Bump patch number for non-breaking non-adding changes,
 #    e.g. fixing broken relative paths
-CWLPROV_VERSION = "https://w3id.org/cwl/prov/0.6.0"
+CWLPROV_VERSION = "https://w3id.org/cwl/prov/0.7.0"
 
 # JSON-LD context employed to render the PROV-JSONLD provenance file as a valid,
-# term-compacted JSON-LD document (top-level object with "@context"/"@graph"),
-# instead of the bare "expanded" array representation obtained without one.
-# https://openprovenance.org/prov-jsonld/
+# term-compacted JSON-LD document (top-level object with "@context"/"@graph").
 # A local copy is vendored (see 'prov-jsonld-context.json') to perform the
-# term compaction without requiring network access during provenance
-# generation. The canonical remote IRI is nonetheless referenced in the
-# "@context" of the generated document, as consumers are expected to already
-# know/resolve this well-known context when interpreting PROV-JSONLD content.
+# term compaction without requiring network access during provenance generation.
 JSONLD_CONTEXT_URL = "https://openprovenance.org/prov-jsonld/context.jsonld"
 JSONLD_CONTEXT = json.loads(
     files("cwltool.cwlprov").joinpath("prov-jsonld-context.json").read_text(encoding="UTF-8")

--- a/cwltool/cwlprov/provenance_constants.py
+++ b/cwltool/cwlprov/provenance_constants.py
@@ -1,6 +1,8 @@
 import hashlib
+import json
 import os
 import uuid
+from importlib.resources import files
 
 from prov.identifier import Namespace
 
@@ -15,6 +17,20 @@ __citation__ = "https://doi.org/10.5281/zenodo.1208477"
 # 3. Bump patch number for non-breaking non-adding changes,
 #    e.g. fixing broken relative paths
 CWLPROV_VERSION = "https://w3id.org/cwl/prov/0.6.0"
+
+# JSON-LD context employed to render the PROV-JSONLD provenance file as a valid,
+# term-compacted JSON-LD document (top-level object with "@context"/"@graph"),
+# instead of the bare "expanded" array representation obtained without one.
+# https://openprovenance.org/prov-jsonld/
+# A local copy is vendored (see 'prov-jsonld-context.json') to perform the
+# term compaction without requiring network access during provenance
+# generation. The canonical remote IRI is nonetheless referenced in the
+# "@context" of the generated document, as consumers are expected to already
+# know/resolve this well-known context when interpreting PROV-JSONLD content.
+JSONLD_CONTEXT_URL = "https://openprovenance.org/prov-jsonld/context.jsonld"
+JSONLD_CONTEXT = json.loads(
+    files("cwltool.cwlprov").joinpath("prov-jsonld-context.json").read_text(encoding="UTF-8")
+)["@context"]
 
 # Research Object folders
 METADATA = "metadata"

--- a/cwltool/cwlprov/provenance_constants.py
+++ b/cwltool/cwlprov/provenance_constants.py
@@ -22,7 +22,7 @@ CWLPROV_VERSION = "https://w3id.org/cwl/prov/0.7.0"
 # term-compacted JSON-LD document (top-level object with "@context"/"@graph").
 # A local copy is vendored (see 'prov-jsonld-context.json') to perform the
 # term compaction without requiring network access during provenance generation.
-JSONLD_CONTEXT_URL = "https://openprovenance.org/prov-jsonld/context.jsonld"
+JSONLD_CONTEXT_URL = "https://openprovenance.org/prov-jsonld/2026-09-01/context.jsonld"
 JSONLD_CONTEXT = json.loads(
     files("cwltool.cwlprov").joinpath("prov-jsonld-context.json").read_text(encoding="UTF-8")
 )["@context"]

--- a/cwltool/cwlprov/provenance_profile.py
+++ b/cwltool/cwlprov/provenance_profile.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import json
 import logging
 import urllib
 import uuid
@@ -30,6 +31,8 @@ from .provenance_constants import (
     ACCOUNT_UUID,
     CWLPROV,
     ENCODING,
+    JSONLD_CONTEXT,
+    JSONLD_CONTEXT_URL,
     METADATA,
     ORE,
     PROVENANCE,
@@ -733,11 +736,28 @@ class ProvenanceProfile:
             prov_ids.append(self.provenance_ns[filename + ".nt"])
 
         # https://www.w3.org/TR/json-ld/
-        # TODO: Use a nice JSON-LD context
+        # Produce a proper JSON-LD document, i.e.: a top-level object providing
+        # "@context" and "@graph", instead of publishing the bare "expanded"
+        # array on its own, which is not a valid JSON-LD document on its own.
+        # The vendored PROV-JSONLD context (see 'prov-jsonld-context.json') is
+        # employed locally to compact the produced terms (shorter, human
+        # readable keys/values) without requiring network access during
+        # provenance generation, while the emitted "@context" nonetheless
+        # references the corresponding canonical IRI for interoperability.
         # see also https://eprints.soton.ac.uk/395985/
         # 404 Not Found on https://provenance.ecs.soton.ac.uk/prov.jsonld :(
         with write_bag_file(self.research_object, basename + ".jsonld") as provenance_file:
-            self.document.serialize(provenance_file, format="rdf", rdf_format="json-ld")
+            graph = self.document.serialize(
+                format="rdf",
+                rdf_format="json-ld",
+                context=JSONLD_CONTEXT,
+                auto_compact=True,
+            )
+            jsonld_doc = {
+                "@context": [JSONLD_CONTEXT_URL],
+                "@graph": json.loads(graph)["@graph"],
+            }
+            json.dump(jsonld_doc, provenance_file, indent=2, sort_keys=True)
             prov_ids.append(self.provenance_ns[filename + ".jsonld"])
 
         _logger.debug("[provenance] added provenance: %s", prov_ids)

--- a/cwltool/cwlprov/provenance_profile.py
+++ b/cwltool/cwlprov/provenance_profile.py
@@ -16,8 +16,12 @@ from cwl_utils.types import (
     is_directory,
     is_file,
 )
+from prov.constants import PROV_N_MAP
 from prov.identifier import Identifier, QualifiedName
 from prov.model import PROV, PROV_LABEL, PROV_TYPE, PROV_VALUE, ProvDocument, ProvEntity
+from prov.serializers.provrdf import ProvRDFSerializer
+from rdflib.namespace import RDF
+from rdflib.term import URIRef
 from schema_salad.sourceline import SourceLine
 
 from ..errors import WorkflowException
@@ -59,6 +63,46 @@ class _CWLDirectoryArtifact(CWLArtifact, CWLDirectoryType):
 
 class _CWLFileArtifact(CWLArtifact, CWLFileType):
     pass
+
+
+# The base PROV record classes/relations that `prov.model.ProvRecord.get_type()`
+# may assign (via `prov.constants.PROV_N_MAP`) as a record's own `rdf:type`
+# (e.g. an activity's `prov:Activity`, or a qualified `used`/`wasGeneratedBy`
+# bnode's `prov:Usage`/`prov:Generation`). Everything else that ends up as an
+# `rdf:type` triple in the RDF graph produced by `prov.serializers.provrdf` is
+# in fact the value of a `prov:type` *attribute* (e.g. `PROV_TYPE:
+# WFPROV["WorkflowEngine"]`, or the PROV-namespace subtype refinements such as
+# `prov:SoftwareAgent`/`prov:Person`/`prov:Plan`) that `ProvRDFSerializer`
+# incorrectly encodes using the `rdf:type` predicate instead of `prov:type`
+# (see its `encode_container`: `elif attr == PROV['type']: pred = RDF.type`).
+# Per the PROV-JSONLD context/schema, only the record's own base PROV class
+# belongs under the JSON-LD `@type` keyword; any supplementary/derived type
+# must be a `prov:type` attribute value, compacting to the separate `type`
+# key. See https://www.w3.org/submissions/2024/SUBM-prov-jsonld-20240825/#IC4
+_PROV_BASE_TYPES = frozenset(URIRef(t.uri) for t in PROV_N_MAP)
+
+
+def _prov_document_to_jsonld(document: ProvDocument) -> str:
+    """Serialize a :py:class:`ProvDocument` to a PROV-JSONLD-compliant graph.
+
+    Builds the RDF graph via :py:class:`~prov.serializers.provrdf.ProvRDFSerializer`
+    as usual, then corrects its handling of `prov:type` attributes (see
+    `_PROV_BASE_TYPES`) before compacting to JSON-LD, so that each node's
+    `@type` only ever holds its own PROV record class, with any other type
+    information routed to the separate `type` attribute.
+    """
+    serializer = ProvRDFSerializer(document)
+    graph = serializer.encode_document(document)
+    prov_type = URIRef(PROV["type"].uri)
+    for subject, _predicate, prov_type_value in list(graph.triples((None, RDF.type, None))):
+        if prov_type_value not in _PROV_BASE_TYPES:
+            graph.remove((subject, RDF.type, prov_type_value))
+            graph.add((subject, prov_type, prov_type_value))
+    return graph.serialize(
+        format="json-ld",
+        context=JSONLD_CONTEXT,
+        auto_compact=True,
+    )
 
 
 def copy_job_order(job: Process | JobsType, job_order_object: CWLObjectType) -> CWLObjectType:
@@ -736,23 +780,9 @@ class ProvenanceProfile:
             prov_ids.append(self.provenance_ns[filename + ".nt"])
 
         # https://www.w3.org/TR/json-ld/
-        # Produce a proper JSON-LD document, i.e.: a top-level object providing
-        # "@context" and "@graph", instead of publishing the bare "expanded"
-        # array on its own, which is not a valid JSON-LD document on its own.
-        # The vendored PROV-JSONLD context (see 'prov-jsonld-context.json') is
-        # employed locally to compact the produced terms (shorter, human
-        # readable keys/values) without requiring network access during
-        # provenance generation, while the emitted "@context" nonetheless
-        # references the corresponding canonical IRI for interoperability.
-        # see also https://eprints.soton.ac.uk/395985/
-        # 404 Not Found on https://provenance.ecs.soton.ac.uk/prov.jsonld :(
+        # https://openprovenance.org/prov-jsonld/
         with write_bag_file(self.research_object, basename + ".jsonld") as provenance_file:
-            graph = self.document.serialize(
-                format="rdf",
-                rdf_format="json-ld",
-                context=JSONLD_CONTEXT,
-                auto_compact=True,
-            )
+            graph = _prov_document_to_jsonld(self.document)
             jsonld_doc = {
                 "@context": [JSONLD_CONTEXT_URL],
                 "@graph": json.loads(graph)["@graph"],


### PR DESCRIPTION
## Description

Aligns with: 
- https://github.com/openprov/prov-jsonld/pull/3

Notably: 
- Follow the schema with `@context` and `@graph` structure (not the array directly)
- Respect the `@type` (`prov:type`) vs other supplementary `type` as distinct fields
  (see https://www.w3.org/submissions/2024/SUBM-prov-jsonld-20240825/#IC4)

## Implementation Notes

- I've indicated a `cwlprov@0.7.0` URL ref to flag the change of implementation, but it is not really backported to `cwlprov` project. Is that necessary?

- I've used the version references that will exist if everything is pushed, but the `2026-09-01` version is not yet published (still being evaluted https://github.com/openprov/prov-jsonld/pull/3)

- This patch works with `prov==1.5.1` which is pinned by `cwlprov`/`cwltool`. However, `prov>=3.1.0` is available with various fixes. 
  - investigating potential solutions for PROV JSON-LD patch of this PR specifically:
    https://github.com/trungdong/prov/issues/181#issuecomment-5498276277
  - trying `prov==3.1.0` directly is not entirely compatible
    some minor change happens with `prov:wasAssociatedWith`

    With `prov==1.5.1` (current, pinned):
    ```
    id:8871068c-... a prov:Activity ;
        rdfs:label "Run of workflow/packed.cwl#main" ;
        prov:qualifiedAssociation [ a prov:Association ;
                prov:hadPlan wf:main ] ;                    # <-- no prov:agent here
        ...
        prov:wasAssociatedWith id:cfcaecbd-... .             # <-- direct binary triple IS emitted
    ```
    With `prov==3.1.0` :
    ```
    id:8871068c-... a prov:Activity ;
        rdfs:label "Run of workflow/packed.cwl#main" ;
        prov:qualifiedAssociation [ a prov:Association ;
                prov:agent id:0707ee8f-... ;                # <-- agent moved *into* the bnode
                prov:hadPlan wf:main ] ;
        ...
        # (no separate `prov:wasAssociatedWith` triple on the Activity at all)
    ```

    Therefore, they are technically equivalent semantically (at least the relation is indicated), but not literally equal. 
    A test checks specifically for `prov:wasAssociatedWith`, so it would have to be adjusted.

    If the explicit `prov:wasAssociatedWith` should be preserved for backward compatibility, it would need to be injected explicitly.